### PR TITLE
[Feature] 앱(WebView) 셸 구성(헤더·푸터 숨김, 하단 탭바)

### DIFF
--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -4,6 +4,7 @@ import { ActivityIndicator, BackHandler, Pressable, StyleSheet, Text, View } fro
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 
+import { APP_USER_AGENT_SUFFIX } from './config/user-agent';
 import { getWebUrl } from './config/web-url';
 
 export function WebViewScreen() {
@@ -26,6 +27,7 @@ export function WebViewScreen() {
       <WebView
         ref={webViewRef}
         source={{ uri: getWebUrl() }}
+        applicationNameForUserAgent={APP_USER_AGENT_SUFFIX}
         style={styles.webview}
         onNavigationStateChange={(navState) => setCanGoBack(navState.canGoBack)}
         startInLoadingState

--- a/apps/mobile/src/config/user-agent.ts
+++ b/apps/mobile/src/config/user-agent.ts
@@ -1,0 +1,3 @@
+// 웹 측 감지 토큰과 상호 참조: apps/web/src/shared/lib/app-webview.ts (APP_WEBVIEW_UA_TOKEN = "BareunApp").
+// 이 suffix가 WebView UA에 실려 웹이 앱 요청을 SSR 시점에 분기한다.
+export const APP_USER_AGENT_SUFFIX = 'BareunApp/1.0';

--- a/apps/web/e2e/app-shell.spec.ts
+++ b/apps/web/e2e/app-shell.spec.ts
@@ -5,16 +5,21 @@ import { expect, test, type Page } from "@playwright/test";
  *
  * 원칙: 사용자가 보는 결과(헤더/푸터/탭바 노출·활성 탭)만 검증. 셀렉터는 role·텍스트.
  * 앱 감지 = 컨텍스트 UA에 "BareunApp/1.0" suffix — SSR 최초 요청부터 실려 서버가 헤더·푸터를 미렌더한다.
- * 인증: 기본 MSW GET /users/me → insured_person(윤서). 비로그인은 x-mock-scenario:unauthenticated 헤더로
- *       401(repo 표준 주입 — MSW 워커가 fetch를 가로채 page.route 불가).
+ * 데스크톱(suffix 없음)은 회귀로 기존 헤더·푸터 유지를 확인한다.
+ * 인증: 기본 MSW GET /users/me → insured_person(윤서). 사정사는 localStorage["mock:userType"]="adjuster",
+ *       비로그인은 x-mock-scenario:unauthenticated 헤더로 401(repo 표준 주입 — MSW 워커가 fetch를 가로채 page.route 불가).
  * 정적 위임(미테스트): 토큰 스타일·safe-area·아이콘 형상은 Storybook·figma 게이트에 위임.
  */
 
 const APP_UA =
   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1 BareunApp/1.0";
+const DESKTOP_UA =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const DESKTOP_VIEWPORT = { width: 1280, height: 900 };
 
 const CUSTOMER_TAB_LABELS = ["홈", "리포트", "채팅", "내정보"];
+const PARTNER_TAB_LABELS = ["홈", "검수", "채팅", "내정보"];
 
 // 탭바 = "내정보" 링크를 가진 navigation 영역(헤더의 nav와 구분되는 유일 신호).
 function tabBar(page: Page) {
@@ -68,5 +73,71 @@ test.describe("고객 · 앱 UA", () => {
     await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
     await gotoAwaitingMe(page, "/customer/dashboard");
     await expect(tabBar(page)).toHaveCount(0);
+  });
+});
+
+test.describe("사정사 · 앱 UA", () => {
+  test.use({ userAgent: APP_UA, viewport: MOBILE_VIEWPORT });
+
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("mock:userType", "adjuster");
+    });
+  });
+
+  test("사정사로 홈에 들어가면 검수 포함 4탭 탭바가 보이고 홈이 활성이다", async ({
+    page,
+  }) => {
+    await page.goto("/partner");
+
+    const bar = tabBar(page);
+    await expect(bar).toBeVisible();
+    for (const label of PARTNER_TAB_LABELS) {
+      await expect(bar.getByRole("link", { name: label, exact: true })).toBeVisible();
+    }
+    await expect(bar.getByRole("link", { name: "홈", exact: true })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    await expect(page.getByRole("banner")).toHaveCount(0);
+    await expect(page.getByRole("contentinfo")).toHaveCount(0);
+  });
+
+  test("검수 상세에 들어가면 탭바가 숨겨진다", async ({ page }) => {
+    await gotoAwaitingMe(page, "/partner/review/11111111-1111-4111-8111-111111111111");
+    await expect(tabBar(page)).toHaveCount(0);
+  });
+
+  test("검수 내역(마이페이지 하위)에 들어가면 탭바가 숨겨진다", async ({ page }) => {
+    await gotoAwaitingMe(page, "/partner/mypage/review-history");
+    await expect(tabBar(page)).toHaveCount(0);
+  });
+});
+
+test.describe("데스크톱 회귀 · 일반 UA", () => {
+  test.use({ userAgent: DESKTOP_UA, viewport: DESKTOP_VIEWPORT });
+
+  test("데스크톱에서는 헤더·푸터가 유지되고 탭바가 없다", async ({ page }) => {
+    await gotoAwaitingMe(page, "/customer/dashboard");
+
+    await expect(page.getByRole("banner")).toBeVisible();
+    await expect(page.getByRole("contentinfo")).toBeVisible();
+    await expect(tabBar(page)).toHaveCount(0);
+  });
+});
+
+test.describe("랜딩 · 앱 UA", () => {
+  test.use({ userAgent: APP_UA, viewport: MOBILE_VIEWPORT });
+
+  test("앱에서 랜딩에 들어가면 랜딩 헤더·푸터가 없다", async ({ page }) => {
+    await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
+    await page.goto("/");
+
+    await expect(
+      page.getByRole("heading", { name: /놓친 만큼 찾아드립니다/ }),
+    ).toBeVisible();
+    await expect(page.getByRole("banner")).toHaveCount(0);
+    await expect(page.getByRole("contentinfo")).toHaveCount(0);
   });
 });

--- a/apps/web/e2e/app-shell.spec.ts
+++ b/apps/web/e2e/app-shell.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * 앱(WebView) 셸 E2E (이슈 #103) — 웹 헤더·푸터 숨김 + 역할별 하단 탭바.
+ *
+ * 원칙: 사용자가 보는 결과(헤더/푸터/탭바 노출·활성 탭)만 검증. 셀렉터는 role·텍스트.
+ * 앱 감지 = 컨텍스트 UA에 "BareunApp/1.0" suffix — SSR 최초 요청부터 실려 서버가 헤더·푸터를 미렌더한다.
+ * 인증: 기본 MSW GET /users/me → insured_person(윤서). 비로그인은 x-mock-scenario:unauthenticated 헤더로
+ *       401(repo 표준 주입 — MSW 워커가 fetch를 가로채 page.route 불가).
+ * 정적 위임(미테스트): 토큰 스타일·safe-area·아이콘 형상은 Storybook·figma 게이트에 위임.
+ */
+
+const APP_UA =
+  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1 BareunApp/1.0";
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+const CUSTOMER_TAB_LABELS = ["홈", "리포트", "채팅", "내정보"];
+
+// 탭바 = "내정보" 링크를 가진 navigation 영역(헤더의 nav와 구분되는 유일 신호).
+function tabBar(page: Page) {
+  return page
+    .getByRole("navigation")
+    .filter({ has: page.getByRole("link", { name: "내정보", exact: true }) });
+}
+
+// 탭바는 useAuthStatus(GET /users/me) 응답 후 노출 여부가 확정된다.
+// 부재 단언이 인증 확정 전에 조기 통과하지 않도록 응답을 기다린 뒤 진행한다.
+async function gotoAwaitingMe(page: Page, path: string) {
+  const me = page.waitForResponse((res) => res.url().includes("/users/me"));
+  await page.goto(path);
+  await me;
+}
+
+test.describe("고객 · 앱 UA", () => {
+  test.use({ userAgent: APP_UA, viewport: MOBILE_VIEWPORT });
+
+  test("로그인 상태로 대시보드에 들어가면 헤더·푸터 없이 4탭 탭바가 보이고 홈이 활성이다", async ({
+    page,
+  }) => {
+    await page.goto("/customer/dashboard");
+
+    const bar = tabBar(page);
+    await expect(bar).toBeVisible();
+    for (const label of CUSTOMER_TAB_LABELS) {
+      await expect(bar.getByRole("link", { name: label, exact: true })).toBeVisible();
+    }
+    await expect(bar.getByRole("link", { name: "홈", exact: true })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+
+    // 앱에서는 웹 헤더(banner)·푸터(contentinfo)가 렌더되지 않는다.
+    await expect(page.getByRole("banner")).toHaveCount(0);
+    await expect(page.getByRole("contentinfo")).toHaveCount(0);
+  });
+
+  test("리포트 상세에 들어가면 탭바가 숨겨진다", async ({ page }) => {
+    await gotoAwaitingMe(page, "/customer/report/test-id-123");
+    await expect(tabBar(page)).toHaveCount(0);
+  });
+
+  test("분석 신청 퍼널에 들어가면 탭바가 숨겨진다", async ({ page }) => {
+    await gotoAwaitingMe(page, "/customer/adjust-request");
+    await expect(tabBar(page)).toHaveCount(0);
+  });
+
+  test("비로그인 상태면 탭바가 보이지 않는다", async ({ page }) => {
+    await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
+    await gotoAwaitingMe(page, "/customer/dashboard");
+    await expect(tabBar(page)).toHaveCount(0);
+  });
+});

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -1,13 +1,16 @@
 import type { ReactNode } from "react";
+import { getIsAppWebView } from "@/shared/lib/app-webview";
 import { LandingFooter } from "./_components/LandingFooter";
 import { LandingHeader } from "./_components/LandingHeader";
 
-export default function PublicLayout({ children }: { children: ReactNode }) {
+export default async function PublicLayout({ children }: { children: ReactNode }) {
+  const isApp = await getIsAppWebView();
+
   return (
     <div className="flex min-h-dvh flex-col bg-paper">
-      <LandingHeader />
+      {!isApp && <LandingHeader />}
       <main className="flex-1">{children}</main>
-      <LandingFooter />
+      {!isApp && <LandingFooter />}
     </div>
   );
 }

--- a/apps/web/src/app/customer/layout.tsx
+++ b/apps/web/src/app/customer/layout.tsx
@@ -1,17 +1,26 @@
 import type { ReactNode } from "react";
+import { getIsAppWebView } from "@/shared/lib/app-webview";
+import { AppTabBar } from "@/shared/ui/AppTabBar";
 import { CustomerHeader } from "@/shared/ui/CustomerHeader";
 import { Footer } from "@/shared/ui/Footer";
 
-export default function CustomerLayout({ children }: { children: ReactNode }) {
+export default async function CustomerLayout({ children }: { children: ReactNode }) {
+  const isApp = await getIsAppWebView();
+
   return (
     <div className="flex min-h-dvh flex-col">
-      <div className="hidden md:block">
-        <CustomerHeader />
-      </div>
+      {!isApp && (
+        <div className="hidden md:block">
+          <CustomerHeader />
+        </div>
+      )}
       <main className="flex-1">{children}</main>
-      <div className="hidden md:block">
-        <Footer />
-      </div>
+      {!isApp && (
+        <div className="hidden md:block">
+          <Footer />
+        </div>
+      )}
+      {isApp && <AppTabBar variant="customer" />}
     </div>
   );
 }

--- a/apps/web/src/app/customer/mypage/page.tsx
+++ b/apps/web/src/app/customer/mypage/page.tsx
@@ -1,0 +1,8 @@
+export default function CustomerMypagePage() {
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center px-4 py-24 text-center">
+      <h1 className="text-lg font-semibold text-ink">내 정보를 준비하고 있어요</h1>
+      <p className="mt-2 text-sm text-ink-3">곧 프로필과 알림 설정을 이곳에서 관리할 수 있어요.</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { fontVariables } from "@/shared/fonts";
 import { Providers } from "@/shared/providers";
@@ -7,6 +7,10 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "Insurance Platform",
   description: "보험 플랫폼 웹"
+};
+
+export const viewport: Viewport = {
+  viewportFit: "cover"
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/web/src/app/partner/chat/page.tsx
+++ b/apps/web/src/app/partner/chat/page.tsx
@@ -1,0 +1,8 @@
+export default function PartnerChatPage() {
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center px-4 py-24 text-center">
+      <h1 className="text-lg font-semibold text-ink">상담 채팅을 준비하고 있어요</h1>
+      <p className="mt-2 text-sm text-ink-3">곧 의뢰인과 검수 건에 대한 상담을 주고받을 수 있어요.</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/partner/layout.tsx
+++ b/apps/web/src/app/partner/layout.tsx
@@ -1,14 +1,19 @@
 import type { ReactNode } from "react";
-import { PartnerHeader } from "./_components/PartnerHeader";
+import { getIsAppWebView } from "@/shared/lib/app-webview";
+import { AppTabBar } from "@/shared/ui/AppTabBar";
 import { Footer } from "@/shared/ui/Footer";
+import { PartnerHeader } from "./_components/PartnerHeader";
 
-/** 파트너(손해사정사) 페이지 레이아웃 셸 — 파트너 헤더 + 본문 + 푸터. */
-export default function PartnerLayout({ children }: { children: ReactNode }) {
+/** 파트너(손해사정사) 페이지 레이아웃 셸 — 파트너 헤더 + 본문 + 푸터. 앱에서는 헤더·푸터 대신 하단 탭바. */
+export default async function PartnerLayout({ children }: { children: ReactNode }) {
+  const isApp = await getIsAppWebView();
+
   return (
     <div className="flex min-h-dvh flex-col">
-      <PartnerHeader />
+      {!isApp && <PartnerHeader />}
       <main className="flex-1">{children}</main>
-      <Footer />
+      {!isApp && <Footer />}
+      {isApp && <AppTabBar variant="partner" />}
     </div>
   );
 }

--- a/apps/web/src/shared/lib/app-webview.ts
+++ b/apps/web/src/shared/lib/app-webview.ts
@@ -1,0 +1,11 @@
+import { headers } from "next/headers";
+
+// 앱(RN WebView)이 UA에 붙이는 식별 토큰. 모바일 측 상수와 상호 참조:
+// apps/mobile/src/config/user-agent.ts (APP_USER_AGENT_SUFFIX = "BareunApp/1.0").
+export const APP_WEBVIEW_UA_TOKEN = "BareunApp";
+
+/** 현재 요청이 앱 WebView에서 온 요청인지 서버에서 판별한다(UA suffix 검사). */
+export async function getIsAppWebView(): Promise<boolean> {
+  const userAgent = (await headers()).get("user-agent");
+  return userAgent?.includes(APP_WEBVIEW_UA_TOKEN) ?? false;
+}

--- a/apps/web/src/shared/ui/AppTabBar.stories.tsx
+++ b/apps/web/src/shared/ui/AppTabBar.stories.tsx
@@ -1,0 +1,73 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Decorator, Meta, StoryObj } from "@storybook/nextjs-vite";
+import { userKeys } from "@/shared/api/query-keys";
+import type { Me } from "@/shared/model/user";
+import { AppTabBar } from "./AppTabBar";
+
+const CUSTOMER_ME: Me = {
+  userId: "user-1",
+  nickname: "김보험",
+  email: "customer@example.com",
+  userType: "insured_person",
+  createdAt: "2026-01-01T00:00:00.000Z"
+};
+
+const ADJUSTER_ME: Me = { ...CUSTOMER_ME, nickname: "박사정", userType: "adjuster" };
+
+/** useAuthStatus 쿼리에 인증 사용자를 미리 심어 탭바가 노출되도록 감싼다. */
+function authenticatedAs(me: Me): Decorator {
+  return (Story) => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } }
+    });
+    queryClient.setQueryData(userKeys.me.queryKey, me);
+    return (
+      <QueryClientProvider client={queryClient}>
+        <Story />
+      </QueryClientProvider>
+    );
+  };
+}
+
+const meta = {
+  title: "UI/AppTabBar",
+  component: AppTabBar,
+  parameters: {
+    layout: "fullscreen",
+    nextjs: { appDirectory: true }
+  },
+  globals: { viewport: { value: "mobile1" } }
+} satisfies Meta<typeof AppTabBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 고객 홈 — 홈 탭 활성. */
+export const Customer: Story = {
+  args: { variant: "customer" },
+  decorators: [authenticatedAs(CUSTOMER_ME)],
+  parameters: { nextjs: { appDirectory: true, navigation: { pathname: "/customer/dashboard" } } }
+};
+
+/** 고객 리포트 탭 활성. */
+export const CustomerReportActive: Story = {
+  args: { variant: "customer" },
+  decorators: [authenticatedAs(CUSTOMER_ME)],
+  parameters: { nextjs: { appDirectory: true, navigation: { pathname: "/customer/proposals" } } }
+};
+
+/** 사정사 홈 — 홈 탭 활성. */
+export const Partner: Story = {
+  args: { variant: "partner" },
+  decorators: [authenticatedAs(ADJUSTER_ME)],
+  parameters: { nextjs: { appDirectory: true, navigation: { pathname: "/partner" } } }
+};
+
+/** 탭 href가 아닌 상세 경로 — default-hide로 탭바 미노출(빈 화면). */
+export const HiddenOnDetailRoute: Story = {
+  args: { variant: "customer" },
+  decorators: [authenticatedAs(CUSTOMER_ME)],
+  parameters: {
+    nextjs: { appDirectory: true, navigation: { pathname: "/customer/report/abc123" } }
+  }
+};

--- a/apps/web/src/shared/ui/AppTabBar.tsx
+++ b/apps/web/src/shared/ui/AppTabBar.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import type { ComponentType } from "react";
+import { useAuthStatus } from "@/shared/api/use-auth-status";
+import { cn } from "@/shared/lib/utils";
+import type { UserType } from "@/shared/model/user";
+import { Chat } from "@/shared/ui/icons/Chat";
+import { FileText } from "@/shared/ui/icons/FileText";
+import { Home } from "@/shared/ui/icons/Home";
+import { ShieldCheck } from "@/shared/ui/icons/ShieldCheck";
+import { User } from "@/shared/ui/icons/User";
+
+type IconComponent = ComponentType<{ className?: string }>;
+type TabVariant = "customer" | "partner";
+
+interface Tab {
+  label: string;
+  href: string;
+  Icon: IconComponent;
+}
+
+const CUSTOMER_TABS: Tab[] = [
+  { label: "홈", href: "/customer/dashboard", Icon: Home },
+  { label: "리포트", href: "/customer/proposals", Icon: FileText },
+  { label: "채팅", href: "/customer/chat", Icon: Chat },
+  { label: "내정보", href: "/customer/mypage", Icon: User },
+];
+
+const PARTNER_TABS: Tab[] = [
+  { label: "홈", href: "/partner", Icon: Home },
+  { label: "검수", href: "/partner/review", Icon: ShieldCheck },
+  { label: "채팅", href: "/partner/chat", Icon: Chat },
+  { label: "내정보", href: "/partner/mypage", Icon: User },
+];
+
+const TABS_BY_VARIANT: Record<TabVariant, Tab[]> = {
+  customer: CUSTOMER_TABS,
+  partner: PARTNER_TABS,
+};
+
+const REQUIRED_USER_TYPE: Record<TabVariant, UserType> = {
+  customer: "insured_person",
+  partner: "adjuster",
+};
+
+/**
+ * 앱(WebView) 전용 역할별 하단 탭바.
+ * 로그인·역할 확정 + 현재 경로가 탭 href와 정확히 일치할 때만 노출(default-hide).
+ */
+export function AppTabBar({ variant }: { variant: TabVariant }) {
+  const pathname = usePathname();
+  const auth = useAuthStatus();
+  const tabs = TABS_BY_VARIANT[variant];
+
+  const isRoleMatched =
+    auth.status === "authenticated" && auth.me.userType === REQUIRED_USER_TYPE[variant];
+  const isTabRoute = tabs.some((tab) => tab.href === pathname);
+  if (!isRoleMatched || !isTabRoute) return null;
+
+  return (
+    <nav className="sticky bottom-0 z-10 flex border-t border-line bg-paper-2/[0.92] pb-[env(safe-area-inset-bottom)] backdrop-blur">
+      {tabs.map(({ label, href, Icon }) => {
+        const isActive = href === pathname;
+        return (
+          <Link
+            key={label}
+            href={href}
+            aria-current={isActive ? "page" : undefined}
+            className="flex flex-1 flex-col items-center gap-1 py-2.5"
+          >
+            <Icon className={cn("size-[1.375rem]", isActive ? "text-ink" : "text-ink-3")} />
+            <span
+              className={cn(
+                "text-[0.6875rem]",
+                isActive ? "font-bold text-ink" : "font-medium text-ink-3",
+              )}
+            >
+              {label}
+            </span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #103

## ✅ 작업 내용

### RN WebView 앱 전용 레이아웃을 구성했습니다

앱에서 실행될 때는 웹 헤더와 푸터를 숨기고, 사용자 역할에 맞는 하단 탭바를 표시하도록 구현했습니다. 웹에서는 기존 레이아웃을 그대로 유지합니다.

| 고객 홈(앱) | 사정사 홈(앱) | 상세 화면(탭바 숨김) | 데스크톱 |
| --- | --- | --- | --- |
| <img alt="customer-dashboard-app" width="200" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/15c3a1e44a638b4438e722d267c4dce5289f75e8/.pr-assets/issue-103/01-customer-dashboard-app.png" /> | <img alt="partner-home-app" width="200" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/15c3a1e44a638b4438e722d267c4dce5289f75e8/.pr-assets/issue-103/03-partner-home-app.png" /> | <img alt="report-detail-app" width="200" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/15c3a1e44a638b4438e722d267c4dce5289f75e8/.pr-assets/issue-103/02-customer-report-detail-app.png" /> | <img alt="desktop" width="280" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/15c3a1e44a638b4438e722d267c4dce5289f75e8/.pr-assets/issue-103/04-customer-dashboard-desktop.png" /> |

<br/>

### 1. 앱 환경 감지

RN WebView에서 `applicationNameForUserAgent`를 사용해 User-Agent에 `BareunApp/1.0`을 추가하고, 웹에서는 서버에서 User-Agent를 확인해 앱 실행 여부를 판단합니다.

User-Agent는 최초 요청부터 포함되므로 첫 화면부터 앱 전용 레이아웃을 적용할 수 있습니다. 화면이 잠깐 바뀌는 현상(FOUC)을 막기 위해 User-Agent 방식을 선택했습니다. `injectedJavaScript`는 hydration 이후에만 실행되고, 쿼리 파라미터와 쿠키는 최초 요청에서 안정적으로 구분하기 어려웠습니다.

```ts
// apps/web/src/shared/lib/app-webview.ts
export async function getIsAppWebView(): Promise<boolean> {
  const userAgent = (await headers()).get("user-agent");
  return userAgent?.includes(APP_WEBVIEW_UA_TOKEN) ?? false;
}
```

#### 세부 작업

- `apps/mobile/src/config/user-agent.ts`
  - 앱 식별용 User-Agent 상수 정의
- `WebViewScreen`
  - `applicationNameForUserAgent` 적용
- `app-webview.ts`
  - 서버에서 User-Agent를 확인하는 유틸 추가

<br/>

### 2. 헤더·푸터 숨김

customer, partner, public 레이아웃에서 앱 여부를 확인해 서버에서 분기하도록 변경했습니다.

앱에서는 헤더와 푸터를 렌더하지 않고, 웹에서는 기존과 동일하게 렌더합니다. CSS로 숨기는 방식이 아니라 서버에서 렌더 여부를 결정합니다.

`auth`, `/notifications`, 루트 레이아웃은 원래 헤더와 푸터가 없어 변경하지 않았습니다.

#### 세부 작업

- `customer/layout.tsx`
  - 앱에서는 `CustomerHeader`와 `Footer`를 렌더하지 않음
  - 고객용 하단 탭바 표시
- `partner/layout.tsx`
  - 앱에서는 `PartnerHeader`와 `Footer`를 렌더하지 않음
  - 사정사용 하단 탭바 표시
- `(public)/layout.tsx`
  - 앱에서는 `LandingHeader`와 `LandingFooter`를 렌더하지 않음
- `layout.tsx`
  - Safe Area 지원을 위해 `viewport-fit=cover` 적용

<br/>

### 3. 역할별 하단 탭바

고객과 사정사에 맞는 하단 탭바를 추가했습니다.

고객은 홈, 리포트, 채팅, 내 정보를 표시하고, 사정사는 홈, 검수, 채팅, 내 정보를 표시합니다. 현재 선택된 탭은 `aria-current`로 표시합니다.

탭바는 주요 화면에서만 표시되며, 상세 화면, 작성·수정 화면, 퍼널, 마이페이지 하위 화면에서는 자동으로 숨겨집니다. 로그인 전이거나 사용자 역할이 맞지 않는 경우에도 표시하지 않습니다.

```tsx
// apps/web/src/shared/ui/AppTabBar.tsx
const isRoleMatched =
  auth.status === "authenticated" &&
  auth.me.userType === REQUIRED_USER_TYPE[variant];

const isTabRoute = tabs.some((tab) => tab.href === pathname);

if (!isRoleMatched || !isTabRoute) return null;
```

#### 세부 작업

- `AppTabBar`
  - 역할별 탭 구성
  - 현재 탭 활성 표시
  - 노출 경로 제어
  - Safe Area 하단 패딩 적용
- `AppTabBar.stories.tsx`
  - 고객·사정사 Storybook 스토리 추가
- `/customer/mypage`
- `/partner/chat`
  - 탭 연결을 위한 임시 페이지 추가
  - 실제 화면은 별도 이슈에서 구현 예정

<br/>

## 🧪 테스트

Playwright와 MSW를 사용해 앱 전용 레이아웃을 검증했습니다.

앱 User-Agent와 일반 브라우저 User-Agent를 각각 주입해 서버에서 올바르게 분기되는지 확인했습니다.

**E2E 9개 모두 통과**

| # | 테스트 | 검증 내용 |
| --- | --- | --- |
| 1 | 고객이 앱에서 대시보드에 접속 | 헤더·푸터 없이 고객 탭바 표시, 홈 활성 |
| 2 | 리포트 상세 화면 | 탭바 숨김 |
| 3 | 분석 신청 퍼널 | 탭바 숨김 |
| 4 | 비로그인 상태 | 탭바 미표시 |
| 5 | 사정사가 앱에서 홈에 접속 | 사정사용 탭바 표시, 홈 활성 |
| 6 | 검수 상세 화면 | 탭바 숨김 |
| 7 | 검수 내역 화면 | 하위 경로에서는 탭바 숨김 |
| 8 | 데스크톱 | 기존 헤더·푸터 유지, 탭바 미표시 |
| 9 | 앱에서 랜딩 접속 | 랜딩 헤더·푸터 미표시 |

## 💬 특이사항 / 결정 사항

### 랜딩 페이지는 Dynamic Rendering으로 전환됩니다

앱 여부를 확인하기 위해 `headers()`를 사용하면서 public 레이아웃이 Dynamic Rendering으로 전환됩니다.

customer와 partner는 원래 인증 정보를 사용하므로 영향이 거의 없고, 랜딩은 첫 화면부터 앱 전용 레이아웃을 정확하게 적용하는 것을 우선해 이 방식을 선택했습니다.

### User-Agent 상수는 모바일과 웹에 각각 관리합니다

현재 모노레포에는 공용 패키지가 없어 `BareunApp` 문자열을 모바일과 웹에서 각각 정의했습니다.

두 파일에는 서로를 참조하는 주석을 추가해 값이 달라지지 않도록 관리했습니다.

### 고객 리포트 탭은 받은 제안 목록으로 연결됩니다

고객 리포트 탭은 `/customer/proposals`로 연결하는 것이 의도한 동작입니다.

탭 연결을 위해 `/customer/mypage`와 `/partner/chat` 임시 페이지를 추가했으며, 실제 화면은 각 담당 이슈에서 구현할 예정입니다.