### PR TITLE
[Feature] 소셜 회원가입 티켓 연동 및 회원가입 진입 가드(web/app)

### DIFF
--- a/.claude/skills/frontend-feature/references/naming-dictionary.md
+++ b/.claude/skills/frontend-feature/references/naming-dictionary.md
@@ -60,6 +60,7 @@
 ### auth — `POST /auth/register`
 `provider`(`kakao`|`naver`) · `socialToken` · `nickname`(2~20자) · `userType` · `email`(N)
 → resp: `userId` · `nickname` · `userType` · `accessToken` · `refreshToken`
+- `nickname` = **사용자 이름**(소셜 프로필 표시명, 팀 확정 2026-07-12). 별도 "이름/실명" 필드를 만들지 말 것(사정사 자격신청의 `name`(실명)은 별개). ⚠️ 콜백 응답에 프로필이 없어 프론트가 이름을 알 수 없음 — 백엔드가 signupTicket에서 추출하는지 확인 필요.
 
 ### user — `GET /users/me`
 `userId` · `nickname` · `email` · `userType` · `createdAt`

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -84,6 +84,8 @@ test("신규 회원 콜백이면 회원가입으로 이동한다", async ({ page
   await page.goto("/oauth/kakao/callback?code=new&state=s1");
 
   await expect(page).toHaveURL(/\/signup/, { timeout: 15000 });
+  // 콜백이 보관한 가입 티켓으로 컨텍스트 가드를 통과해 퍼널 첫 단계가 렌더된다.
+  await expect(page.getByRole("heading", { name: "어떤 역할로 시작하시겠어요?" })).toBeVisible();
 });
 
 test("콜백이 실패하면 에러 안내와 다시 시도 버튼이 보이고 재시도해도 실패가 유지된다", async ({ page }) => {

--- a/apps/web/e2e/signup.spec.ts
+++ b/apps/web/e2e/signup.spec.ts
@@ -6,12 +6,13 @@ import { expect, test, type Page } from "@playwright/test";
  * 원칙: 핵심 사용자 흐름만 — 역할 선택 → 약관 동의 → 가입 완료(CUJ),
  *   필수 약관 게이트, 전체 동의 토글, 중복 계정 에러(고가치), 약관 상세 왕복, 손해사정사 분기.
  * 응답은 기본 MSW 핸들러(POST /auth/register: 성공 201 + 토큰)가 제공.
- *   소셜 컨텍스트(nickname/email/provider)는 useSignupSocial mock 기본값(윤서 / yunseo@email.com / kakao).
+ *   소셜 컨텍스트(socialToken/nickname/email)는 진입 쿼리로 주입(개발·E2E 경로) —
+ *   컨텍스트 없이 직접 진입하면 /login으로 가드되므로 mock 폴백 없음.
  * DUPLICATE_RESOURCE는 nickname "중복닉네임" 진입 쿼리로 MSW 409 분기를 태워 검증(핸들러 override 대체).
  * 필드 형식·범위(닉네임 2~20자 등) 검증은 zod·MSW 계약에 위임(미테스트).
  */
 
-const PATH = "/signup";
+const PATH = "/signup?socialToken=e2e-social-token&nickname=%EC%9C%A4%EC%84%9C&email=yunseo%40email.com";
 const DUPLICATE_PATH = "/signup?socialToken=dup&nickname=%EC%A4%91%EB%B3%B5%EB%8B%89%EB%84%A4%EC%9E%84";
 
 // 하이드레이션 전 클릭 유실 방지: 클릭+상태확인을 묶어 재시도.
@@ -101,6 +102,13 @@ test("약관 상세보기로 이동했다가 돌아와도 선택한 동의 상�
 
   await expect(page.getByRole("heading", { name: "약관에 동의해주세요" })).toBeVisible();
   await expect(page.getByRole("checkbox", { name: /서비스 이용약관/ })).toBeChecked();
+});
+
+test("소셜 인증 컨텍스트 없이 직접 진입하면 로그인으로 되돌아간다", async ({ page }) => {
+  await page.goto("/signup");
+
+  await expect(page).toHaveURL(/\/login/, { timeout: 15000 });
+  await expect(page.getByRole("heading", { name: "바른보상 시작하기" })).toBeVisible();
 });
 
 test("손해사정사를 선택하고 시작하면 자격 인증 안내가 노출된다", async ({ page }) => {

--- a/apps/web/e2e/signup.spec.ts
+++ b/apps/web/e2e/signup.spec.ts
@@ -105,6 +105,9 @@ test("약관 상세보기로 이동했다가 돌아와도 선택한 동의 상�
 });
 
 test("소셜 인증 컨텍스트 없이 직접 진입하면 로그인으로 되돌아간다", async ({ page }) => {
+  // 로그인 화면은 비로그인 유저에게만 보인다(#108 접근 제한 가드). 기본 MSW의 /users/me는
+  // 로그인 유저를 반환하므로 비로그인 시나리오를 헤더로 주입한다.
+  await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
   await page.goto("/signup");
 
   await expect(page).toHaveURL(/\/login/, { timeout: 15000 });

--- a/apps/web/src/app/(auth)/_shared/lib/signup-ticket.ts
+++ b/apps/web/src/app/(auth)/_shared/lib/signup-ticket.ts
@@ -1,27 +1,49 @@
 const SIGNUP_TICKET_KEY = "bb.signupTicket";
 
+export interface SignupTicket {
+  ticket: string;
+  provider: "kakao" | "naver";
+}
+
 function isBrowser(): boolean {
   return typeof window !== "undefined";
 }
 
 /**
  * 신규 회원 가입용 signupTicket 임시 보관. register(POST /auth/register)가
- * socialToken으로 소비. sessionStorage 실패(사생활 모드·quota)는 조용히 무시.
+ * socialToken으로 소비. 퍼널이 다단계(약관 상세 왕복 포함)라 읽기는 비파괴,
+ * 제거는 가입 성공 시 clear로만. sessionStorage 실패(사생활 모드·quota)는 조용히 무시.
  */
-export function saveSignupTicket(ticket: string): void {
+export function saveSignupTicket(ticket: string, provider: SignupTicket["provider"]): void {
   if (!isBrowser()) return;
   try {
-    window.sessionStorage.setItem(SIGNUP_TICKET_KEY, ticket);
+    window.sessionStorage.setItem(SIGNUP_TICKET_KEY, JSON.stringify({ ticket, provider }));
   } catch {}
 }
 
-export function takeSignupTicket(): string | null {
+export function getSignupTicket(): SignupTicket | null {
   if (!isBrowser()) return null;
   try {
-    const ticket = window.sessionStorage.getItem(SIGNUP_TICKET_KEY);
-    window.sessionStorage.removeItem(SIGNUP_TICKET_KEY);
-    return ticket;
+    const raw = window.sessionStorage.getItem(SIGNUP_TICKET_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as SignupTicket).ticket !== "string" ||
+      ((parsed as SignupTicket).provider !== "kakao" && (parsed as SignupTicket).provider !== "naver")
+    ) {
+      return null;
+    }
+    return parsed as SignupTicket;
   } catch {
     return null;
   }
+}
+
+export function clearSignupTicket(): void {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.removeItem(SIGNUP_TICKET_KEY);
+  } catch {}
 }

--- a/apps/web/src/app/(auth)/oauth/[provider]/callback/page.tsx
+++ b/apps/web/src/app/(auth)/oauth/[provider]/callback/page.tsx
@@ -63,7 +63,7 @@ export default function OauthCallbackPage() {
 
     // 신규 회원은 쿠키가 없어(getMe 시 401) 티켓만 보관하고 가입으로 이동한다.
     if (data.isNewUser) {
-      if (data.signupTicket) saveSignupTicket(data.signupTicket);
+      if (data.signupTicket) saveSignupTicket(data.signupTicket, provider);
       router.replace("/signup");
       return;
     }

--- a/apps/web/src/app/(auth)/signup/_hooks/use-signup-social.ts
+++ b/apps/web/src/app/(auth)/signup/_hooks/use-signup-social.ts
@@ -1,43 +1,54 @@
 "use client";
 
 import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { getSignupTicket } from "../../_shared/lib/signup-ticket";
 import type { RegisterBody } from "../_model/register.schema";
 
 /**
- * 소셜 인증 컨텍스트 획득. 기능6 "소셜 인증 후 진입".
- * MVP: 진입 쿼리스트링에서 읽고, 없으면 개발용 mock 기본값 사용.
- * TODO: 로그인/OAuth 콜백 이슈 확정 후 실제 전달 경로(세션/쿠키)로 교체.
+ * 소셜 인증 컨텍스트 획득. OAuth 콜백(#40)이 보관한 signupTicket(sessionStorage)을
+ * register의 socialToken으로 사용한다. URL 쿼리는 개발·E2E 주입 경로로 유지.
+ * 둘 다 없으면 null — 페이지가 /login으로 가드한다.
  */
 export interface SignupSocialContext {
   provider: RegisterBody["provider"];
   socialToken: string;
-  /** 소셜 프로필에서 넘어온 표시 이름(닉네임 기본값·완료 화면 표시) */
+  /** 닉네임 기본값·완료 화면 표시 */
   nickname: string;
-  /** 소셜 프로필 이메일(완료 화면 표시·register email 후보) */
+  /** 완료 화면 표시·register email 후보 */
   email?: string;
 }
 
-const MOCK_SOCIAL: SignupSocialContext = {
-  provider: "kakao",
-  socialToken: "mock-social-token",
-  nickname: "윤서",
-  email: "yunseo@email.com",
-};
+// nickname = 사용자 이름(소셜 프로필 표시명). 콜백 응답에 프로필이 없어 임시 기본값.
+// TODO: 백엔드가 register 시 signupTicket에서 이름을 추출하는지 확인 후 교체(그렇다면 이 필드 전송 제거).
+const DEFAULT_NICKNAME = "바른보상 회원";
 
 function toProvider(value: string | null): RegisterBody["provider"] {
   return value === "naver" ? "naver" : "kakao";
 }
 
-export function useSignupSocial(): SignupSocialContext {
+export function useSignupSocial(): SignupSocialContext | null {
   const searchParams = useSearchParams();
-  const socialToken = searchParams.get("socialToken");
+  // 가입 성공 시 티켓이 지워져도 완료 화면이 유지되도록 최초 렌더 값을 고정한다.
+  const [stored] = useState(getSignupTicket);
 
-  if (!socialToken) return MOCK_SOCIAL;
+  const queryToken = searchParams.get("socialToken");
+  if (queryToken) {
+    return {
+      provider: toProvider(searchParams.get("provider")),
+      socialToken: queryToken,
+      nickname: searchParams.get("nickname") ?? DEFAULT_NICKNAME,
+      email: searchParams.get("email") ?? undefined,
+    };
+  }
 
-  return {
-    provider: toProvider(searchParams.get("provider")),
-    socialToken,
-    nickname: searchParams.get("nickname") ?? MOCK_SOCIAL.nickname,
-    email: searchParams.get("email") ?? undefined,
-  };
+  if (stored) {
+    return {
+      provider: stored.provider,
+      socialToken: stored.ticket,
+      nickname: DEFAULT_NICKNAME,
+    };
+  }
+
+  return null;
 }

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -13,6 +13,7 @@ import { useSignupFunnel } from "./_hooks/use-signup-funnel";
 import { useSignupSocial } from "./_hooks/use-signup-social";
 import { type ConsentState } from "./_model/consent-config";
 import { toRegisterBody, type RegisterResponse } from "./_model/register.schema";
+import { clearSignupTicket } from "../_shared/lib/signup-ticket";
 import { clearSignupDraft, loadSignupDraft, saveSignupDraft } from "./_model/signup-draft";
 import type { TermsType } from "./_shared/model/terms";
 
@@ -37,6 +38,11 @@ function SignupFunnel() {
   useEffect(() => {
     saveSignupDraft({ userType: selectedUserType, consent });
   }, [selectedUserType, consent]);
+
+  // 소셜 인증 컨텍스트(티켓·쿼리) 없이 직접 진입하면 로그인으로 되돌림.
+  useEffect(() => {
+    if (!social) router.replace("/login");
+  }, [social, router]);
 
   // 직접 URL 진입 가드: 선행 단계 미완이면 첫 단계로 되돌림.
   useEffect(() => {
@@ -66,7 +72,7 @@ function SignupFunnel() {
   };
 
   const handleSubmit = () => {
-    if (selectedUserType !== "insured_person") return;
+    if (selectedUserType !== "insured_person" || !social) return;
 
     const body = toRegisterBody({
       provider: social.provider,
@@ -78,13 +84,15 @@ function SignupFunnel() {
 
     register.mutate(body, {
       onSuccess: (data) => {
-        // TODO: accessToken/refreshToken 저장은 auth 토큰 저장 유틸 확정 후 연결.
         clearSignupDraft();
+        clearSignupTicket();
         setResult(data);
         funnel.goTo("done", { replace: true });
       },
     });
   };
+
+  if (!social) return null;
 
   return (
     <div className="flex min-h-dvh w-full flex-col pb-8 pt-6 sm:pt-10">


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #107

## ✅ 작업 내용

### 회원가입 퍼널이 OAuth 콜백의 가입 티켓을 실제로 사용하도록 연결했습니다

| 신규 회원 콜백 → 퍼널 진입 (PC) | 신규 회원 콜백 → 퍼널 진입 (모바일) |
|---|---|
| <img width="620" alt="funnel-desktop" src="https://gist.githubusercontent.com/JuJangGwon/5475765412e55146742ad02ec8acf8fb/raw/01-funnel-desktop.png" /> | <img width="240" alt="funnel-mobile" src="https://gist.githubusercontent.com/JuJangGwon/5475765412e55146742ad02ec8acf8fb/raw/02-funnel-mobile.png" /> |

| 티켓 없이 직접 진입 → 로그인으로 리다이렉트 |
|---|
| <img width="620" alt="direct-entry-login" src="https://gist.githubusercontent.com/JuJangGwon/5475765412e55146742ad02ec8acf8fb/raw/03-direct-entry-login.png" /> |

OAuth 콜백(#56)이 sessionStorage(`bb.signupTicket`)에 보관한 가입 티켓을 회원가입 퍼널이 `POST /auth/register`의 `socialToken`으로 사용하도록 연결했습니다. 기존에는 퍼널이 티켓을 읽지 않고 개발용 mock 값(`mock-social-token`)으로 가입 요청을 보내고 있어, 실제 신규 가입이 올바르게 이루어지지 않는 상태였습니다.

소셜 인증을 거치지 않고 `/signup`에 직접 접근하면 `/login`으로 리다이렉트하는 진입 가드도 함께 추가했습니다.

### 1. 가입 티켓 연동

* 티켓 유틸을 `{ ticket, provider }` 구조로 확장하고, 콜백이 provider를 함께 저장
* `useSignupSocial` 우선순위: URL 쿼리(개발·E2E 주입) → sessionStorage 티켓 → 없으면 `null`
* mock 토큰 폴백 제거 — 조용히 가짜 토큰으로 가입되는 경로 차단
* 퍼널이 다단계(약관 상세 왕복 포함)라 티켓 읽기는 비파괴로 두고, 가입 성공 시에만 제거

### 2. 회원가입 진입 가드

* 소셜 인증 컨텍스트가 없으면 `/login`으로 리다이렉트
* 신규 회원 콜백 경유 진입은 가드를 통과해 퍼널 첫 단계 정상 렌더

## 🧪 테스트

Playwright + MSW **E2E** — signup 6개(신규 1) + login 1개 보강, 13개 전체 통과 확인

| # | 테스트 | 검증 내용 |
|---|--------|-----------|
| 1 | 소셜 인증 컨텍스트 없이 직접 진입하면 로그인으로 되돌아간다 (신규) | 가드 리다이렉트 + 로그인 화면 노출 |
| 2 | 신규 회원 콜백이면 회원가입으로 이동한다 (보강) | 티켓으로 가드 통과, 퍼널 첫 단계 렌더 확인 |
| 3 | 기존 signup 퍼널 5개 | 진입을 쿼리 주입 방식으로 전환 후 회귀 없음 |


