### PR TITLE
[Fix] 기본 base URL /api 프리픽스 제거(web)

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -3,6 +3,7 @@ const nextConfig = {
   transpilePackages: ['@insurance/bridge', '@insurance/shared'],
   // BACKEND_ORIGIN(서버 전용 env) 설정 시 /api를 백엔드로 프록시 — 쿠키 퍼스트파티 유지, CORS 불필요
   // 백엔드는 버저닝 없이 루트 경로로 서빙 → /api 프리픽스를 벗겨 전달
+  // 프록시 배포에서만 NEXT_PUBLIC_API_BASE_URL=/api를 함께 주입해 사용(기본 base URL은 프리픽스 없음)
   async rewrites() {
     const backendOrigin = process.env.BACKEND_ORIGIN;
     if (!backendOrigin) return [];

--- a/apps/web/src/shared/api/config.ts
+++ b/apps/web/src/shared/api/config.ts
@@ -1,5 +1,5 @@
 /**
- * 백엔드 base URL. 백엔드는 버저닝 없이 루트 경로로 서빙(/api/v1 없음).
- * 기본값 /api는 동일 오리진 프록시 프리픽스 — BACKEND_ORIGIN 리라이트가 벗겨 전달하고, 모킹 시엔 MSW가 가로챈다.
+ * 백엔드 base URL. 백엔드는 버저닝·프리픽스 없이 루트 경로로 서빙 — 기본값도 프리픽스 없음(모킹 시 MSW가 상대경로를 가로챈다).
+ * 프록시 배포 시에만 env로 /api를 주입해 BACKEND_ORIGIN 리라이트가 벗겨 전달.
  */
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "/api";
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "";


### PR DESCRIPTION
## 🔗 관련 이슈

- #169 후속 — #170이 두 번째 커밋 푸시 전에 머지되어 남은 변경을 분리

## ✅ 작업 내용

### 기본 base URL의 /api 프리픽스를 제거했습니다

백엔드는 프리픽스 없이 루트 경로로 서빙하므로, 기본 요청 경로도 프리픽스 없이 백엔드와 동일하게 맞췄습니다(모킹 시 MSW가 상대경로를 가로챈다).

* `shared/api/config.ts` — 기본값 `/api` → 빈 값(프리픽스 없음)
* `next.config.mjs` — `/api` 프리픽스는 프록시 배포에서 `NEXT_PUBLIC_API_BASE_URL=/api`를 주입할 때만 사용하도록 주석 정리(리라이트 동작 변화 없음)

## 🧪 테스트

경로 상수 변경으로 화면 변화 없음.

| # | 검증 | 결과 |
|---|------|------|
| 1 | `pnpm typecheck` · `pnpm lint` | 통과(pre-commit 게이트 포함) |
| 2 | MSW 플로우 회귀 | CI E2E(chromium·mobile-chrome·mobile-safari)로 검증 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
