### PR TITLE
Revert "[Fix] API 경로 버저닝(/api/v1)·프록시 리라이트 백엔드 규약 불일치 수정(web)"

### DIFF
--- a/.claude/skills/frontend-feature/references/api-spec.md
+++ b/.claude/skills/frontend-feature/references/api-spec.md
@@ -38,7 +38,7 @@ auth · user · settings · report · review · matching · chat · payment · a
 쿼리키 factory의 최상위 도메인 키와 이 enum을 일치시킨다. 새 도메인을 임의로 만들지 않는다.
 
 ## 전역 응답 봉투 (모든 엔드포인트 공통 — 안정적, 여기 고정)
-**base url**: `https://example.com` (버저닝 없음 — 백엔드 확정, 실제 값은 env로 주입)
+**base url**: `https://example.com/api/v1` (MVP 플레이스홀더 — 실제 값은 env로 주입)
 
 성공:
 ```json

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,15 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ['@insurance/bridge', '@insurance/shared'],
-  // BACKEND_ORIGIN(서버 전용 env) 설정 시 /api를 백엔드로 프록시 — 쿠키 퍼스트파티 유지, CORS 불필요
-  // 백엔드는 버저닝 없이 루트 경로로 서빙 → /api 프리픽스를 벗겨 전달
+  // BACKEND_ORIGIN(서버 전용 env) 설정 시 /api/v1을 백엔드로 프록시 — 쿠키 퍼스트파티 유지, CORS 불필요
   async rewrites() {
     const backendOrigin = process.env.BACKEND_ORIGIN;
     if (!backendOrigin) return [];
     return [
       {
-        source: '/api/:path*',
-        destination: `${backendOrigin.replace(/\/$/, '')}/:path*`,
+        source: '/api/v1/:path*',
+        destination: `${backendOrigin.replace(/\/$/, '')}/api/v1/:path*`,
       },
     ];
   },

--- a/apps/web/src/shared/api/config.ts
+++ b/apps/web/src/shared/api/config.ts
@@ -1,5 +1,2 @@
-/**
- * 백엔드 base URL. 백엔드는 버저닝 없이 루트 경로로 서빙(/api/v1 없음).
- * 기본값 /api는 동일 오리진 프록시 프리픽스 — BACKEND_ORIGIN 리라이트가 벗겨 전달하고, 모킹 시엔 MSW가 가로챈다.
- */
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "/api";
+/** 백엔드 base URL. 실서버 없음 — MSW가 이 URL을 가로채 모킹. */
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "/api/v1";


### PR DESCRIPTION
Reverts SM17-YoonDongJu/Frontend#170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * API 요청 경로를 `/api/v1` 기준으로 통일했습니다.
  * 백엔드 연결 시 API 버전에 맞는 경로로 요청이 전달됩니다.
  * 환경 변수를 통한 API 기본 주소 설정을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->