### PR TITLE
[Design] 프로젝트 공통 디자인 설정 구성

### DIFF
--- a/.claude/agents/ui-builder.md
+++ b/.claude/agents/ui-builder.md
@@ -12,7 +12,8 @@ fe-architect의 슬라이스 명세를 받아 **React 컴포넌트·페이지를
 ## 작업 원칙
 1. **코드 컨벤션 적용** — `code-conventions` 스킬을 읽고 가독성·예측가능성·응집성·결합도 4원칙을 모든 컴포넌트에 적용. 매직넘버 명명, 복잡 조건 변수화, 컴포넌트 단일책임.
 2. **빌드 패턴 적용** — `component-build` 스킬의 App Router·라우트그룹·Server/Client 경계·Tailwind·상태표현 패턴을 따른다.
-   - 시각 디자인 품질(레이아웃·위계·여백·인터랙션)이 중요한 화면은 `frontend-design` 스킬을 참조해 제네릭한 AI 룩을 피한다. 단, 프로젝트 Tailwind 토큰·다크모드·접근성 규칙이 우선이며 frontend-design은 품질 가이드로만 쓴다.
+   - 시각 디자인 품질(레이아웃·위계·여백·인터랙션)이 중요한 화면은 `frontend-design` 스킬을 참조해 제네릭한 AI 룩을 피한다. 단, 프로젝트 Tailwind 토큰·접근성 규칙이 우선이며 frontend-design은 품질 가이드로만 쓴다.
+   - **색·radius·폰트 토큰은 `component-build/references/design-tokens.md`가 단일 진실** — `bg-paper`/`text-ink`/`rounded-card`/`font-serif` 등 유틸로만, 인라인 hex 금지. 디자인 시스템은 **light 전용**이라 `dark:` 변형 안 쓴다(frontend-design=비주얼 품질, design-tokens=토큰 기준으로 역할 구분).
 3. **상태 3종 필수** — 데이터 화면은 로딩·빈(empty)·에러 상태를 빠짐없이 표현. 명세의 "상태" 항목을 누락하지 않는다.
 4. **Server/Client 경계 최소화** — `"use client"`는 상호작용·훅 사용 컴포넌트에만. 페이지 셸은 가능하면 서버 컴포넌트. CSR 화면도 인터랙티브 잎(leaf)만 클라이언트로.
 5. **계약 소비만** — 데이터 shape은 data-engineer의 zod 타입을 import. 직접 인터페이스 재정의 금지(중복 = 드리프트 원인).

--- a/.claude/skills/component-build/SKILL.md
+++ b/.claude/skills/component-build/SKILL.md
@@ -5,7 +5,7 @@ description: 손해사정 플랫폼 Next.js App Router UI 구현 패턴. 페이�
 
 # Next.js App Router 컴포넌트 구현 패턴
 
-대상: React 19 + Next.js 16 App Router + Tailwind 4. 코드 컨벤션은 `code-conventions` 스킬과 함께 적용한다(이 스킬은 "어떻게 만드나", 컨벤션 스킬은 "어떻게 잘 쓰나"). 시각 디자인 완성도가 필요한 화면은 `frontend-design` 스킬을 품질 가이드로 참조하되, 아래 프로젝트 규칙(Tailwind 토큰·3상태·접근성)이 항상 우선한다.
+대상: React 19 + Next.js 16 App Router + Tailwind 4. 코드 컨벤션은 `code-conventions` 스킬과 함께 적용한다(이 스킬은 "어떻게 만드나", 컨벤션 스킬은 "어떻게 잘 쓰나"). 시각 디자인 완성도가 필요한 화면은 `frontend-design` 스킬을 품질 가이드로 참조하되, 아래 프로젝트 규칙(Tailwind 토큰·3상태·접근성)이 항상 우선한다. 색·radius·폰트 토큰은 `references/design-tokens.md`가 단일 진실.
 
 ## 라우트그룹 = 역할 경계
 ```
@@ -44,7 +44,8 @@ function ReportList() {
 - props는 도메인 타입을 받되, 필요한 필드만 좁혀 받는다(`Pick`).
 
 ## Tailwind 스타일
-- 기존 토큰 따르기: 다크모드 `dark:` 변형, `app/layout.tsx`의 `bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100`.
+- **디자인 토큰 따르기** — 색·radius·폰트는 `@theme` 토큰 유틸로(`bg-paper`/`text-ink`/`border-line`/`rounded-card`/`font-serif`). 인라인 hex·임의 색 금지. 전체 토큰표·상태 유틸 레시피는 `references/design-tokens.md`.
+- **light 전용** — 디자인 시스템은 라이트 테마만. `dark:` 변형 쓰지 않는다.
 - 인라인 long-class는 논리 그룹 순서(layout → spacing → color → state)로 정렬.
 - 모바일 우선: 기본이 모바일, `md:` 이상에서 데스크탑. 기획의 "모바일은 필터칩+카드" 같은 반응형 분기 반영.
 

--- a/.claude/skills/component-build/references/design-tokens.md
+++ b/.claude/skills/component-build/references/design-tokens.md
@@ -1,0 +1,81 @@
+# 디자인 토큰 (바른보상 디자인 시스템)
+
+Tailwind v4 주력. 토큰은 `apps/web/src/app/globals.css`의 `@theme`에 정의되어 있고 = **단일 진실**. 컴포넌트는 유틸 클래스로만 소비한다. **인라인 hex(`#15202e`)·임의 색 금지** — 토큰에 없는 값이 필요하면 먼저 `@theme`에 추가.
+
+> Tailwind v4는 `@theme`의 `--color-*`/`--radius-*`/`--font-*`를 읽어 유틸을 자동 생성한다. `tailwind.config.js` 없음.
+> **light 전용** — 디자인 시스템은 라이트 테마만 정의. `dark:` 변형 쓰지 않는다.
+> 출처: 바른보상 디자인 시스템 번들 → 디코드본 `_design_primitives.jsx`(아토믹 원본 스펙).
+
+## 컬러
+
+| 토큰 | hex | 용도 |
+|------|-----|------|
+| `ink` | `#15202e` | 본문 텍스트·1차 액션 배경 |
+| `ink-2` | `#3c4856` | 보조 텍스트 |
+| `ink-3` | `#7b8693` | 흐린 텍스트·placeholder·캡션 |
+| `paper` | `#f4f1ea` | 페이지 배경·ghost 버튼 |
+| `paper-2` | `#fbf9f4` | 내부 타일·CTA 존 |
+| `card` | `#ffffff` | 카드·인풋 표면 |
+| `line` | `#e6e0d4` | 보더·구분선 |
+| `line-2` | `#efeadf` | 약한 구분선 |
+| `navy` | `#182740` | 로고·딥 surface |
+| `gold` | `#b0822e` | 주요 강조·골드 액션·포커스 |
+| `gold-2` | `#d8b25f` | 밝은 골드 악센트 |
+| `gold-ink` | `#8a6420` | 골드 위 텍스트·키커 |
+| `gold-soft` | `#f3e9d4` | 골드 배경 톤·포커스 링 |
+| `green` | `#2f6149` | 성공·완료 |
+| `green-soft` | `#e3eee7` | 성공 배경 톤 |
+| `terra` | `#b0492c` | 위험·에러·danger 액션 |
+| `terra-2` | `#e0987f` | 밝은 테라 악센트 |
+| `terra-soft` | `#f6e7df` | 에러 배경 톤 |
+
+`--color-brand`(`#2563eb`)는 레거시. 디자인 토큰은 위 팔레트를 쓴다.
+
+## radius
+
+| 토큰 | 값 | 용도 |
+|------|-----|------|
+| `rounded-tag` | 6px | 태그·근거 칩 |
+| `rounded-pill` | 7px | pill·상태 칩 |
+| `rounded-chip` | 9px | 칩 |
+| `rounded-button` | 11px | 버튼 |
+| `rounded-input` | 13px | 인풋·셀렉트·텍스트영역 |
+| `rounded-card` | 16px | 카드 |
+| `rounded-card-lg` | 22px | 큰 카드·딥 surface |
+
+## 폰트
+
+| 토큰 | 값 | 용도 |
+|------|-----|------|
+| `font-serif` | Gowun Batang | **Title 계열 전용**(화면·금액 제목). `layout.tsx`의 next/font로 로드(`--font-gowun-batang`) |
+| `font-mono` | ui-monospace 계열 | 코드·수치·스펙 라벨 |
+
+본문(Heading·Label·UI)은 기본 산세(`inherit`). serif를 본문에 쓰지 않는다.
+
+## 유틸 매핑
+
+`@theme` 토큰 1개 → 관련 유틸 자동 생성. 예 `--color-ink`:
+- `bg-ink` 배경 · `text-ink` 글자 · `border-ink` 테두리 · `ring-ink` 포커스 링 · `fill-ink`/`stroke-ink` SVG
+
+```tsx
+<div className="bg-card border border-line rounded-card text-ink">
+<span className="bg-gold-soft text-gold-ink rounded-pill">  // 골드 톤 칩
+```
+
+## 상태 = 유틸 (전역 CSS 클래스 X)
+
+원본 디자인 시스템은 `.bb-btn` 등 전역 클래스를 주입했지만, 이 프로젝트는 **Tailwind 유틸로 푼다**.
+
+| 상태 | 유틸 |
+|------|------|
+| hover 어둡게 | `hover:brightness-[.96]` |
+| disabled / loading | `disabled:opacity-[.42] disabled:cursor-not-allowed` |
+| 인풋 focus 링 | `focus:border-gold focus:ring-[3px] focus:ring-gold-soft focus:outline-none` |
+| 아이콘버튼 hover | `hover:bg-paper` |
+| 로딩 스피너 | 내장 `animate-spin` (별도 keyframe 불필요) |
+| 트랜지션 | `transition` |
+
+```tsx
+// 예: primary 버튼
+<button className="bg-ink text-white rounded-button px-[18px] py-3 font-semibold transition hover:brightness-[.96] disabled:opacity-[.42] disabled:cursor-not-allowed">
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,4 @@
 | 2026-06-09 | TMI 트림 | skills/component-build | 일반 a11y·Tailwind 상식 압축, 프로젝트 고유 규칙만 유지 |
 | 2026-06-15 | 아키텍처 전환 Feature-Based→프렉탈(라우트 코로케이션) | CLAUDE.md, code-conventions, fe-architect, ui-builder, data-engineer, react-query-data, component-build, frontend-feature, react-patterns | top-level features/ 폐기, app 라우트 트리 코로케이션(_components/_hooks/_api/_model)·중첩 재귀·_shared 승격·전역 src/shared 유지로 결정 |
 | 2026-06-15 | 식별자 사전 추가 | frontend-feature/references/naming-dictionary.md (+ fe-architect·ui-builder·data-engineer·code-conventions·frontend-feature 포인터) | API 명세 필드명을 단일 진실로 박아 변수·필드·enum·ID타입·훅/쿼리키 작명 통일, 명세 내 드리프트 4건 플래그 |
+| 2026-06-16 | 디자인 토큰 이식 + 레퍼런스 추가 | globals.css(@theme 색·radius·폰트), layout.tsx(next/font Gowun Batang), component-build/references/design-tokens.md (+ component-build·ui-builder 포인터) | 바른보상 디자인 시스템 토큰을 Tailwind v4 @theme 단일 진실로 박음, 상태는 유틸로(전역 .bb-* X), light 전용 확정(dark: 폐기) |

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -28,6 +28,19 @@
   --color-terra: #b0492c;
   --color-terra-2: #e0987f;
   --color-terra-soft: #f6e7df;
+
+  /* radius 스케일 → rounded-* 유틸 */
+  --radius-tag: 6px;
+  --radius-pill: 7px;
+  --radius-chip: 9px;
+  --radius-button: 11px;
+  --radius-input: 13px;
+  --radius-card: 16px;
+  --radius-card-lg: 22px;
+
+  /* 폰트 → font-* 유틸 (serif=Title 전용) */
+  --font-serif: var(--font-gowun-batang), "Gowun Batang", serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, monospace;
 }
 
 :root {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,6 +2,32 @@
 
 @theme {
   --color-brand: #2563eb;
+
+  /* 디자인 시스템 컬러 토큰 (출처: 바른보상 디자인 시스템) */
+  --color-ink: #15202e;
+  --color-ink-2: #3c4856;
+  --color-ink-3: #7b8693;
+
+  --color-paper: #f4f1ea;
+  --color-paper-2: #fbf9f4;
+  --color-card: #ffffff;
+
+  --color-line: #e6e0d4;
+  --color-line-2: #efeadf;
+
+  --color-navy: #182740;
+
+  --color-gold: #b0822e;
+  --color-gold-2: #d8b25f;
+  --color-gold-ink: #8a6420;
+  --color-gold-soft: #f3e9d4;
+
+  --color-green: #2f6149;
+  --color-green-soft: #e3eee7;
+
+  --color-terra: #b0492c;
+  --color-terra-2: #e0987f;
+  --color-terra-soft: #f6e7df;
 }
 
 :root {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -44,5 +44,5 @@
 }
 
 :root {
-  color-scheme: light dark;
+  color-scheme: light;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,8 +1,17 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
+import { Gowun_Batang } from "next/font/google";
 import { MockProvider } from "@/shared/mocks/mock-provider";
 import QueryProvider from "@/shared/providers/query-provider";
 import "./globals.css";
+
+// Title 계열 전용 세리프. CJK라 전체 preload 안 함(용량) → preload: false.
+const gowunBatang = Gowun_Batang({
+  weight: ["400", "700"],
+  variable: "--font-gowun-batang",
+  display: "swap",
+  preload: false
+});
 
 export const metadata: Metadata = {
   title: "Insurance Platform",
@@ -11,7 +20,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="ko">
+    <html lang="ko" className={gowunBatang.variable}>
       <body className="min-h-dvh bg-white text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100">
         <MockProvider>
           <QueryProvider>{children}</QueryProvider>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="ko" className={gowunBatang.variable}>
-      <body className="min-h-dvh bg-white text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-100">
+      <body className="min-h-dvh bg-white text-gray-900 antialiased">
         <MockProvider>
           <QueryProvider>{children}</QueryProvider>
         </MockProvider>


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #12

## ✅ 작업 내용

### 디자인 토큰을 Tailwind v4 `@theme`에 이식

색상, radius, 폰트 등 디자인 토큰들을  `globals.css`의 `@theme`에 저장하여 컴포넌트에서 색상이나 radius 값을 직접 넣지 않고 `bg-ink`, `text-terra`, `border-line`, `rounded-button`, `font-serif` 같은 토큰 유틸을 사용할 수 있게 했습니다.


#### 토큰 구성

**컬러 19종**

| 그룹 | 토큰 | 용도 |
|------|------|------|
| Ink | `ink` `ink-2` `ink-3` | 본문/보조/흐린 텍스트, 1차 액션 배경 |
| Paper | `paper` `paper-2` `card` | 페이지 배경 · 내부 타일 · 카드 표면 |
| Line | `line` `line-2` | 보더 · 약한 구분선 |
| Navy | `navy` | 로고 · 딥 surface |
| Gold | `gold` `gold-2` `gold-ink` `gold-soft` | 주요 강조 · 골드 액션 · 포커스 · 톤 배경 |
| Green | `green` `green-soft` | 성공 · 완료 |
| Terra | `terra` `terra-2` `terra-soft` | 위험 · 에러 · danger 액션 |

**radius 7종** — `tag`(6) · `pill`(7) · `chip`(9) · `button`(11) · `input`(13) · `card`(16) · `card-lg`(22)
**폰트 2종** — `serif`(Gowun Batang, Title 계열 전용) · `mono`(코드·수치·스펙 라벨). 본문은 기본 산세 유지.

<br/>

### 2. Gowun Batang 폰트 로드

Title 계열에 쓸 세리프를 `next/font/google`로 불러왔습니다. CJK 폰트라 전체 preload하면 용량이 크니까 `preload: false`로 두고, CSS 변수(`--font-gowun-batang`)로 연결해 `font-serif` 토큰이 참조하도록 했습니다.

```tsx
const gowunBatang = Gowun_Batang({
  weight: ["400", "700"],
  variable: "--font-gowun-batang",
  display: "swap",
  preload: false
});

<html lang="ko" className={gowunBatang.variable}>
```

<br/>

### 3. 디자인 토큰 레퍼런스 문서 추가

Claude(스킬·에이전트)가 토큰을 일관되게 쓰도록 `component-build/references/design-tokens.md`를 새로 만들었습니다. 
문서에는 `토큰표`·`토큰별 Tailwind 클래스 사용법`·`Hover·Focus·Disabled 스타일 가이드`·`출처를 담았으며,
`component-build` 스킬과 `ui-builder` 에이전트에 레퍼런스를 연결해 토큰 사용 기준을 통일했습니다.

## 💬 참고

다크모드 색상을 이번 PR 단위에서 넣을까 고민했지만, 다크모드 색상 선택을 고민하는데 조금의 시간이 걸릴 수 있을거 같다는 생각에 MVP 완성 이후에 진행하려합니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 표준화된 디자인 토큰 체계를 도입해 색/반경/폰트 토큰 기반으로 스타일을 구성할 수 있게 했습니다.
  * Gowun_Batang 폰트를 적용하고, 라이트 전용 테마 방식으로 전환했습니다.
* **Documentation**
  * 디자인 토큰 단일 진실 원칙, 유틸리티 클래스 기반 사용, 인라인 색상/임의 값 금지, 다크 변형 미사용 가이드를 명확히 했습니다.
  * 디자인 토큰 참조 문서를 확장/정리했습니다.
* **Chores**
  * 전역 스타일 구성을 토큰 중심으로 정비하고 다크 모드 관련 스타일 적용을 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->