### PR TITLE
[Refactor] 레거시 px 길이값 rem/스케일 전환

### DIFF
--- a/apps/web/src/app/customer/adjust-request/_components/FileDropzone.stories.tsx
+++ b/apps/web/src/app/customer/adjust-request/_components/FileDropzone.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof FileDropzone> = {
   args: { accept: ".pdf,.jpg,.jpeg,.png", onFiles: () => {} },
   decorators: [
     (Story) => (
-      <div className="w-[520px]">
+      <div className="w-[32.5rem]">
         <Story />
       </div>
     ),

--- a/apps/web/src/app/customer/adjust-request/_components/SubmitComplete.tsx
+++ b/apps/web/src/app/customer/adjust-request/_components/SubmitComplete.tsx
@@ -19,28 +19,28 @@ interface SubmitCompleteProps {
 
 export function SubmitComplete({ result, onRestart }: SubmitCompleteProps) {
   return (
-    <div className="mx-auto w-full max-w-[560px] px-4 py-16 text-center">
+    <div className="mx-auto w-full max-w-[35rem] px-4 py-16 text-center">
       <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-green-soft">
         <svg width="26" height="26" viewBox="0 0 24 24" fill="none" className="text-green">
           <path d="m5 12.5 4 4 10-10" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       </div>
 
-      <h1 className="mt-5 font-serif text-[24px] font-bold text-ink">분석 요청이 접수됐어요</h1>
-      <p className="mt-2 text-[14px] text-ink-3">
+      <h1 className="mt-5 font-serif text-[1.5rem] font-bold text-ink">분석 요청이 접수됐어요</h1>
+      <p className="mt-2 text-[0.875rem] text-ink-3">
         입력하신 정보로 약관·특약·판례를 분석합니다. 진행 상황은 내 리포트에서 확인할 수 있어요.
       </p>
 
       <div className="mt-6 rounded-card border border-line bg-paper-2 px-4 py-3 text-left">
         <div className="flex items-center justify-between border-b border-line py-2.5">
-          <span className="text-[13px] text-ink-3">진행 상태</span>
-          <span className="rounded-pill bg-gold-soft px-2.5 py-1 text-[12.5px] font-semibold text-gold-ink">
+          <span className="text-[0.8125rem] text-ink-3">진행 상태</span>
+          <span className="rounded-pill bg-gold-soft px-2.5 py-1 text-[0.78125rem] font-semibold text-gold-ink">
             {STATUS_LABELS[result.status] ?? result.status}
           </span>
         </div>
         <div className="flex items-center justify-between py-2.5">
-          <span className="text-[13px] text-ink-3">요청 번호</span>
-          <span className="text-[13px] font-medium text-ink">{result.reportId}</span>
+          <span className="text-[0.8125rem] text-ink-3">요청 번호</span>
+          <span className="text-[0.8125rem] font-medium text-ink">{result.reportId}</span>
         </div>
       </div>
 

--- a/apps/web/src/app/customer/adjust-request/_components/ToggleChip.tsx
+++ b/apps/web/src/app/customer/adjust-request/_components/ToggleChip.tsx
@@ -14,7 +14,7 @@ export function ToggleChip({ label, selected, onClick }: ToggleChipProps) {
       aria-pressed={selected}
       onClick={onClick}
       className={cn(
-        "rounded-chip border px-4 py-2 text-[14px] font-medium transition",
+        "rounded-chip border px-4 py-2 text-[0.875rem] font-medium transition",
         selected ? "border-ink bg-ink text-white" : "border-line bg-card text-ink-2 hover:border-ink/40",
       )}
     >

--- a/apps/web/src/app/customer/adjust-request/_components/UploadFileItem.stories.tsx
+++ b/apps/web/src/app/customer/adjust-request/_components/UploadFileItem.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof UploadFileItem> = {
   },
   decorators: [
     (Story) => (
-      <div className="w-[420px]">
+      <div className="w-[26.25rem]">
         <Story />
       </div>
     ),

--- a/apps/web/src/app/customer/dashboard/_components/ReceivedProposalsCard.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/ReceivedProposalsCard.tsx
@@ -42,7 +42,7 @@ function ProposalsPreview({ reportId, count }: { reportId: string; count: number
           <Link
             key={proposal.adjusterId}
             href={DASHBOARD_LINKS.proposals(reportId)}
-            className={`flex items-center gap-[11px] py-[0.8125rem] transition hover:opacity-80 ${index > 0 ? "border-t border-line-2" : ""}`}
+            className={`flex items-center gap-[0.6875rem] py-[0.8125rem] transition hover:opacity-80 ${index > 0 ? "border-t border-line-2" : ""}`}
           >
             <span
               aria-hidden

--- a/apps/web/src/app/customer/proposals/[reportId]/_components/AnalysisTargetCard.tsx
+++ b/apps/web/src/app/customer/proposals/[reportId]/_components/AnalysisTargetCard.tsx
@@ -21,10 +21,10 @@ export function AnalysisTargetCard({
       </span>
       <div className="min-w-0">
         <div className="flex items-baseline gap-2">
-          <p className="truncate text-[16px] font-semibold">{accidentType}</p>
-          <span className="shrink-0 text-[13px] text-white/45">No.{reportNo}</span>
+          <p className="truncate text-[1rem] font-semibold">{accidentType}</p>
+          <span className="shrink-0 text-[0.8125rem] text-white/45">No.{reportNo}</span>
         </div>
-        <p className="mt-1 text-[13px] text-white/70">
+        <p className="mt-1 text-[0.8125rem] text-white/70">
           접수 {receivedAt} · 손해사정사 {proposalCount}명이 검수 의견을 보냈어요
         </p>
       </div>

--- a/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalCard.tsx
+++ b/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalCard.tsx
@@ -65,24 +65,24 @@ export function ProposalCard({ reportId, proposal }: ProposalCardProps) {
         <div className="flex min-w-0 items-center gap-3">
           <span
             aria-hidden
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-navy text-[17px] font-semibold text-white"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-navy text-[1.0625rem] font-semibold text-white"
           >
             {avatarLabel}
           </span>
           <div className="min-w-0">
             <div className="flex items-center gap-1.5">
-              <p className="truncate text-[15px] font-semibold text-ink">
+              <p className="truncate text-[0.9375rem] font-semibold text-ink">
                 {nickname} 손해사정사
               </p>
               {isVerified && <VerifiedIcon />}
               {isNew && (
-                <span className="shrink-0 rounded-full bg-terra-soft px-2 py-0.5 text-[11px] font-medium text-terra">
+                <span className="shrink-0 rounded-full bg-terra-soft px-2 py-0.5 text-[0.6875rem] font-medium text-terra">
                   신규
                 </span>
               )}
             </div>
             {(speciality || career != null) && (
-              <p className="mt-0.5 text-[13px] text-ink-3">
+              <p className="mt-0.5 text-[0.8125rem] text-ink-3">
                 {[speciality, career != null ? `경력 ${career}년` : null]
                   .filter(Boolean)
                   .join(" · ")}
@@ -93,25 +93,25 @@ export function ProposalCard({ reportId, proposal }: ProposalCardProps) {
         <button
           type="button"
           onClick={openAdjusterProfile}
-          className="shrink-0 text-[13px] text-ink-3 transition hover:text-ink"
+          className="shrink-0 text-[0.8125rem] text-ink-3 transition hover:text-ink"
         >
           프로필 보기
         </button>
       </div>
 
-      <p className="mt-4 text-[14px] leading-relaxed text-ink-2">“{proposalSummary}”</p>
+      <p className="mt-4 text-[0.875rem] leading-relaxed text-ink-2">“{proposalSummary}”</p>
 
       <div className="mt-5 flex items-end justify-between gap-4">
         <div className="flex min-w-0 gap-8">
           <div className="min-w-0">
-            <p className="text-[12px] text-ink-3">이 사정사의 검토 범위 · 참고용</p>
-            <p className="mt-1 text-[15px] font-semibold text-ink">
+            <p className="text-[0.75rem] text-ink-3">이 사정사의 검토 범위 · 참고용</p>
+            <p className="mt-1 text-[0.9375rem] font-semibold text-ink">
               {estimateRange ?? "범위 미제시"}
             </p>
           </div>
           <div className="min-w-0">
-            <p className="text-[12px] text-ink-3">보수 기준</p>
-            <p className="mt-1 text-[15px] font-semibold text-ink">{feeBasis ?? "상담 시 안내"}</p>
+            <p className="text-[0.75rem] text-ink-3">보수 기준</p>
+            <p className="mt-1 text-[0.9375rem] font-semibold text-ink">{feeBasis ?? "상담 시 안내"}</p>
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">

--- a/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalList.tsx
+++ b/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalList.tsx
@@ -10,8 +10,8 @@ export function ProposalList({ reportId, proposals }: ProposalListProps) {
   if (proposals.length === 0) {
     return (
       <div className="rounded-card-lg border border-line bg-card px-6 py-16 text-center">
-        <p className="text-[16px] font-semibold text-ink">아직 도착한 제안이 없어요</p>
-        <p className="mt-2 text-[14px] text-ink-3">
+        <p className="text-[1rem] font-semibold text-ink">아직 도착한 제안이 없어요</p>
+        <p className="mt-2 text-[0.875rem] text-ink-3">
           손해사정사가 검수 의견을 보내면 이곳에 표시됩니다.
         </p>
       </div>

--- a/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalsError.tsx
+++ b/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalsError.tsx
@@ -5,8 +5,8 @@ export function ProposalsError({ code, onRetry }: { code?: string; onRetry: () =
 
   return (
     <div className="mx-auto flex max-w-md flex-col items-center px-4 py-24 text-center">
-      <h2 className="text-[18px] font-semibold text-ink">제안을 불러오지 못했어요</h2>
-      <p className="mt-2 text-[14px] text-ink-3">잠시 후 다시 시도해 주세요.</p>
+      <h2 className="text-[1.125rem] font-semibold text-ink">제안을 불러오지 못했어요</h2>
+      <p className="mt-2 text-[0.875rem] text-ink-3">잠시 후 다시 시도해 주세요.</p>
       <Button className="mt-5" onClick={onRetry}>
         다시 시도
       </Button>

--- a/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalsSkeleton.tsx
+++ b/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalsSkeleton.tsx
@@ -1,6 +1,6 @@
 export function ProposalsSkeleton() {
   return (
-    <div className="mx-auto w-full max-w-[760px] px-4 py-8">
+    <div className="mx-auto w-full max-w-[47.5rem] px-4 py-8">
       <div className="h-4 w-20 animate-pulse rounded bg-line-2" />
       <div className="mt-3 h-9 w-72 animate-pulse rounded bg-line-2" />
       <div className="mt-6 h-24 animate-pulse rounded-card-lg bg-line-2" />

--- a/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalsView.tsx
+++ b/apps/web/src/app/customer/proposals/[reportId]/_components/ProposalsView.tsx
@@ -12,12 +12,12 @@ export function ProposalsView({ reportId }: { reportId: string }) {
   const proposalCount = proposalList.pagination.totalElements;
 
   return (
-    <div className="mx-auto w-full max-w-[760px] px-4 py-8">
-      <p className="text-[13px] font-semibold text-gold-ink">받은 제안</p>
-      <h1 className="mt-1 font-serif text-[26px] font-bold leading-tight text-ink">
+    <div className="mx-auto w-full max-w-[47.5rem] px-4 py-8">
+      <p className="text-[0.8125rem] font-semibold text-gold-ink">받은 제안</p>
+      <h1 className="mt-1 font-serif text-[1.625rem] font-bold leading-tight text-ink">
         제안 {proposalCount}건이 도착했어요
       </h1>
-      <p className="mt-2 text-[14px] text-ink-3">
+      <p className="mt-2 text-[0.875rem] text-ink-3">
         검수 펼침된 리포트를 본 손해사정사들의 상담 제안입니다.
       </p>
 
@@ -36,7 +36,7 @@ export function ProposalsView({ reportId }: { reportId: string }) {
         <ProposalList reportId={reportId} proposals={proposals} />
       </div>
 
-      <p className="mt-8 rounded-card border border-line bg-paper-2 px-4 py-3 text-[12.5px] leading-relaxed text-ink-3">
+      <p className="mt-8 rounded-card border border-line bg-paper-2 px-4 py-3 text-[0.78125rem] leading-relaxed text-ink-3">
         검토 범위는 추정·참고용이며 결과를 보장하지 않습니다. 상담은 해당 손해사정사에게
         전달되며, 검토 의견은 가입자님의 판단을 돕기 위한 참고 자료입니다.
       </p>

--- a/apps/web/src/app/customer/report/[id]/_components/ReportDetailError.tsx
+++ b/apps/web/src/app/customer/report/[id]/_components/ReportDetailError.tsx
@@ -11,8 +11,8 @@ export function ReportDetailError({ code, onRetry }: { code?: string; onRetry: (
 
   return (
     <div className="mx-auto flex max-w-md flex-col items-center px-4 py-24 text-center">
-      <h2 className="text-[18px] font-semibold text-ink">{message.title}</h2>
-      <p className="mt-2 text-[14px] text-ink-3">{message.desc}</p>
+      <h2 className="text-[1.125rem] font-semibold text-ink">{message.title}</h2>
+      <p className="mt-2 text-[0.875rem] text-ink-3">{message.desc}</p>
       {!known && (
         <Button className="mt-5" onClick={onRetry}>
           다시 시도

--- a/apps/web/src/app/customer/report/[id]/_components/ReportSummaryAside.tsx
+++ b/apps/web/src/app/customer/report/[id]/_components/ReportSummaryAside.tsx
@@ -19,26 +19,26 @@ export function ReportSummaryAside({
 
   return (
     <div className="rounded-card-lg border border-line bg-card p-6">
-      <h2 className="text-[15px] font-semibold text-ink">한눈에 보기</h2>
+      <h2 className="text-[0.9375rem] font-semibold text-ink">한눈에 보기</h2>
 
       <dl className="mt-2 divide-y divide-line-2">
         <div className="flex items-center justify-between gap-2 py-3">
-          <dt className="text-[13px] text-ink-3">이 사정서의 검토 범위</dt>
+          <dt className="text-[0.8125rem] text-ink-3">이 사정서의 검토 범위</dt>
           <dd>
             <AmountRange min={claimedMinAmount} max={claimedMaxAmount} />
           </dd>
         </div>
 
         <div className="flex items-center justify-between gap-2 py-3">
-          <dt className="text-[13px] text-ink-3">제안받은 금액</dt>
-          <dd className="text-[14px] font-semibold text-ink">
+          <dt className="text-[0.8125rem] text-ink-3">제안받은 금액</dt>
+          <dd className="text-[0.875rem] font-semibold text-ink">
             {offeredAmount != null ? <AmountRange min={offeredAmount} /> : "제안 없음"}
           </dd>
         </div>
 
         <div className="flex items-center justify-between gap-2 py-3">
-          <dt className="text-[13px] text-ink-3">권장 다음 단계</dt>
-          <dd className="text-[14px] font-semibold text-gold-ink">{meta.nextStep}</dd>
+          <dt className="text-[0.8125rem] text-ink-3">권장 다음 단계</dt>
+          <dd className="text-[0.875rem] font-semibold text-gold-ink">{meta.nextStep}</dd>
         </div>
       </dl>
     </div>

--- a/apps/web/src/app/partner/review/[reportId]/_components/AccidentNarrativeSection.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/AccidentNarrativeSection.tsx
@@ -7,9 +7,9 @@ export function AccidentNarrativeSection({ description }: AccidentNarrativeSecti
 
   return (
     <div>
-      <p className="text-[13px] font-bold text-ink">의뢰인이 작성한 사고 경위</p>
+      <p className="text-[0.8125rem] font-bold text-ink">의뢰인이 작성한 사고 경위</p>
       <div className="mt-2 rounded-card border border-line bg-paper-2 p-4">
-        <p className="text-[14px] leading-relaxed text-ink-2">{description}</p>
+        <p className="text-[0.875rem] leading-relaxed text-ink-2">{description}</p>
       </div>
     </div>
   );

--- a/apps/web/src/app/partner/review/[reportId]/_components/AttachmentSection.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/AttachmentSection.tsx
@@ -127,7 +127,7 @@ export function AttachmentSection({ attachments }: AttachmentSectionProps) {
         </Button>
       </div>
 
-      <div className="mt-4 grid gap-4 md:grid-cols-[200px_1fr]">
+      <div className="mt-4 grid gap-4 md:grid-cols-[12.5rem_1fr]">
         <ul className="flex flex-col gap-2" aria-label="첨부 파일 목록">
           {attachments.map((file) => {
             const active = file.id === selected?.id;
@@ -175,7 +175,7 @@ export function AttachmentSection({ attachments }: AttachmentSectionProps) {
               )}
             </div>
 
-            <div className="mt-3 grid gap-4 sm:grid-cols-[140px_1fr]">
+            <div className="mt-3 grid gap-4 sm:grid-cols-[8.75rem_1fr]">
               <div
                 aria-hidden
                 className="aspect-[3/4] rounded-card border border-line bg-card"

--- a/apps/web/src/app/partner/review/[reportId]/_components/ClaimInfoSection.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ClaimInfoSection.tsx
@@ -51,7 +51,7 @@ export function ClaimInfoSection({
         총 {totalDays}일{hospitalizations.length > 1 && ` · ${hospitalizations.length}회`}
         <span
           role="tooltip"
-          className="invisible absolute left-0 top-full z-30 mt-2 w-max max-w-[280px] rounded-card border border-line bg-card p-3 text-left text-[12.5px] font-normal opacity-0 shadow-lg transition-opacity duration-150 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+          className="invisible absolute left-0 top-full z-30 mt-2 w-max max-w-[17.5rem] rounded-card border border-line bg-card p-3 text-left text-[0.78125rem] font-normal opacity-0 shadow-lg transition-opacity duration-150 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
         >
           {hospitalizations.map((h, index) => {
             const days = periodDays(h.hospitalStart, h.hospitalEnd);
@@ -87,8 +87,8 @@ export function ClaimInfoSection({
     <dl className="grid grid-cols-1 gap-px rounded-card border border-line bg-line sm:grid-cols-3">
       {fields.map((field) => (
         <div key={field.kicker} className="bg-card p-4">
-          <dt className="text-[12.5px] text-ink-3">{field.kicker}</dt>
-          <dd className="mt-1.5 text-[15px] font-semibold text-ink">{field.value}</dd>
+          <dt className="text-[0.78125rem] text-ink-3">{field.kicker}</dt>
+          <dd className="mt-1.5 text-[0.9375rem] font-semibold text-ink">{field.value}</dd>
         </div>
       ))}
     </dl>

--- a/apps/web/src/app/partner/review/[reportId]/_components/ClientAccidentSection.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ClientAccidentSection.tsx
@@ -13,7 +13,7 @@ export function ClientAccidentSection({ client, isMasked }: ClientAccidentSectio
   return (
     <div>
       <div className="flex items-center justify-between gap-2">
-        <h2 className="flex items-center gap-2 font-serif text-[17px] font-bold text-ink">
+        <h2 className="flex items-center gap-2 font-serif text-[1.0625rem] font-bold text-ink">
           <User className="text-ink-3" />
           의뢰인 정보 · 사고 내용
         </h2>
@@ -27,7 +27,7 @@ export function ClientAccidentSection({ client, isMasked }: ClientAccidentSectio
         >
           {initial}
         </span>
-        <div className="text-[14px]">
+        <div className="text-[0.875rem]">
           <p>
             <span className="font-semibold text-ink">{client.maskedName}</span>
             <span className="text-ink-3"> · {client.ageBand} · {client.gender}</span>

--- a/apps/web/src/app/partner/review/[reportId]/_components/ConfirmDialog.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ConfirmDialog.tsx
@@ -54,9 +54,9 @@ export function ConfirmDialog({
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-sm rounded-card-lg border border-line bg-card p-6 shadow-lg outline-none"
       >
-        <h2 className="font-serif text-[18px] font-bold text-ink">{title}</h2>
+        <h2 className="font-serif text-[1.125rem] font-bold text-ink">{title}</h2>
         {description && (
-          <p className="mt-2 text-[14px] leading-relaxed text-ink-2">{description}</p>
+          <p className="mt-2 text-[0.875rem] leading-relaxed text-ink-2">{description}</p>
         )}
         <div className="mt-6 flex justify-end gap-2">
           <Button variant="ghost" size="sm" onClick={onCancel}>

--- a/apps/web/src/app/partner/review/[reportId]/_components/EstimatedRangeSection.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/EstimatedRangeSection.tsx
@@ -29,9 +29,9 @@ function ConfirmedAmountInput({ label, value, onValueChange }: ConfirmedAmountIn
         aria-label={label}
         value={value}
         onChange={(e) => onValueChange(e.target.value)}
-        className="h-[42px] w-full rounded-input border border-white/20 bg-ink pl-3 pr-12 text-[15px] font-semibold text-white outline-none transition placeholder:text-white/40 focus:border-gold-2 focus:ring-[3px] focus:ring-gold/30"
+        className="h-[2.625rem] w-full rounded-input border border-white/20 bg-ink pl-3 pr-12 text-[0.9375rem] font-semibold text-white outline-none transition placeholder:text-white/40 focus:border-gold-2 focus:ring-[3px] focus:ring-gold/30"
       />
-      <span className="pointer-events-none absolute right-3 text-[12px] text-white/60">만원</span>
+      <span className="pointer-events-none absolute right-3 text-[0.75rem] text-white/60">만원</span>
     </div>
   );
 }
@@ -53,7 +53,7 @@ export function EstimatedRangeSection({
 }: EstimatedRangeSectionProps) {
   return (
     <section className="rounded-card-lg border border-line bg-card p-6">
-      <h2 className="font-serif text-[17px] font-bold text-ink">예상 보상 범위</h2>
+      <h2 className="font-serif text-[1.0625rem] font-bold text-ink">예상 보상 범위</h2>
 
       <div className="mt-4 grid gap-4 md:grid-cols-2">
         <div className="rounded-card border border-line-2 bg-paper-2 p-4">
@@ -64,7 +64,7 @@ export function EstimatedRangeSection({
         </div>
 
         <div className="rounded-card border border-navy bg-navy p-4">
-          <p className="text-[12.5px] font-semibold uppercase tracking-[0.12em] text-gold-2">
+          <p className="text-[0.78125rem] font-semibold uppercase tracking-[0.12em] text-gold-2">
             사정사 확정 (직접 입력)
           </p>
           <div className="mt-2 flex items-center gap-2">

--- a/apps/web/src/app/partner/review/[reportId]/_components/IssueAddForm.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/IssueAddForm.tsx
@@ -42,7 +42,7 @@ export function IssueAddForm({ onAdd }: IssueAddFormProps) {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="w-full rounded-card border border-dashed border-gold-2 bg-gold-soft/30 py-3 text-[14px] font-semibold text-gold-ink transition hover:bg-gold-soft/60"
+        className="w-full rounded-card border border-dashed border-gold-2 bg-gold-soft/30 py-3 text-[0.875rem] font-semibold text-gold-ink transition hover:bg-gold-soft/60"
       >
         + 쟁점 추가
       </button>
@@ -51,7 +51,7 @@ export function IssueAddForm({ onAdd }: IssueAddFormProps) {
 
   return (
     <div className="space-y-3 rounded-card border border-gold-2 bg-gold-soft/40 p-4">
-      <p className="text-[13.5px] font-semibold text-ink">신규 쟁점 추가</p>
+      <p className="text-[0.84375rem] font-semibold text-ink">신규 쟁점 추가</p>
 
       <div>
         <Label htmlFor="add-issue-title">쟁점 제목</Label>

--- a/apps/web/src/app/partner/review/[reportId]/_components/IssueBoard.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/IssueBoard.tsx
@@ -19,15 +19,15 @@ export interface IssueBoardProps {
 export function IssueBoard({ issues, actions }: IssueBoardProps) {
   return (
     <section className="rounded-card-lg border border-line bg-card p-6">
-      <h2 className="font-serif text-[17px] font-bold text-ink">
+      <h2 className="font-serif text-[1.0625rem] font-bold text-ink">
         쟁점별 검수 <span className="text-gold-ink">{issues.length}건</span>
       </h2>
-      <p className="mt-1.5 text-[13px] leading-relaxed text-ink-3">
+      <p className="mt-1.5 text-[0.8125rem] leading-relaxed text-ink-3">
         AI 초안 판단을 검토해 인정·수정·제외와 의견을 남겨주세요. 빠진 쟁점은 직접 추가할 수 있어요.
       </p>
 
       {issues.length === 0 ? (
-        <p className="mt-4 rounded-card border border-dashed border-line-2 bg-paper-2 px-4 py-6 text-center text-[13.5px] text-ink-3">
+        <p className="mt-4 rounded-card border border-dashed border-line-2 bg-paper-2 px-4 py-6 text-center text-[0.84375rem] text-ink-3">
           AI가 추출한 쟁점이 없습니다. 아래에서 검토할 쟁점을 직접 추가해 주세요.
         </p>
       ) : (

--- a/apps/web/src/app/partner/review/[reportId]/_components/IssueCard.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/IssueCard.tsx
@@ -40,14 +40,14 @@ export function IssueCard({ issue, index, onSetStatus, onPatch, onRemove }: Issu
     >
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-2.5">
-          <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-ink text-[12px] font-semibold text-white">
+          <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full bg-ink text-[0.75rem] font-semibold text-white">
             {index + 1}
           </span>
           <div>
             <div className="flex flex-wrap items-center gap-2">
-              <h3 className="text-[15px] font-semibold text-ink">{issue.title}</h3>
+              <h3 className="text-[0.9375rem] font-semibold text-ink">{issue.title}</h3>
               {impact && (
-                <span className={cn("text-[13px] font-semibold", impactTone)}>{impact}</span>
+                <span className={cn("text-[0.8125rem] font-semibold", impactTone)}>{impact}</span>
               )}
               {issue.isNew && <StatusBadge tone="gold">신규</StatusBadge>}
             </div>
@@ -57,16 +57,16 @@ export function IssueCard({ issue, index, onSetStatus, onPatch, onRemove }: Issu
       </div>
 
       {!isModified && (
-        <p className="mt-2.5 pl-[34px] text-[13.5px] leading-relaxed text-ink-2">
+        <p className="mt-2.5 pl-[2.125rem] text-[0.84375rem] leading-relaxed text-ink-2">
           {issue.description}
         </p>
       )}
 
       {issue.tags.length > 0 && (
-        <ul className="mt-2.5 flex flex-wrap gap-1.5 pl-[34px]">
+        <ul className="mt-2.5 flex flex-wrap gap-1.5 pl-[2.125rem]">
           {issue.tags.map((tag) => (
             <li key={tag}>
-              <span className="inline-flex items-center rounded-tag border border-line bg-card px-2 py-1 text-[12px] text-ink-3">
+              <span className="inline-flex items-center rounded-tag border border-line bg-card px-2 py-1 text-[0.75rem] text-ink-3">
                 {tag}
               </span>
             </li>
@@ -74,7 +74,7 @@ export function IssueCard({ issue, index, onSetStatus, onPatch, onRemove }: Issu
         </ul>
       )}
 
-      <div className="mt-3 pl-[34px]">
+      <div className="mt-3 pl-[2.125rem]">
         {isModified && <IssueModifyForm issue={issue} onPatch={onPatch} />}
         {issue.reviewStatus === "EXCLUDED" && <IssueExcludeForm issue={issue} onPatch={onPatch} />}
 
@@ -83,7 +83,7 @@ export function IssueCard({ issue, index, onSetStatus, onPatch, onRemove }: Issu
             aria-hidden
             className="mt-1.5 flex size-7 shrink-0 items-center justify-center rounded-full bg-navy text-gold"
           >
-            <Scale className="text-[13px]" />
+            <Scale className="text-[0.8125rem]" />
           </span>
           <Input
             aria-label="사정사 의견"
@@ -100,7 +100,7 @@ export function IssueCard({ issue, index, onSetStatus, onPatch, onRemove }: Issu
           <button
             type="button"
             onClick={onRemove}
-            className="mt-2 text-[12.5px] font-medium text-terra hover:underline"
+            className="mt-2 text-[0.78125rem] font-medium text-terra hover:underline"
           >
             쟁점 삭제
           </button>

--- a/apps/web/src/app/partner/review/[reportId]/_components/IssueModifyForm.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/IssueModifyForm.tsx
@@ -23,9 +23,9 @@ export interface IssueModifyFormProps {
 export function IssueModifyForm({ issue, onPatch }: IssueModifyFormProps) {
   return (
     <div className="mt-3 space-y-3 rounded-card border border-gold-2 bg-gold-soft/40 p-4">
-      <p className="text-[12.5px] font-semibold text-gold-ink">AI 초안 수정 중 — 제목·금액·설명을 고치세요</p>
+      <p className="text-[0.78125rem] font-semibold text-gold-ink">AI 초안 수정 중 — 제목·금액·설명을 고치세요</p>
 
-      <div className="grid gap-3 sm:grid-cols-[1fr_160px]">
+      <div className="grid gap-3 sm:grid-cols-[1fr_10rem]">
         <div>
           <Label htmlFor={`modify-title-${issue.issueId}`}>쟁점 제목</Label>
           <Input

--- a/apps/web/src/app/partner/review/[reportId]/_components/IssueStatusControl.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/IssueStatusControl.tsx
@@ -33,7 +33,7 @@ export function IssueStatusControl({ value, onChange }: IssueStatusControlProps)
             aria-checked={selected}
             onClick={() => onChange(option.value)}
             className={cn(
-              "rounded-pill px-3 py-1.5 text-[12.5px] font-semibold transition",
+              "rounded-pill px-3 py-1.5 text-[0.78125rem] font-semibold transition",
               selected ? ACTIVE_CLASS[option.value] : "bg-transparent text-ink-3 hover:text-ink",
             )}
           >

--- a/apps/web/src/app/partner/review/[reportId]/_components/OverallOpinionSection.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/OverallOpinionSection.tsx
@@ -14,11 +14,11 @@ const OPINION_PLACEHOLDER =
 export function OverallOpinionSection({ value, onChange }: OverallOpinionSectionProps) {
   return (
     <section className="rounded-card-lg border border-line bg-card p-6">
-      <h2 className="flex items-center gap-2 font-serif text-[17px] font-bold text-ink">
+      <h2 className="flex items-center gap-2 font-serif text-[1.0625rem] font-bold text-ink">
         <Scale className="text-gold" />
         손해사정사 종합 의견
       </h2>
-      <p className="mt-1.5 text-[13px] text-ink-3">고객 리포트 상단에 함께 전달됩니다.</p>
+      <p className="mt-1.5 text-[0.8125rem] text-ink-3">고객 리포트 상단에 함께 전달됩니다.</p>
 
       <Input
         aria-label="손해사정사 종합 의견"

--- a/apps/web/src/app/partner/review/[reportId]/_components/ReviewDetailError.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ReviewDetailError.tsx
@@ -11,8 +11,8 @@ export function ReviewDetailError({ code, onRetry }: { code?: string; onRetry: (
 
   return (
     <div className="mx-auto flex max-w-md flex-col items-center px-6 py-24 text-center">
-      <h2 className="text-[18px] font-semibold text-ink">{message.title}</h2>
-      <p className="mt-2 text-[14px] text-ink-3">{message.desc}</p>
+      <h2 className="text-[1.125rem] font-semibold text-ink">{message.title}</h2>
+      <p className="mt-2 text-[0.875rem] text-ink-3">{message.desc}</p>
       {!known && (
         <Button className="mt-5" onClick={onRetry}>
           다시 시도

--- a/apps/web/src/app/partner/review/[reportId]/_components/ReviewDetailSkeleton.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ReviewDetailSkeleton.tsx
@@ -2,7 +2,7 @@ export function ReviewDetailSkeleton() {
   return (
     <div className="mx-auto w-full max-w-6xl px-6 py-8">
       <div className="h-9 w-72 animate-pulse rounded bg-line-2" />
-      <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_320px]">
+      <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_20rem]">
         <div className="space-y-6">
           <div className="h-44 animate-pulse rounded-card-lg bg-line-2" />
           <div className="h-28 animate-pulse rounded-card-lg bg-line-2" />

--- a/apps/web/src/app/partner/review/[reportId]/_components/ReviewDetailView.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ReviewDetailView.tsx
@@ -75,7 +75,7 @@ export function ReviewDetailView({ reportId }: { reportId: string }) {
         </div>
       </div>
 
-      <div className="mx-auto w-full max-w-6xl px-6 py-8 grid gap-6 lg:grid-cols-[1fr_320px]">
+      <div className="mx-auto w-full max-w-6xl px-6 py-8 grid gap-6 lg:grid-cols-[1fr_20rem]">
         <div className="space-y-6">
           <section className="space-y-5 rounded-card-lg border border-line bg-card p-6">
             <ClientAccidentSection client={data.client} isMasked={data.isMasked} />

--- a/apps/web/src/app/partner/review/[reportId]/_components/ReviewHeader.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ReviewHeader.tsx
@@ -48,10 +48,10 @@ export function ReviewHeader({
         </Link>
         <div>
           <div className="flex flex-wrap items-center gap-2">
-            <h1 className="font-serif text-[22px] font-bold text-ink">{treatment} 검수</h1>
+            <h1 className="font-serif text-[1.375rem] font-bold text-ink">{treatment} 검수</h1>
             <StatusBadge tone="gold">{accidentCategory(accidentType)}</StatusBadge>
           </div>
-          <p className="mt-1 text-[13px] text-ink-3">
+          <p className="mt-1 text-[0.8125rem] text-ink-3">
             #{caseId} · {region} · {clientName} 의뢰
           </p>
         </div>

--- a/apps/web/src/app/partner/review/[reportId]/_components/ReviewSidebar.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/_components/ReviewSidebar.tsx
@@ -42,8 +42,8 @@ export function ReviewSidebar({
   return (
     <div className="space-y-5">
       <section className="rounded-card-lg border border-line bg-card p-5">
-        <h2 className="font-serif text-[16px] font-bold text-ink">검수 진행</h2>
-        <div className="mt-3 flex items-center justify-between text-[13.5px]">
+        <h2 className="font-serif text-[1rem] font-bold text-ink">검수 진행</h2>
+        <div className="mt-3 flex items-center justify-between text-[0.84375rem]">
           <span className="text-ink-3">쟁점 검토</span>
           <span className="font-semibold tabular-nums text-ink">
             {progress.reviewed}/{progress.total}
@@ -55,7 +55,7 @@ export function ReviewSidebar({
           max={progress.total}
           label="쟁점 검토 진행"
         />
-        <dl className="mt-4 space-y-2.5 border-t border-line-2 pt-4 text-[14px]">
+        <dl className="mt-4 space-y-2.5 border-t border-line-2 pt-4 text-[0.875rem]">
           {COUNT_ROWS.map((row) => (
             <div key={row.key} className="flex items-center justify-between">
               <dt className="text-ink-2">{row.label}</dt>
@@ -68,15 +68,15 @@ export function ReviewSidebar({
       </section>
 
       <section className="rounded-card-lg border border-line bg-card p-5">
-        <h2 className="font-serif text-[16px] font-bold text-ink">고객 전송 요약</h2>
-        <dl className="mt-3 space-y-2.5 text-[14px]">
+        <h2 className="font-serif text-[1rem] font-bold text-ink">고객 전송 요약</h2>
+        <dl className="mt-3 space-y-2.5 text-[0.875rem]">
           <div className="flex items-center justify-between gap-2">
             <dt className="text-ink-2">확정 보상 범위</dt>
             <dd>
               {confirmedMin != null ? (
                 <AmountRange min={confirmedMin} max={confirmedMax} />
               ) : (
-                <span className="text-[13px] text-ink-3">미입력</span>
+                <span className="text-[0.8125rem] text-ink-3">미입력</span>
               )}
             </dd>
           </div>
@@ -110,13 +110,13 @@ export function ReviewSidebar({
       {errorMessage && (
         <p
           role="alert"
-          className="rounded-card border border-terra-2 bg-terra-soft px-4 py-3 text-[12.5px] leading-relaxed text-terra"
+          className="rounded-card border border-terra-2 bg-terra-soft px-4 py-3 text-[0.78125rem] leading-relaxed text-terra"
         >
           {errorMessage}
         </p>
       )}
 
-      <p className="rounded-card bg-green-soft px-4 py-3 text-[12.5px] leading-relaxed text-green">
+      <p className="rounded-card bg-green-soft px-4 py-3 text-[0.78125rem] leading-relaxed text-green">
         전송 시 손해사정사 검수 완료 배지가 부착되어 고객에게 발송됩니다.
       </p>
     </div>

--- a/apps/web/src/app/partner/review/[reportId]/complete/page.tsx
+++ b/apps/web/src/app/partner/review/[reportId]/complete/page.tsx
@@ -26,14 +26,14 @@ export default async function ReviewCompletePage({
       >
         ✓
       </span>
-      <h1 className="mt-6 font-serif text-[22px] font-bold text-ink">
+      <h1 className="mt-6 font-serif text-[1.375rem] font-bold text-ink">
         검수 리포트를 고객에게 전송했습니다
       </h1>
-      <p className="mt-2 text-[14px] text-ink-3">
+      <p className="mt-2 text-[0.875rem] text-ink-3">
         손해사정사 검수 완료 배지가 부착되어 고객 리포트에 반영됩니다.
       </p>
 
-      <dl className="mt-8 w-full space-y-2.5 rounded-card-lg border border-line bg-card p-5 text-[14px]">
+      <dl className="mt-8 w-full space-y-2.5 rounded-card-lg border border-line bg-card p-5 text-[0.875rem]">
         {caseId && (
           <div className="flex items-center justify-between">
             <dt className="text-ink-3">사건 번호</dt>

--- a/apps/web/src/app/partner/review/_components/ReviewError.tsx
+++ b/apps/web/src/app/partner/review/_components/ReviewError.tsx
@@ -11,8 +11,8 @@ export function ReviewError({ code, onRetry }: { code?: string; onRetry: () => v
 
   return (
     <div className="mx-auto flex max-w-md flex-col items-center px-4 py-24 text-center">
-      <h2 className="text-[18px] font-semibold text-ink">{message.title}</h2>
-      <p className="mt-2 text-[14px] text-ink-3">{message.desc}</p>
+      <h2 className="text-[1.125rem] font-semibold text-ink">{message.title}</h2>
+      <p className="mt-2 text-[0.875rem] text-ink-3">{message.desc}</p>
       {!known && (
         <Button className="mt-5" onClick={onRetry}>
           다시 시도

--- a/apps/web/src/shared/ui/AmountRange.tsx
+++ b/apps/web/src/shared/ui/AmountRange.tsx
@@ -5,8 +5,8 @@ import { cn } from "@/shared/lib/utils";
 const amountVariants = cva("font-semibold tabular-nums text-ink", {
   variants: {
     size: {
-      md: "text-[15px]",
-      lg: "text-[28px] leading-tight",
+      md: "text-[0.9375rem]",
+      lg: "text-[1.75rem] leading-tight",
     },
   },
   defaultVariants: { size: "md" },

--- a/apps/web/src/shared/ui/Button.tsx
+++ b/apps/web/src/shared/ui/Button.tsx
@@ -15,9 +15,9 @@ const buttonVariants = cva(
         danger: "bg-terra text-white"
       },
       size: {
-        sm: "px-[14px] py-2 text-[13.5px]",
-        md: "px-[18px] py-3 text-[15px]",
-        lg: "px-[22px] py-[15px] text-[16px]"
+        sm: "px-3.5 py-2 text-[0.84375rem]",
+        md: "px-[1.125rem] py-3 text-[0.9375rem]",
+        lg: "px-[1.375rem] py-[0.9375rem] text-[1rem]"
       },
       full: { true: "w-full" }
     },

--- a/apps/web/src/shared/ui/Checkbox.tsx
+++ b/apps/web/src/shared/ui/Checkbox.tsx
@@ -14,7 +14,7 @@ export function Checkbox({ checked, onChange, label, disabled, className }: Chec
   return (
     <label
       className={cn(
-        "relative inline-flex cursor-pointer select-none items-center gap-2.5 text-[14px] text-ink",
+        "relative inline-flex cursor-pointer select-none items-center gap-2.5 text-[0.875rem] text-ink",
         disabled && "cursor-not-allowed opacity-60",
         className,
       )}
@@ -29,7 +29,7 @@ export function Checkbox({ checked, onChange, label, disabled, className }: Chec
       <span
         aria-hidden
         className={cn(
-          "flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-[5px] border transition",
+          "flex h-[1.125rem] w-[1.125rem] shrink-0 items-center justify-center rounded-[0.3125rem] border transition",
           checked ? "border-ink bg-ink text-white" : "border-line bg-card",
         )}
       >

--- a/apps/web/src/shared/ui/ConfidenceGauge.tsx
+++ b/apps/web/src/shared/ui/ConfidenceGauge.tsx
@@ -25,7 +25,7 @@ export function ConfidenceGauge({ level, showLabel = true, className, ...props }
           style={{ width: `${percent}%` }}
         />
       </div>
-      {showLabel && <span className="shrink-0 text-[13px] font-semibold">{label}</span>}
+      {showLabel && <span className="shrink-0 text-[0.8125rem] font-semibold">{label}</span>}
     </div>
   );
 }

--- a/apps/web/src/shared/ui/DatePicker.stories.tsx
+++ b/apps/web/src/shared/ui/DatePicker.stories.tsx
@@ -13,7 +13,7 @@ type Story = StoryObj<typeof meta>;
 function Demo({ error }: { error?: string }) {
   const [value, setValue] = useState<string | undefined>();
   return (
-    <div className="w-[260px]">
+    <div className="w-[16.25rem]">
       <DatePicker value={value} onChange={(v) => setValue(v ?? undefined)} error={error} />
     </div>
   );

--- a/apps/web/src/shared/ui/DatePicker.tsx
+++ b/apps/web/src/shared/ui/DatePicker.tsx
@@ -58,12 +58,12 @@ export function DatePicker({
   const selected = fromISO(value);
 
   return (
-    <div className={cn("relative flex flex-col gap-[7px]", className)} ref={ref}>
+    <div className={cn("relative flex flex-col gap-[0.4375rem]", className)} ref={ref}>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          "flex h-[46px] items-center justify-between rounded-input border bg-card px-[14px] text-[14.5px] outline-none transition focus:border-gold focus:ring-[3px] focus:ring-gold-soft",
+          "flex h-[2.875rem] items-center justify-between rounded-input border bg-card px-3.5 text-[0.90625rem] outline-none transition focus:border-gold focus:ring-[3px] focus:ring-gold-soft",
           error ? "border-terra" : "border-line",
           value ? "text-ink" : "text-ink-3",
         )}
@@ -73,7 +73,7 @@ export function DatePicker({
       </button>
 
       {open && (
-        <div className="absolute top-[52px] z-20 rounded-card border border-line bg-card p-2 shadow-lg">
+        <div className="absolute top-[3.25rem] z-20 rounded-card border border-line bg-card p-2 shadow-lg">
           <DayPicker
             mode="single"
             locale={ko}
@@ -96,7 +96,7 @@ export function DatePicker({
         </div>
       )}
 
-      {error && <span className="text-[12px] font-medium text-terra">{error}</span>}
+      {error && <span className="text-[0.75rem] font-medium text-terra">{error}</span>}
     </div>
   );
 }

--- a/apps/web/src/shared/ui/Input.stories.tsx
+++ b/apps/web/src/shared/ui/Input.stories.tsx
@@ -27,7 +27,7 @@ export const SuffixNode: Story = {
   args: {
     placeholder: "010-0000-0000",
     suffix: (
-      <button type="button" className="rounded-button bg-ink px-3 py-1.5 text-[13px] font-semibold text-white">
+      <button type="button" className="rounded-button bg-ink px-3 py-1.5 text-[0.8125rem] font-semibold text-white">
         인증요청
       </button>
     )

--- a/apps/web/src/shared/ui/Input.tsx
+++ b/apps/web/src/shared/ui/Input.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/shared/lib/utils";
 import { Chevron } from "@/shared/ui/icons/Chevron";
 
 const control =
-  "w-full rounded-input border bg-card text-[14.5px] text-ink outline-none transition placeholder:text-ink-3 focus:border-gold focus:ring-[3px] focus:ring-gold-soft";
+  "w-full rounded-input border bg-card text-[0.90625rem] text-ink outline-none transition placeholder:text-ink-3 focus:border-gold focus:ring-[3px] focus:ring-gold-soft";
 
 /** 네이티브 input 속성(required·autoComplete·maxLength·aria-*·data-* 등)을 모두 상속.
  *  우리가 직접 다루는 키만 Omit 후 커스텀 정의로 대체한다. */
@@ -56,7 +56,7 @@ export function Input({
         {...(shared as TextareaHTMLAttributes<HTMLTextAreaElement>)}
         rows={rows}
         onChange={onChange as ChangeEventHandler<HTMLTextAreaElement>}
-        className={cn(control, border, "resize-y px-[14px] py-3 leading-relaxed")}
+        className={cn(control, border, "resize-y px-3.5 py-3 leading-relaxed")}
       />
     );
   } else if (type === "select") {
@@ -65,7 +65,7 @@ export function Input({
         <select
           {...(shared as SelectHTMLAttributes<HTMLSelectElement>)}
           onChange={onChange as ChangeEventHandler<HTMLSelectElement>}
-          className={cn(control, border, "h-[46px] cursor-pointer appearance-none pl-[14px] pr-[38px]")}
+          className={cn(control, border, "h-[2.875rem] cursor-pointer appearance-none pl-3.5 pr-[2.375rem]")}
         >
           {children}
         </select>
@@ -79,11 +79,11 @@ export function Input({
           {...shared}
           type={type}
           onChange={onChange as ChangeEventHandler<HTMLInputElement>}
-          className={cn(control, border, "h-[46px]", suffix ? "pl-[14px] pr-[90px]" : "px-[14px]")}
+          className={cn(control, border, "h-[2.875rem]", suffix ? "pl-3.5 pr-[5.625rem]" : "px-3.5")}
         />
         {suffix && (
-          <div className="absolute right-[6px] flex items-center">
-            {typeof suffix === "string" ? <span className="pr-2 text-[13px] text-ink-3">{suffix}</span> : suffix}
+          <div className="absolute right-1.5 flex items-center">
+            {typeof suffix === "string" ? <span className="pr-2 text-[0.8125rem] text-ink-3">{suffix}</span> : suffix}
           </div>
         )}
       </div>
@@ -91,12 +91,12 @@ export function Input({
   }
 
   return (
-    <div className={cn("flex flex-col gap-[7px]", className)}>
+    <div className={cn("flex flex-col gap-[0.4375rem]", className)}>
       {field}
       {error ? (
-        <span className="text-[12px] font-medium text-terra">{error}</span>
+        <span className="text-[0.75rem] font-medium text-terra">{error}</span>
       ) : hint ? (
-        <span className="text-[12px] text-ink-3">{hint}</span>
+        <span className="text-[0.75rem] text-ink-3">{hint}</span>
       ) : null}
     </div>
   );

--- a/apps/web/src/shared/ui/Label.tsx
+++ b/apps/web/src/shared/ui/Label.tsx
@@ -9,13 +9,13 @@ export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
 export function Label({ kicker, className, children, ...props }: LabelProps) {
   if (kicker) {
     return (
-      <div className={cn("text-[12.5px] font-semibold uppercase tracking-[0.12em] text-gold-ink", className)}>
+      <div className={cn("text-[0.78125rem] font-semibold uppercase tracking-[0.12em] text-gold-ink", className)}>
         {children}
       </div>
     );
   }
   return (
-    <label className={cn("text-[13.5px] font-semibold text-ink-2", className)} {...props}>
+    <label className={cn("text-[0.84375rem] font-semibold text-ink-2", className)} {...props}>
       {children}
     </label>
   );

--- a/apps/web/src/shared/ui/SegmentedControl.tsx
+++ b/apps/web/src/shared/ui/SegmentedControl.tsx
@@ -16,8 +16,8 @@ export interface SegmentedControlProps<T extends string> {
 }
 
 const SIZE_PADDING = {
-  sm: "px-3 py-1.5 text-[12.5px]",
-  md: "px-4 py-2 text-[13.5px]",
+  sm: "px-3 py-1.5 text-[0.78125rem]",
+  md: "px-4 py-2 text-[0.84375rem]",
 } as const;
 
 export function SegmentedControl<T extends string>({

--- a/apps/web/src/shared/ui/StatusBadge.tsx
+++ b/apps/web/src/shared/ui/StatusBadge.tsx
@@ -3,7 +3,7 @@ import type { HTMLAttributes, ReactNode } from "react";
 import { cn } from "@/shared/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex select-none items-center gap-1 whitespace-nowrap rounded-pill px-2.5 py-1 text-[12.5px] font-semibold leading-none",
+  "inline-flex select-none items-center gap-1 whitespace-nowrap rounded-pill px-2.5 py-1 text-[0.78125rem] font-semibold leading-none",
   {
     variants: {
       tone: {

--- a/apps/web/src/shared/ui/icons/Chevron.tsx
+++ b/apps/web/src/shared/ui/icons/Chevron.tsx
@@ -1,7 +1,7 @@
 export function Chevron() {
   return (
     <svg
-      className="pointer-events-none absolute right-[13px] top-1/2 -translate-y-1/2 text-ink-3"
+      className="pointer-events-none absolute right-[0.8125rem] top-1/2 -translate-y-1/2 text-ink-3"
       width="17"
       height="17"
       viewBox="0 0 24 24"


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #79

## ✅ 작업 내용

### design-tokens 「길이값」 규칙 도입 이전의 레거시 px 길이값을 rem·Tailwind 스케일로 일괄 전환했습니다.

`px-rem-lint` 훅이 파일 전체를 검사하기 때문에, 레거시 px가 남아 있는 파일을 나중에 어떤 이유로든 수정하면 미변환 px 때문에 편집이 차단됩니다. 이를 막기 위해 web 전반의 임의 px 길이값(`[Npx]`)을 선제적으로 rem으로 전환했습니다. **값 등가 변환이라 동작·레이아웃 변화는 없습니다.**

44개 파일에서 약 125개의 길이 토큰을 전환했으며, 리뷰·되돌리기가 쉽도록 원자 커밋으로 나눴습니다(공용 프리미티브는 컴포넌트당 1커밋, 페이지는 세그먼트 디렉토리당 1커밋 — 총 15커밋).

<br/>

### 1. 변환 규칙

렌더 불변(순수 등가)을 최우선으로 다음 규칙을 적용했습니다.

- **폰트 크기**는 exact rem으로만 전환했습니다(`text-[14px]` → `text-[0.875rem]`). Tailwind v4의 `text-*` 유틸은 font-size와 line-height를 함께 지정하기 때문에 `text-sm` 같은 스케일로 스냅하면 line-height가 주입되어 등가가 깨집니다. 이를 피하려고 스케일 스냅 대신 정확한 rem 값을 사용했습니다.
- **간격·크기**는 스케일과 정확히 일치할 때만 유틸로 스냅하고(`px-[14px]` → `px-3.5`, `right-[6px]` → `right-1.5`), 그 외에는 rem으로 전환했습니다.
- **radius·grid 템플릿**의 내장 px도 rem으로 전환했습니다(`rounded-[5px]` → `rounded-[0.3125rem]`, `grid-cols-[1fr_320px]` → `grid-cols-[1fr_20rem]`). variant 프리픽스(`lg:` 등)는 보존했습니다.
- `[1px]` 헤어라인과 `border`·`ring`·`outline`·`divide` 폭은 예외로 그대로 유지했습니다.

<br/>

### 2. shared/ui 프리미티브

공용 컴포넌트는 각각 원자 커밋으로 전환하고 `.stories.tsx`는 같은 커밋에 포함했습니다.

#### 세부 작업
* `Input` · `Button` · `DatePicker` · `Checkbox` · `SegmentedControl` → 폰트·간격·radius 전환
* `Label` · `AmountRange` · `ConfidenceGauge` · `StatusBadge` · `Chevron` → 폰트·위치값 전환

<br/>


## 💬 특이사항 / 결정 사항

### 검증

`px-rem-lint`는 CI/pre-commit 게이트가 아니라 작성 시점 훅이라, 훅 정규식을 복제해 전 트리를 스캔하여 검사 대상 `[Npx]` **0건**(사각지대인 grid·radius 포함)을 확인했습니다. `tsc --noEmit`과 oxlint 모두 통과하며, 값 등가 변환이라 Storybook 시각은 구성상 동일합니다.

### box-shadow px는 이번 범위에서 제외

`shadow-[0px_4px_6px_...]` 계열의 box-shadow 오프셋 px는 길이 유틸이 아니고 `px-rem-lint` 훅 대상도 아니라 이번 정리 범위에서 제외했습니다. 필요하면 후속으로 정리하겠습니다.
