### PR TITLE
[Infra] 실백엔드 연동 배포용 API 프록시 리라이트 구성

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,6 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ['@insurance/bridge', '@insurance/shared'],
+  // BACKEND_ORIGIN(서버 전용 env) 설정 시 /api/v1을 백엔드로 프록시 — 쿠키 퍼스트파티 유지, CORS 불필요
+  async rewrites() {
+    const backendOrigin = process.env.BACKEND_ORIGIN;
+    if (!backendOrigin) return [];
+    return [
+      {
+        source: '/api/v1/:path*',
+        destination: `${backendOrigin.replace(/\/$/, '')}/api/v1/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,7 +1,8 @@
 export async function register() {
   const mockingEnabled =
-    process.env.NEXT_PUBLIC_API_MOCKING === "enabled" ||
-    process.env.NODE_ENV === "development";
+    process.env.NEXT_PUBLIC_API_MOCKING !== "disabled" &&
+    (process.env.NEXT_PUBLIC_API_MOCKING === "enabled" ||
+      process.env.NODE_ENV === "development");
   if (process.env.NEXT_RUNTIME === "nodejs" && mockingEnabled) {
     const { server } = await import("./shared/mocks/server");
     server.listen({ onUnhandledRequest: "bypass" });

--- a/apps/web/src/shared/mocks/mock-provider.tsx
+++ b/apps/web/src/shared/mocks/mock-provider.tsx
@@ -4,9 +4,11 @@ import { use } from "react";
 import type { ReactNode } from "react";
 
 // CI E2E는 production 빌드(next build && next start)로 돌므로 NODE_ENV 대신 플래그로도 켠다.
+// 실백엔드 통합 QA 시 dev에서도 끌 수 있게 disabled 오버라이드 허용.
 const mockingEnabled =
-  process.env.NEXT_PUBLIC_API_MOCKING === "enabled" ||
-  process.env.NODE_ENV === "development";
+  process.env.NEXT_PUBLIC_API_MOCKING !== "disabled" &&
+  (process.env.NEXT_PUBLIC_API_MOCKING === "enabled" ||
+    process.env.NODE_ENV === "development");
 
 const mockingReadyPromise: Promise<void> =
   typeof window !== "undefined" && mockingEnabled


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #166

## ✅ 작업 내용

### 실백엔드 연동 배포에서 인증 쿠키가 퍼스트파티로 유지되도록 API 프록시 리라이트를 구성했습니다

Vercel 배포에서 백엔드를 직접 호출하면 프론트·백엔드 도메인이 달라 인증 쿠키가 서드파티가 되고, Safari·iOS(RN 웹뷰 대상 환경)는 이를 기본 차단해 로그인 유지가 깨집니다. Next.js rewrites로 같은 오리진을 유지해 쿠키를 퍼스트파티로 남기고 백엔드 CORS 설정도 불필요하게 했습니다. 백엔드 dev 공개 엔드포인트 확정 시 Vercel에 `BACKEND_ORIGIN`만 등록하면 바로 붙습니다.

### 1. BACKEND_ORIGIN 게이트 API 프록시 리라이트 (`next.config.mjs`)

* `BACKEND_ORIGIN`(서버 전용 env) 설정 시 `/api/v1/:path*`를 백엔드로 프록시하는 rewrites 추가
* 미설정 시 리라이트 없음 — 로컬 dev·MSW·CI 기존 동작 유지
* 주소 끝 슬래시 정규화

### 2. MSW disabled 오버라이드

* 실백엔드 연동 QA 시 dev에서도 MSW를 끌 수 있도록 서버(`instrumentation.ts`)·브라우저(`mock-provider.tsx`) 모킹 게이트에 `NEXT_PUBLIC_API_MOCKING=disabled` 분기 추가

## 🧪 테스트

인프라 변경으로 화면 변화 없음 — 로컬 프록시 스모크 테스트로 검증했습니다.

| # | 검증 | 결과 |
|---|------|------|
| 1 | `BACKEND_ORIGIN` 설정 시 `/api/v1/*` 프록시 | 가짜 백엔드(로컬 9166) 대상 dev 서버 요청이 백엔드 응답 반환, 끝 슬래시(`http://localhost:9166/`) 정규화 확인 |
| 2 | `BACKEND_ORIGIN` 미설정 시 리라이트 없음 | `/api/v1/ping` 404 — 기존 MSW 플로우 회귀 없음 |
| 3 | `pnpm typecheck` · `pnpm lint` | 통과 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 백엔드 주소가 설정된 경우 API 요청을 백엔드로 자동 전달하도록 지원합니다.

* **버그 수정**
  * API 모킹을 명시적으로 비활성화하면 개발 환경에서도 모킹 서버가 실행되지 않도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->