### PR TITLE
[Feature] 마이페이지 로그아웃 기능 구현(web)

### DIFF
--- a/apps/web/e2e/adjuster-logout.spec.ts
+++ b/apps/web/e2e/adjuster-logout.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 손해사정사(파트너) 마이페이지 로그아웃 E2E (이슈 #155).
+ *
+ * 원칙: 핵심 사용자 흐름만 — 파트너 로그아웃 버튼은 모바일 전용(md:hidden)이라 모바일 뷰포트로
+ * 고정해 검증한다(CI chromium 데스크톱 프로젝트에서도 동일 조건으로 돌기 위함).
+ * 로그아웃 성공 시 MSW가 localStorage["mock:loggedOut"]을 세팅해 GET /adjusters/me/mypage가
+ * 401 LOGIN_REQUIRED를 돌려주므로, 뒤로 가기 시 로그인 안내(#148)로 이동한다.
+ */
+
+const MYPAGE_PATH = "/partner/mypage";
+
+test.use({ viewport: { width: 390, height: 844 } });
+
+test("로그아웃을 누르면 로그인 화면으로 이동하고, 다시 들어가도 마이페이지가 보이지 않는다", async ({
+  page,
+}) => {
+  await page.goto(MYPAGE_PATH);
+  await expect(page.getByRole("heading", { name: /김상정 사정사/ })).toBeVisible();
+
+  const logoutButton = page
+    .getByRole("button", { name: "로그아웃" })
+    .filter({ visible: true });
+
+  // 하이드레이션 가드 — 첫 클릭 유실 시 재시도
+  await expect(async () => {
+    await logoutButton.click();
+    await expect(page).toHaveURL(/\/login$/, { timeout: 5000 });
+  }).toPass({ timeout: 20000 });
+  await expect(
+    page.getByRole("heading", { name: "바른보상 시작하기" }),
+  ).toBeVisible();
+
+  // 마이페이지 히스토리는 대체(location.replace)돼 뒤로 가기 대상이 없으므로 재진입으로 검증 —
+  // 세션이 끝나 이전 계정 데이터 대신 로그인 안내로 이동한다.
+  await page.goto(MYPAGE_PATH);
+  await expect(page).toHaveURL(/\/login-required/, { timeout: 20000 });
+});

--- a/apps/web/e2e/customer-logout.spec.ts
+++ b/apps/web/e2e/customer-logout.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * 고객 마이페이지 로그아웃 E2E (이슈 #155).
+ *
+ * 원칙: 핵심 사용자 흐름만 — PC 사이드바·모바일 하단 버튼으로 로그아웃하면 로그인 화면으로
+ * 이동하고, 뒤로 가기로 보호 페이지에 돌아가도 이전 계정 데이터가 보이지 않는다(#148 안내 이동).
+ * 로그아웃 성공 시 MSW가 localStorage["mock:loggedOut"]을 세팅해 보호 엔드포인트가 401을 돌려준다.
+ * 서버 실패는 x-mock-failure=logout 헤더로 500을 강제 — 세션이 서버에 남아 로그인 게이트가
+ * 홈으로 돌려보낼 수 있으므로(쿠키 기반 설계상 정상) 로그인 화면 이동 시도까지만 검증한다.
+ * 로그인 화면 검증은 기본 변형(신규 가입 히어로 "바른보상 시작하기") 기준 — 최근 로그인 카드
+ * 변형은 login.spec.ts가 다룬다. 응답 봉투·에러코드 enum 검증은 zod·api-spec 훅에 위임(미테스트).
+ * PC/모바일 두 트리가 DOM에 공존(hidden md:grid / md:hidden)하므로 보이는 버튼만 filter로 지정한다.
+ */
+
+const MYPAGE_PATH = "/customer/mypage";
+
+async function clickLogout(page: import("@playwright/test").Page) {
+  const logoutButton = page
+    .getByRole("button", { name: "로그아웃" })
+    .filter({ visible: true });
+
+  // 하이드레이션 가드 — 첫 클릭 유실 시 재시도
+  await expect(async () => {
+    await logoutButton.click();
+    await expect(page).toHaveURL(/\/login$/, { timeout: 5000 });
+  }).toPass({ timeout: 20000 });
+}
+
+test.describe("PC", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test("사이드바 로그아웃을 누르면 로그인 화면으로 이동하고, 뒤로 가도 이전 화면이 보이지 않는다", async ({
+    page,
+  }) => {
+    // 대시보드 → 마이페이지 히스토리를 쌓아 로그아웃 후 뒤로 가기 동작을 검증한다.
+    await page.goto("/customer/dashboard");
+    await expect(
+      page.getByRole("heading", { name: "안녕하세요, 윤서님" }).filter({ visible: true }),
+    ).toBeVisible({ timeout: 15000 });
+
+    await page.goto(MYPAGE_PATH);
+    await expect(page.getByRole("heading", { name: "윤서 님" })).toBeVisible();
+
+    await clickLogout(page);
+    await expect(
+      page.getByRole("heading", { name: "바른보상 시작하기" }),
+    ).toBeVisible();
+
+    // 마이페이지는 히스토리에서 대체(location.replace)돼 뒤로 가면 그 앞의 보호 페이지(대시보드)로
+    // 가고, 세션이 끝났으므로 이전 계정 데이터 대신 로그인 안내로 이동한다.
+    await page.goBack();
+    await expect(page).toHaveURL(/\/login-required/, { timeout: 20000 });
+  });
+});
+
+test.describe("모바일", () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("하단 로그아웃을 누르면 로그인 화면으로 이동한다", async ({ page }) => {
+    await page.goto(MYPAGE_PATH);
+    await expect(
+      page.getByRole("heading", { name: "내 정보" }).filter({ visible: true }),
+    ).toBeVisible();
+
+    await clickLogout(page);
+    await expect(
+      page.getByRole("heading", { name: "바른보상 시작하기" }),
+    ).toBeVisible();
+  });
+
+  test("로그아웃 요청이 실패해도 마이페이지에 갇히지 않고 로그인 화면으로 이동한다", async ({
+    page,
+  }) => {
+    await page.setExtraHTTPHeaders({ "x-mock-failure": "logout" });
+
+    await page.goto(MYPAGE_PATH);
+    await expect(
+      page.getByRole("heading", { name: "내 정보" }).filter({ visible: true }),
+    ).toBeVisible();
+
+    await clickLogout(page);
+  });
+});

--- a/apps/web/src/app/customer/mypage/_components/MypageSidebar.tsx
+++ b/apps/web/src/app/customer/mypage/_components/MypageSidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import type { ComponentType } from "react";
 import { useActivitySummary } from "../_api/use-activity-summary";
 import { MYPAGE_SIDEBAR_LINKS, type MypageSidebarLink } from "../_model/mypage-links";
+import { useLogout } from "@/shared/api/use-logout";
 import { cn } from "@/shared/lib/utils";
 import { FileText } from "@/shared/ui/icons/FileText";
 import { Home } from "@/shared/ui/icons/Home";
@@ -65,12 +66,16 @@ export function MypageSidebar() {
   );
 }
 
-/** 로그아웃 — auth 미구현으로 UI만(후속 이슈에서 POST /auth/logout 연결). */
+/** 로그아웃 — 세션 종료 후 로그인 화면으로 이동(#155). */
 function LogoutButton() {
+  const { mutate: logout, isPending } = useLogout();
+
   return (
     <button
       type="button"
-      className="w-full rounded-button px-3 py-2.5 text-left text-[0.875rem] font-medium text-ink-3 transition hover:bg-paper hover:text-ink-2"
+      onClick={() => logout()}
+      disabled={isPending}
+      className="w-full rounded-button px-3 py-2.5 text-left text-[0.875rem] font-medium text-ink-3 transition hover:bg-paper hover:text-ink-2 disabled:opacity-50"
     >
       로그아웃
     </button>

--- a/apps/web/src/app/customer/mypage/_components/mobile/MobileLogout.tsx
+++ b/apps/web/src/app/customer/mypage/_components/mobile/MobileLogout.tsx
@@ -1,9 +1,17 @@
-/** 모바일 하단 로그아웃 — auth 미구현으로 UI만(후속 이슈에서 POST /auth/logout 연결). */
+"use client";
+
+import { useLogout } from "@/shared/api/use-logout";
+
+/** 모바일 하단 로그아웃 — 세션 종료 후 로그인 화면으로 이동(#155). */
 export function MobileLogout() {
+  const { mutate: logout, isPending } = useLogout();
+
   return (
     <button
       type="button"
-      className="mx-auto block px-4 py-2 text-[0.875rem] text-ink-3 transition hover:text-ink-2"
+      onClick={() => logout()}
+      disabled={isPending}
+      className="mx-auto block px-4 py-2 text-[0.875rem] text-ink-3 transition hover:text-ink-2 disabled:opacity-50"
     >
       로그아웃
     </button>

--- a/apps/web/src/app/partner/mypage/_components/LogoutButton.tsx
+++ b/apps/web/src/app/partner/mypage/_components/LogoutButton.tsx
@@ -1,11 +1,17 @@
 "use client";
 
-/** 로그아웃 — auth 미구현으로 UI만 제공(후속 이슈에서 POST /auth/logout 연결). */
+import { useLogout } from "@/shared/api/use-logout";
+
+/** 로그아웃 — 세션 종료 후 로그인 화면으로 이동(#155). */
 export function LogoutButton() {
+  const { mutate: logout, isPending } = useLogout();
+
   return (
     <button
       type="button"
-      className="mx-auto block px-4 py-2 text-[0.875rem] text-ink-3 transition hover:text-ink-2 md:hidden"
+      onClick={() => logout()}
+      disabled={isPending}
+      className="mx-auto block px-4 py-2 text-[0.875rem] text-ink-3 transition hover:text-ink-2 disabled:opacity-50 md:hidden"
     >
       로그아웃
     </button>

--- a/apps/web/src/shared/api/logout.ts
+++ b/apps/web/src/shared/api/logout.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { API_BASE_URL } from "@/shared/api/config";
+import { fetchJson } from "@/shared/api/fetch-json";
+
+const logoutSchema = z.null().nullish();
+
+/**
+ * 세션 종료 — refresh_token HttpOnly 쿠키 기반이라 요청 바디 없음, 응답 data는 null.
+ * 이미 만료된 세션의 401도 호출부가 정리만 하면 되므로 재발급·로그인 안내 이동을 타지 않는다.
+ */
+export async function logout(): Promise<void> {
+  await fetchJson(`${API_BASE_URL}/auth/logout`, logoutSchema, {
+    method: "POST",
+    skipTokenReissue: true,
+    skipAuthRedirect: true,
+  });
+}

--- a/apps/web/src/shared/api/use-logout.ts
+++ b/apps/web/src/shared/api/use-logout.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { logout } from "./logout";
+
+/**
+ * 로그아웃 mutation — 서버 실패 여부와 무관하게(onSettled) 캐시를 비우고 로그인 화면으로 이동한다.
+ * 하드 이동(location.replace)이라 메모리에 남은 이전 계정 상태까지 페이지 언로드로 확실히 버려진다.
+ */
+export function useLogout() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: logout,
+    onSettled: () => {
+      queryClient.clear();
+      window.location.replace("/login");
+    },
+  });
+}

--- a/apps/web/src/shared/mocks/auth-token-state.ts
+++ b/apps/web/src/shared/mocks/auth-token-state.ts
@@ -4,11 +4,13 @@
  * - `mock:tokenExpired` = "once"            → 보호 엔드포인트 첫 호출 401 EXPIRED_TOKEN, 재발급 성공 후 200
  * - `mock:tokenExpired` = "refresh-expired" → 보호 엔드포인트 401 EXPIRED_TOKEN, 재발급도 401 EXPIRED_TOKEN
  * - `mock:reissueCount`                     → /auth/reissue 실제 호출 횟수(단일-flight 검증용)
+ * - `mock:loggedOut` = "true"               → 로그아웃 상태(#155), 보호 엔드포인트가 401 LOGIN_REQUIRED
  *
  * 플래그가 없으면 만료 없음 = 기존 동작 그대로.
  */
 const SCENARIO_KEY = "mock:tokenExpired";
 const REISSUE_COUNT_KEY = "mock:reissueCount";
+const LOGGED_OUT_KEY = "mock:loggedOut";
 
 type TokenScenario = "once" | "refresh-expired";
 
@@ -49,6 +51,14 @@ function readScenario(): TokenScenario | null {
 
 export function isAccessTokenExpired(): boolean {
   return readScenario() !== null;
+}
+
+export function setLoggedOut(): void {
+  write(LOGGED_OUT_KEY, "true");
+}
+
+export function isLoggedOut(): boolean {
+  return read(LOGGED_OUT_KEY) === "true";
 }
 
 export function reissueCallCount(): number {

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -1,7 +1,12 @@
 ﻿import { delay, http, HttpResponse } from "msw";
 import { camelToSnakeDeep, toSnakeKey } from "@/shared/api/case-convert";
 import { API_BASE_URL } from "@/shared/api/config";
-import { consumeReissue, isAccessTokenExpired } from "@/shared/mocks/auth-token-state";
+import {
+  consumeReissue,
+  isAccessTokenExpired,
+  isLoggedOut,
+  setLoggedOut,
+} from "@/shared/mocks/auth-token-state";
 
 // 로드 시점 기준 상대 마감일(로컬 달력 날짜) — 대시보드 "오늘 마감/N일 남음" 검증용
 function addDays(base: Date, days: number): string {
@@ -1460,6 +1465,13 @@ export const handlers = [
   http.get(`${API_BASE_URL}/adjusters/me/mypage`, async ({ request }) => {
     await delay(500);
 
+    if (isLoggedOut()) {
+      return HttpResponse.json(
+        { status: "401", code: "LOGIN_REQUIRED", message: "로그인이 필요합니다." },
+        { status: 401 },
+      );
+    }
+
     if (request.headers.get("x-mock-failure") === "mypage") {
       return HttpResponse.json(
         { status: "500", code: "INTERNAL_SERVER_ERROR", message: "마이페이지를 불러오지 못했습니다." },
@@ -1646,12 +1658,33 @@ export const handlers = [
     );
   }),
 
+  // 로그아웃 (#155) — refresh_token HttpOnly 쿠키 무효화. 바디 없음, data는 null.
+  // 성공 시 로그아웃 상태를 기록해 이후 보호 엔드포인트가 401 LOGIN_REQUIRED를 돌려준다.
+  // E2E 실패 주입: x-mock-failure=logout → 500(서버 실패에도 클라이언트 정리·이동 검증용, 세션은 유지).
+  http.post(`${API_BASE_URL}/auth/logout`, async ({ request }) => {
+    await delay(200);
+
+    if (request.headers.get("x-mock-failure") === "logout") {
+      return HttpResponse.json(
+        { status: "500", code: "INTERNAL_SERVER_ERROR", message: "로그아웃을 처리하지 못했습니다." },
+        { status: 500 },
+      );
+    }
+
+    setLoggedOut();
+    return HttpResponse.json({
+      status: "200",
+      message: "정상 처리되었습니다.",
+      data: null,
+    });
+  }),
+
   // 본인 정보 조회 (고객 대시보드 인사말)
   // E2E 역할 게이팅 검증용: localStorage["mock:userType"]="adjuster"면 사정사로 응답(기본 insured_person).
   http.get(`${API_BASE_URL}/users/me`, async ({ request }) => {
     await delay(300);
     // 비로그인 시나리오 주입 — E2E 랜딩(온보딩) 검증용. 기본은 로그인 유저(변경 없음).
-    if (request.headers.get("x-mock-scenario") === "unauthenticated") {
+    if (request.headers.get("x-mock-scenario") === "unauthenticated" || isLoggedOut()) {
       return HttpResponse.json(
         { status: "401", code: "LOGIN_REQUIRED", message: "로그인이 필요합니다." },
         { status: 401 },
@@ -1721,7 +1754,7 @@ export const handlers = [
   http.get(`${API_BASE_URL}/users/me/dashboard`, async ({ request }) => {
     await delay(400);
 
-    if (request.headers.get("x-mock-scenario") === "unauthenticated") {
+    if (request.headers.get("x-mock-scenario") === "unauthenticated" || isLoggedOut()) {
       return HttpResponse.json(
         { status: "401", code: "LOGIN_REQUIRED", message: "로그인이 필요합니다." },
         { status: 401 },


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #155

## ✅ 작업 내용

### UI로만 있던 마이페이지 로그아웃 버튼 3곳에 `POST /auth/logout`을 연결합니다

| 고객 모바일 | 고객 PC 사이드바 | 파트너 모바일 |
| --- | --- | --- |
| <img alt="customer-mobile-logout" width="260" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/a1f661031554f1f3b20fddecb3786db4fb2f429e/.pr-assets/issue-155/01-customer-mobile-logout.png" /> | <img alt="customer-pc-sidebar-logout" width="420" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/a1f661031554f1f3b20fddecb3786db4fb2f429e/.pr-assets/issue-155/02-customer-pc-sidebar-logout.png" /> | <img alt="partner-mobile-logout" width="260" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/a1f661031554f1f3b20fddecb3786db4fb2f429e/.pr-assets/issue-155/03-partner-mobile-logout.png" /> |

### 1. 로그아웃 데이터 레이어 (`shared/api`)

* `logout.ts` — 쿠키 기반 `POST /auth/logout`(바디 없음, 응답 `ApiResponseVoid`). 이미 만료된 세션의 401도 호출부가 정리만 하면 되므로 `skipTokenReissue`·`skipAuthRedirect`로 재발급·로그인 안내 이동을 타지 않습니다
* `use-logout.ts` — mutation 훅. `onSettled`에서 쿼리 캐시 전체 초기화 + `/login` 이동이라 **서버 요청이 실패해도 클라이언트 세션 정리와 이동이 보장**됩니다
* 이동은 `location.replace` 하드 이동 — 메모리에 남은 이전 계정 상태가 페이지 언로드로 함께 버려지고, 마이페이지가 히스토리에서 대체돼 뒤로 가기로 돌아갈 수 없습니다

### 2. 버튼 연결 (고객 모바일 · 고객 PC · 파트너)

* `MobileLogout` · `MypageSidebar`의 `LogoutButton` · 파트너 `LogoutButton` — 셋 다 "후속 이슈에서 연결" 주석 상태였던 것을 `useLogout`으로 연결
* 요청 중 `disabled` 처리로 중복 클릭 방지

### 3. MSW 핸들러

* `POST /auth/logout` — 전역 봉투 미러링(`data: null`), 성공 시 `localStorage["mock:loggedOut"]`으로 인증 해제를 기록해 이후 보호 엔드포인트(`/users/me` · `/users/me/dashboard` · `/adjusters/me/mypage`)가 401 `LOGIN_REQUIRED`를 돌려줍니다
* `x-mock-failure=logout` 헤더로 500 강제 — 서버 실패 시나리오 E2E용(세션은 유지)

## 🧪 테스트

* `e2e/customer-logout.spec.ts` 신규 — PC 사이드바·모바일 하단 로그아웃 후 로그인 화면 이동 / 뒤로 가기 시 이전 화면 대신 로그인 안내(#148) 이동 / 서버 실패에도 로그인 화면 이동
* `e2e/adjuster-logout.spec.ts` 신규 — 파트너 로그아웃 후 로그인 화면 이동 / 마이페이지 재진입 시 로그인 안내 이동
* 신규 스펙 chromium·mobile-chrome·mobile-safari 12 passed, 인접 회귀(`token-reissue`·`login-required`·`login`·`user-mypage`·`adjuster-mypage`) chromium 38 passed, 커밋별 typecheck·lint 게이트 통과

## 💬 리뷰 참고

* 로그아웃 실패(500) 시에도 클라이언트는 정리 후 `/login`으로 이동하지만, HttpOnly 쿠키 세션이 서버에 남아 있으면 로그인 게이트가 홈으로 되돌립니다 — 쿠키 기반 설계상 클라이언트가 세션을 지울 수 없어 생기는 동작이라, E2E도 "이동 시도"까지만 검증합니다
* 파트너 로그아웃 버튼은 기존 그대로 모바일 전용(`md:hidden`)입니다 — 파트너 PC 노출은 이슈 범위 밖으로 두었습니다
* RN 웹뷰는 전면 웹뷰 래퍼라 동일 플로우로 동작합니다(별도 네이티브 분기 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
