### PR TITLE
[Feature] 공용 Modal·Toggle 컴포넌트 추가

### DIFF
--- a/apps/web/src/shared/ui/Modal.stories.tsx
+++ b/apps/web/src/shared/ui/Modal.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+import { Button } from "./Button";
+import { Modal } from "./Modal";
+
+const meta = {
+  title: "ui/Modal",
+  component: Modal,
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Demo({ dismissible }: { dismissible?: boolean }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>모달 열기</Button>
+      <Modal
+        open={open}
+        title="알림 설정"
+        dismissible={dismissible}
+        onClose={() => setOpen(false)}
+      >
+        <p className="text-sm leading-relaxed text-ink-2">
+          받고 싶은 알림을 선택해 주세요. 변경 내용은 저장을 눌러야 반영됩니다.
+        </p>
+        <div className="mt-6 flex justify-end gap-2">
+          <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+            취소
+          </Button>
+          <Button size="sm" onClick={() => setOpen(false)}>
+            저장하기
+          </Button>
+        </div>
+      </Modal>
+    </>
+  );
+}
+
+export const Default: Story = {
+  args: { open: false, title: "알림 설정", onClose: () => {}, children: null },
+  render: () => <Demo />,
+};
+
+export const NonDismissible: Story = {
+  args: { open: false, title: "알림 설정", onClose: () => {}, children: null },
+  render: () => <Demo dismissible={false} />,
+};

--- a/apps/web/src/shared/ui/Modal.tsx
+++ b/apps/web/src/shared/ui/Modal.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { cn } from "@/shared/lib/utils";
+import { useFocusTrap } from "@/shared/lib/use-focus-trap";
+
+export interface ModalProps {
+  open: boolean;
+  title: string;
+  /** 배경/Esc로 닫기 허용 여부. 강제 선택 플로우면 false. */
+  dismissible?: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  /** 카드 오버라이드(예: max-w-sm) */
+  className?: string;
+}
+
+/** 오버레이 + 카드 모달 셸. 포커스 트랩·Esc·overlay 클릭 닫기 내장, 본문은 children 슬롯. */
+export function Modal({
+  open,
+  title,
+  dismissible = true,
+  onClose,
+  children,
+  className,
+}: ModalProps) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(cardRef, open);
+
+  useEffect(() => {
+    if (!open || !dismissible) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, dismissible, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      onClick={dismissible ? onClose : undefined}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/60 p-4"
+    >
+      <div
+        ref={cardRef}
+        tabIndex={-1}
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          "max-h-[85dvh] w-full max-w-md overflow-y-auto rounded-card-lg border border-line bg-card p-6 shadow-lg outline-none",
+          className,
+        )}
+      >
+        <h2 className="font-serif text-[1.125rem] font-bold text-ink">{title}</h2>
+        <div className="mt-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/shared/ui/Toggle.stories.tsx
+++ b/apps/web/src/shared/ui/Toggle.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+import { Toggle } from "./Toggle";
+
+const meta = {
+  title: "ui/Toggle",
+  component: Toggle,
+} satisfies Meta<typeof Toggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Demo({ disabled }: { disabled?: boolean }) {
+  const [checked, setChecked] = useState(true);
+  return (
+    <Toggle
+      checked={checked}
+      onChange={setChecked}
+      disabled={disabled}
+      label="새 검수 요청 알림"
+    />
+  );
+}
+
+export const Default: Story = {
+  args: { checked: true, onChange: () => {} },
+  render: () => <Demo />,
+};
+
+export const Disabled: Story = {
+  args: { checked: true, onChange: () => {} },
+  render: () => <Demo disabled />,
+};
+
+export const SettingsRow: Story = {
+  args: { checked: true, onChange: () => {} },
+  render: () => (
+    <div className="w-80 rounded-card border border-line bg-card p-4">
+      <Demo />
+    </div>
+  ),
+};

--- a/apps/web/src/shared/ui/Toggle.tsx
+++ b/apps/web/src/shared/ui/Toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { cn } from "@/shared/lib/utils";
+
+interface ToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: ReactNode;
+  disabled?: boolean;
+  className?: string;
+}
+
+/** 스위치 토글(role="switch") + 라벨. */
+export function Toggle({ checked, onChange, label, disabled, className }: ToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={cn(
+        "group inline-flex cursor-pointer select-none items-center gap-2.5 text-sm text-ink focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60",
+        className,
+      )}
+    >
+      {label}
+      <span
+        aria-hidden
+        className={cn(
+          "flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition group-focus-visible:ring-[3px] group-focus-visible:ring-gold-soft",
+          checked ? "bg-ink" : "bg-line",
+        )}
+      >
+        <span
+          className={cn(
+            "size-5 rounded-full bg-card shadow-sm transition",
+            checked && "translate-x-5",
+          )}
+        />
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

#46 (손해사정사 마이페이지) 선행 작업 — 이슈는 마이페이지 PR에서 닫습니다.

## ✅ 작업 내용

### 마이페이지에서 사용할 공용 Modal·Toggle 컴포넌트를 `shared/ui`에 추가했습니다

알림 설정 모달·자격 증빙 모달(이슈 #46)에 앞서, 여러 화면에서 재사용할 모달 셸과 스위치 토글을 전역 공용 UI로 승격했습니다. 두 컴포넌트 모두 `@theme` 디자인 토큰만 사용하며(raw hex·px 임의값 0건) Storybook 스토리를 함께 추가했습니다.

<br/>

### 1. Modal — 오버레이 + 카드 모달 셸

기존 `ConfirmDialog`(profile/edit·review에 동일 코드 2벌 복제)의 셸 부분을 일반화한 컴포넌트입니다. 포커스 트랩·Esc·배경 클릭 닫기를 내장하고, 본문은 `children` 슬롯으로 받아 확인 다이얼로그가 아닌 폼·목록형 모달에도 쓸 수 있게 했습니다.

```tsx
// shared/ui/Modal.tsx
export function Modal({ open, title, dismissible = true, onClose, children, className }: ModalProps)
```

#### 세부 작업
* `Modal` → `role="dialog"`·`aria-modal`·`useFocusTrap` 기반 접근성, `dismissible=false`로 강제 선택 플로우 지원
* 카드에 `max-h-[85dvh] overflow-y-auto` 적용 → 모바일에서 긴 본문 스크롤 대응
* `Modal.stories.tsx` → 기본·dismiss 불가 스토리

<br/>

### 2. Toggle — role="switch" 스위치

알림 설정 토글(on/off)용 스위치입니다. 기존 `Checkbox`와 동일한 API(`checked`/`onChange`/`label`/`disabled`)로 맞춰 폼에서 예측 가능하게 썼습니다.

#### 세부 작업
* `Toggle` → `role="switch"`·`aria-checked` 접근성, on=`bg-ink`·포커스 링 `gold-soft`(디자인 토큰 상태 레시피)
* `Toggle.stories.tsx` → 기본·비활성·설정 행 컨텍스트 스토리

## 💬 특이사항 / 고민했던 부분 / 결정 사항

### 기존 ConfirmDialog 마이그레이션은 범위에서 제외

`ConfirmDialog` 복제 2벌을 `Modal` 기반으로 합치는 작업은 이 PR에 포함하지 않았습니다(동작 회귀 리스크 분리). 후속 리팩터링 이슈로 처리 예정입니다.

### Toggle 시각 스펙은 토큰 기반 조합

Figma 알림 설정 모달(146-4640) 시안과의 세부 대조는 마이페이지 알림 모달 구현 시점에 진행합니다. 어긋나는 값이 나오면 해당 PR에서 보정합니다(토큰 팔레트 안에서만 변경될 예정).

## 🔜 후속 이슈

- 손해사정사 마이페이지 구현(#46) — 이 컴포넌트들의 첫 소비처(알림 설정 모달·증빙 모달)
- `ConfirmDialog` 2벌 → `Modal` 기반 통합 리팩터링


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 모달과 토글 UI 컴포넌트가 새로 추가되어, 화면에서 바로 사용할 수 있게 되었습니다.
  * 모달은 닫기 가능/불가 옵션을 지원하고, 접근성 속성이 포함됩니다.
  * 토글은 켜짐/꺼짐 상태, 비활성화 상태를 지원합니다.

* **Documentation**
  * Storybook에 모달과 토글의 기본 사용 예시와 다양한 표시 사례가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->