### PR TITLE
[Feature] 데스크톱 헤더 채팅 진입 아이콘 버튼 추가(web)

### DIFF
--- a/apps/web/src/app/partner/_components/PartnerHeader.tsx
+++ b/apps/web/src/app/partner/_components/PartnerHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { Chat } from "@/shared/ui/icons/Chat";
 import { Scale } from "@/shared/ui/icons/Scale";
 import { NotificationBellMenu } from "@/shared/ui/NotificationBellMenu";
 import { useProfile } from "../_api/use-profile";
@@ -65,6 +66,13 @@ export function PartnerHeader() {
         </div>
 
         <div className="flex items-center gap-3">
+          <Link
+            href="/partner/chat"
+            aria-label="채팅"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xl text-ink-2 transition hover:bg-paper hover:text-ink"
+          >
+            <Chat />
+          </Link>
           <NotificationBellMenu settingsHref="/partner/mypage?panel=notifications" />
           <Link href="/partner/mypage" className="flex items-center gap-2">
             <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-navy text-lg text-gold">

--- a/apps/web/src/shared/ui/CustomerHeader.tsx
+++ b/apps/web/src/shared/ui/CustomerHeader.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Chat } from "@/shared/ui/icons/Chat";
 import { Scale } from "@/shared/ui/icons/Scale";
 import { User } from "@/shared/ui/icons/User";
 import { NotificationBellMenu } from "@/shared/ui/NotificationBellMenu";
@@ -38,6 +39,13 @@ export function CustomerHeader() {
         </div>
 
         <div className="flex items-center gap-2">
+          <Link
+            href="/customer/chat"
+            aria-label="채팅"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xl text-ink-2 transition hover:bg-paper hover:text-ink"
+          >
+            <Chat />
+          </Link>
           <NotificationBellMenu settingsHref="/customer/mypage?panel=notifications" />
           <Link
             href="/customer/mypage"


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #176

## ✅ 작업 내용

### 데스크톱 헤더(고객·파트너)에 채팅 진입 아이콘 버튼을 추가했습니다

채팅 페이지(`/customer/chat`, `/partner/chat`)는 구현돼 있었지만 데스크톱 헤더에 진입 동선이 없어 간접 동선으로만 들어갈 수 있던 문제를 해소합니다. 알림 벨 왼쪽에 채팅 아이콘 버튼을 배치했고, 아이콘은 모바일 하단 탭바 "채팅" 탭과 동일한 공용 `Chat` 아이콘을, 버튼 스타일은 알림 벨과 동일한 원형 아이콘 버튼 스타일을 재사용해 시각 일관성을 유지했습니다.

- `CustomerHeader` — 알림 벨 옆에 `/customer/chat` 채팅 아이콘 버튼 추가
- `PartnerHeader` — 알림 벨 옆에 `/partner/chat` 채팅 아이콘 버튼 추가

| 고객 헤더 | 파트너 헤더 |
| --- | --- |
| <img alt="customer-header" width="480" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/a25144300b0c0bcdbaf235fd46506c973044730d/.pr-assets/issue-176/00-customer-header.png" /> | <img alt="partner-header" width="480" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/a25144300b0c0bcdbaf235fd46506c973044730d/.pr-assets/issue-176/01-partner-header.png" /> |

## 🧪 테스트

`pnpm typecheck` · `pnpm lint` 통과. dev 서버에서 고객·파트너 헤더의 채팅 아이콘 클릭 시 각각 채팅 목록으로 이동하는 것을 확인했습니다(위 스크린샷).

## 💬 특이사항 / 고민했던 부분

- 이슈 본문은 네비게이션 텍스트 링크로 적혀 있었으나, 논의에 따라 **알림 벨 옆 아이콘 버튼** 방식으로 구현했습니다.
- 아이콘 전용 버튼이라 `aria-label="채팅"`으로 접근성 라벨을 붙였습니다.
- 안 읽은 채팅 수 배지는 이슈 범위 밖이라 다루지 않았습니다.
