### PR TITLE
[Fix] 랜딩 헤더 죽은 메뉴 제거 및 푸터 보강(web)

### DIFF
--- a/apps/web/e2e/_capture-168.spec.ts
+++ b/apps/web/e2e/_capture-168.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "@playwright/test";
+import { hideQueryDevtools } from "./_region-helpers";
+
+/** PR 스크린샷 캡처 헬퍼(#168). 테스트 아님 — CI 제외(testIgnore). */
+
+const DIR = "../../.pr-assets/issue-168";
+
+const MOBILE = { width: 390, height: 900 };
+const DESKTOP = { width: 1280, height: 900 };
+
+test.beforeEach(async ({ page }) => {
+  await hideQueryDevtools(page);
+});
+
+test("01 랜딩 헤더 PC", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto("/");
+  await page.getByRole("link", { name: "서비스 소개" }).first().waitFor();
+  await page.locator("header").screenshot({ path: `${DIR}/01-header-pc.png` });
+});
+
+test("02 랜딩 푸터 PC", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto("/");
+  await page.locator("footer").scrollIntoViewIfNeeded();
+  await page.locator("footer").screenshot({ path: `${DIR}/02-footer-pc.png` });
+});
+
+test("03 랜딩 푸터 모바일", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto("/");
+  await page.locator("footer").scrollIntoViewIfNeeded();
+  await page.locator("footer").screenshot({ path: `${DIR}/03-footer-mobile.png` });
+});

--- a/apps/web/e2e/public-pages.spec.ts
+++ b/apps/web/e2e/public-pages.spec.ts
@@ -26,7 +26,10 @@ test.describe("공개 페이지 진입 흐름", () => {
     await page.goto(LANDING);
 
     await expect(async () => {
-      await page.getByRole("navigation").getByRole("link", { name: "서비스 소개" }).click();
+      await page
+        .getByRole("navigation", { name: "주요 메뉴" })
+        .getByRole("link", { name: "서비스 소개" })
+        .click();
       await expect(page).toHaveURL(/\/about$/);
     }).toPass({ timeout: 10000 });
 
@@ -39,7 +42,10 @@ test.describe("공개 페이지 진입 흐름", () => {
     await page.goto(LANDING);
 
     await expect(async () => {
-      await page.getByRole("navigation").getByRole("link", { name: "이용 방법" }).click();
+      await page
+        .getByRole("navigation", { name: "주요 메뉴" })
+        .getByRole("link", { name: "이용 방법" })
+        .click();
       await expect(page).toHaveURL(/\/guide$/);
     }).toPass({ timeout: 10000 });
 

--- a/apps/web/src/app/(public)/_components/LandingFooter.tsx
+++ b/apps/web/src/app/(public)/_components/LandingFooter.tsx
@@ -23,7 +23,7 @@ export function LandingFooter() {
             </span>
             <span className="font-serif text-[1.25rem] font-bold text-ink">바른보상</span>
           </div>
-          <nav className="flex items-center gap-5">
+          <nav aria-label="푸터 메뉴" className="flex items-center gap-5">
             {FOOTER_LINKS.map((item) => (
               <Link
                 key={item.label}

--- a/apps/web/src/app/(public)/_components/LandingFooter.tsx
+++ b/apps/web/src/app/(public)/_components/LandingFooter.tsx
@@ -1,22 +1,41 @@
+import Link from "next/link";
 import { Scale } from "@/shared/ui/icons/Scale";
 
+const FOOTER_LINKS = [
+  { label: "서비스 소개", href: "/about" },
+  { label: "이용 방법", href: "/guide" }
+] as const;
+
 const LEGAL_NOTICE =
-  "바른보상이 제공하는 분석은 참고용 추정이며 법적 효력이 없습니다. 손해사정·법률자문이 필요한 경우 등록된 손해사정사 상담으로 연결됩니다.";
+  "바른보상은 수익을 목적으로 하지 않는 프로젝트입니다. 제공되는 분석은 참고용 추정이며 법적 효력이 없습니다. 손해사정·법률자문이 필요한 경우 등록된 손해사정사 상담으로 연결됩니다.";
 
 /**
- * 랜딩 푸터. 법적 고지. PC(md↑) 전용 — 모바일 시안엔 푸터가 없다.
+ * 랜딩 푸터. 로고·서비스 링크·법적 고지. 모바일은 세로 스택, md↑는 가로 배치.
  */
 export function LandingFooter() {
   return (
-    <footer className="hidden border-t border-line-2 md:block">
-      <div className="mx-auto flex w-full max-w-[80rem] items-center justify-between gap-10 px-14 py-10">
-        <div className="flex items-center gap-2.5">
-          <span className="flex size-[1.875rem] items-center justify-center rounded-[0.5rem] bg-gold text-white">
-            <Scale className="size-[1.1875rem]" />
-          </span>
-          <span className="font-serif text-[1.25rem] font-bold text-ink">바른보상</span>
+    <footer className="border-t border-line-2">
+      <div className="mx-auto flex w-full max-w-[80rem] flex-col gap-6 px-6 py-8 md:flex-row md:items-center md:justify-between md:gap-10 md:px-14 md:py-10">
+        <div className="flex flex-col gap-4 md:shrink-0">
+          <div className="flex items-center gap-2.5">
+            <span className="flex size-[1.875rem] items-center justify-center rounded-[0.5rem] bg-gold text-white">
+              <Scale className="size-[1.1875rem]" />
+            </span>
+            <span className="font-serif text-[1.25rem] font-bold text-ink">바른보상</span>
+          </div>
+          <nav className="flex items-center gap-5">
+            {FOOTER_LINKS.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                className="text-[0.8125rem] font-medium text-ink-2 transition hover:text-ink"
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
         </div>
-        <p className="max-w-[38.75rem] text-[0.75rem] leading-[0.9375rem] text-ink-3">
+        <p className="max-w-[38.75rem] text-[0.75rem] leading-[1.125rem] text-ink-3">
           {LEGAL_NOTICE}
         </p>
       </div>

--- a/apps/web/src/app/(public)/_components/LandingHeader.tsx
+++ b/apps/web/src/app/(public)/_components/LandingHeader.tsx
@@ -5,9 +5,7 @@ import { Scale } from "@/shared/ui/icons/Scale";
 
 const NAV_ITEMS = [
   { label: "서비스 소개", href: "/about" },
-  { label: "이용 방법", href: "/guide" },
-  { label: "손해사정사", href: "#" },
-  { label: "요금", href: "#" }
+  { label: "이용 방법", href: "/guide" }
 ] as const;
 
 /**

--- a/apps/web/src/app/(public)/_components/LandingHeader.tsx
+++ b/apps/web/src/app/(public)/_components/LandingHeader.tsx
@@ -24,7 +24,7 @@ export function LandingHeader() {
           </span>
         </Link>
 
-        <nav className="hidden items-center gap-8 md:flex">
+        <nav aria-label="주요 메뉴" className="hidden items-center gap-8 md:flex">
           {NAV_ITEMS.map((item) => (
             <Link
               key={item.label}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #168

## ✅ 작업 내용

### 랜딩 헤더의 죽은 메뉴를 제거하고 푸터를 보강했습니다

랜딩 헤더 내비게이션에 placeholder(`#`)로 남아 있던 "손해사정사"·"요금" 메뉴를 제거하고, 로고와 법적 고지 한 줄뿐이던 푸터를 서비스 링크가 있는 구획으로 재구성했습니다. 푸터는 `(public)` 레이아웃 공유라 `/` · `/about` · `/guide` 전부에 동일하게 렌더됩니다.

<br/>

### 1. 헤더 죽은 메뉴 제거

`LandingHeader` NAV_ITEMS에서 대응 페이지가 없는 "손해사정사"·"요금"을 제거하고 "서비스 소개"·"이용 방법"만 유지했습니다. 헤더에 눌러도 이동하지 않는 메뉴가 없습니다.

| 헤더 PC |
| --- |
| <img alt="header-pc" width="720" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/7bda2960ce8c4610b9ad0fdd4fb5670562c31efb/.pr-assets/issue-168/01-header-pc.png" /> |

<br/>

### 2. 랜딩 푸터 보강

로고 · 서비스 링크(서비스 소개 `/about`, 이용 방법 `/guide`) · 법적 고지 구획으로 재구성했습니다. 법적 고지 첫 문장에 수익을 목적으로 하지 않는 프로젝트임을 명시했습니다.

기존 `hidden md:block`을 제거해 모바일에서도 푸터가 보입니다 — 모바일은 세로 스택, md 이상은 기존처럼 가로 배치입니다.

#### 세부 작업
* `LandingFooter` → 서비스 링크 내비 추가, 모바일 세로 스택/PC 가로 배치 반응형 재구성
* `LEGAL_NOTICE` → 비영리 프로젝트 문구 추가

| 푸터 PC | 푸터 모바일 |
| --- | --- |
| <img alt="footer-pc" width="560" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/7bda2960ce8c4610b9ad0fdd4fb5670562c31efb/.pr-assets/issue-168/02-footer-pc.png" /> | <img alt="footer-mobile" width="300" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/7bda2960ce8c4610b9ad0fdd4fb5670562c31efb/.pr-assets/issue-168/03-footer-mobile.png" /> |

## 🧪 테스트

`pnpm typecheck` · lint 통과. 정적 마크업(링크·문구·반응형 노출)만 변경이라 신규 E2E는 추가하지 않았고, 뷰포트별 렌더 결과는 캡처 스크린샷으로 확인했습니다(`_capture-168.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 모바일 환경에서도 랜딩 페이지 푸터를 확인할 수 있습니다.
  - 푸터에 ‘서비스 소개’와 ‘이용 방법’ 바로가기가 추가되었습니다.
  - 화면 크기에 따라 푸터가 세로 또는 가로 형태로 표시됩니다.

- **변경 사항**
  - 헤더 내비게이션에서 ‘손해사정사’와 ‘요금’ 메뉴가 제거되고 ‘이용 방법’만 유지됩니다.
  - 푸터의 법적 고지 문구와 모바일 화면 구성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->