### PR TITLE
[Feature] RN 웹뷰 네이티브 연동 구현 (app)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,6 +1,9 @@
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
+import { configureNotifications } from './src/push/push-token';
 import { WebViewScreen } from './src/WebViewScreen';
+
+configureNotifications();
 
 export default function App() {
   return (

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,6 +3,7 @@
     "name": "mobile",
     "slug": "mobile",
     "version": "1.0.0",
+    "scheme": "bareun",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,7 +16,8 @@
         "backgroundImage": "./assets/android-icon-background.png",
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "permissions": ["android.permission.CAMERA", "android.permission.READ_MEDIA_IMAGES", "android.permission.READ_EXTERNAL_STORAGE"]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -4,7 +4,10 @@
     "slug": "mobile",
     "version": "1.0.0",
     "scheme": "bareun",
-    "plugins": ["expo-notifications"],
+    "plugins": [
+      "expo-notifications",
+      "expo-web-browser"
+    ],
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -24,7 +27,11 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "permissions": ["android.permission.CAMERA", "android.permission.READ_MEDIA_IMAGES", "android.permission.READ_EXTERNAL_STORAGE"]
+      "permissions": [
+        "android.permission.CAMERA",
+        "android.permission.READ_MEDIA_IMAGES",
+        "android.permission.READ_EXTERNAL_STORAGE"
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -7,7 +7,12 @@
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "infoPlist": {
+        "NSPhotoLibraryUsageDescription": "사진 첨부를 위해 사진 보관함 접근 권한이 필요합니다.",
+        "NSCameraUsageDescription": "사진 촬영 후 첨부를 위해 카메라 접근 권한이 필요합니다.",
+        "NSMicrophoneUsageDescription": "동영상 촬영 후 첨부를 위해 마이크 접근 권한이 필요합니다."
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -4,6 +4,7 @@
     "slug": "mobile",
     "version": "1.0.0",
     "scheme": "bareun",
+    "plugins": ["expo-notifications"],
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,7 +4,9 @@
   "main": "index.ts",
   "dependencies": {
     "expo": "~54.0.35",
+    "expo-constants": "~18.0.13",
     "expo-linking": "~8.0.12",
+    "expo-notifications": "~0.32.17",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -9,6 +9,7 @@
     "expo-linking": "~8.0.12",
     "expo-notifications": "~0.32.17",
     "expo-status-bar": "~3.0.9",
+    "expo-web-browser": "~15.0.11",
     "react": "19.1.0",
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.2",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,6 +4,7 @@
   "main": "index.ts",
   "dependencies": {
     "expo": "~54.0.35",
+    "expo-linking": "~8.0.12",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "main": "index.ts",
   "dependencies": {
+    "@insurance/bridge": "workspace:*",
     "expo": "~54.0.35",
     "expo-constants": "~18.0.13",
     "expo-linking": "~8.0.12",

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -1,20 +1,23 @@
 import { parseWebMessage, serializeToWeb } from '@insurance/bridge/native';
 import * as Linking from 'expo-linking';
 import { StatusBar } from 'expo-status-bar';
+import * as WebBrowser from 'expo-web-browser';
 import { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, BackHandler, Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 
-import { getAllowedHosts } from './config/allowed-hosts';
+import { EXTERNAL_AUTH_HOSTS, getAllowedHosts } from './config/allowed-hosts';
 import { APP_USER_AGENT_SUFFIX } from './config/user-agent';
 import { getWebUrl } from './config/web-url';
 import { createLoadDecider } from './lib/create-should-start-load';
+import { APP_SCHEME, mapDeepLinkToWebUrl } from './linking/deep-link';
 import { useDeepLink } from './linking/use-deep-link';
 import { getPushToken } from './push/push-token';
 import { useNotificationResponse } from './push/use-notification-response';
 
-const decideLoad = createLoadDecider(getAllowedHosts());
+const decideLoad = createLoadDecider(getAllowedHosts(), EXTERNAL_AUTH_HOSTS);
+const AUTH_SESSION_RETURN_URL = `${APP_SCHEME}://login/oauth2/code`;
 
 export function WebViewScreen() {
   const webViewRef = useRef<WebView>(null);
@@ -69,8 +72,22 @@ export function WebViewScreen() {
         allowFileAccess
         onMessage={(event) => handleWebMessage(event.nativeEvent.data)}
         onShouldStartLoadWithRequest={(request) => {
-          if (decideLoad(request) === 'open-external') {
+          const decision = decideLoad(request);
+          if (decision === 'open-external') {
             Linking.openURL(request.url).catch(() => {});
+            return false;
+          }
+          if (decision === 'open-auth-session') {
+            WebBrowser.openAuthSessionAsync(request.url, AUTH_SESSION_RETURN_URL)
+              .then((result) => {
+                if (result.type === 'success') {
+                  const webUrl = mapDeepLinkToWebUrl(result.url);
+                  if (webUrl) {
+                    setSourceUri(webUrl);
+                  }
+                }
+              })
+              .catch(() => {});
             return false;
           }
           return true;

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -1,3 +1,4 @@
+import { parseWebMessage, serializeToWeb } from '@insurance/bridge/native';
 import * as Linking from 'expo-linking';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useRef, useState } from 'react';
@@ -10,6 +11,7 @@ import { APP_USER_AGENT_SUFFIX } from './config/user-agent';
 import { getWebUrl } from './config/web-url';
 import { createLoadDecider } from './lib/create-should-start-load';
 import { useDeepLink } from './linking/use-deep-link';
+import { getPushToken } from './push/push-token';
 
 const decideLoad = createLoadDecider(getAllowedHosts());
 
@@ -17,8 +19,30 @@ export function WebViewScreen() {
   const webViewRef = useRef<WebView>(null);
   const [canGoBack, setCanGoBack] = useState(false);
   const [sourceUri, setSourceUri] = useState(getWebUrl);
+  const webReadyRef = useRef(false);
 
   useDeepLink(setSourceUri);
+
+  const handleWebMessage = (data: string) => {
+    const message = parseWebMessage(data);
+    if (!message) {
+      return;
+    }
+    if (message.type === 'WEB_READY') {
+      webReadyRef.current = true;
+      return;
+    }
+    if (message.type === 'REQUEST_PUSH_TOKEN') {
+      getPushToken().then((result) => {
+        if (!result || !webReadyRef.current) {
+          return;
+        }
+        webViewRef.current?.injectJavaScript(
+          serializeToWeb({ v: 1, type: 'PUSH_TOKEN', payload: result }),
+        );
+      });
+    }
+  };
 
   useEffect(() => {
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -41,6 +65,7 @@ export function WebViewScreen() {
         thirdPartyCookiesEnabled
         allowsBackForwardNavigationGestures
         allowFileAccess
+        onMessage={(event) => handleWebMessage(event.nativeEvent.data)}
         onShouldStartLoadWithRequest={(request) => {
           if (decideLoad(request) === 'open-external') {
             Linking.openURL(request.url).catch(() => {});

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -9,12 +9,16 @@ import { getAllowedHosts } from './config/allowed-hosts';
 import { APP_USER_AGENT_SUFFIX } from './config/user-agent';
 import { getWebUrl } from './config/web-url';
 import { createLoadDecider } from './lib/create-should-start-load';
+import { useDeepLink } from './linking/use-deep-link';
 
 const decideLoad = createLoadDecider(getAllowedHosts());
 
 export function WebViewScreen() {
   const webViewRef = useRef<WebView>(null);
   const [canGoBack, setCanGoBack] = useState(false);
+  const [sourceUri, setSourceUri] = useState(getWebUrl);
+
+  useDeepLink(setSourceUri);
 
   useEffect(() => {
     const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
@@ -31,7 +35,7 @@ export function WebViewScreen() {
     <SafeAreaView style={styles.container}>
       <WebView
         ref={webViewRef}
-        source={{ uri: getWebUrl() }}
+        source={{ uri: sourceUri }}
         applicationNameForUserAgent={APP_USER_AGENT_SUFFIX}
         sharedCookiesEnabled
         thirdPartyCookiesEnabled

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -30,6 +30,7 @@ export function WebViewScreen() {
         applicationNameForUserAgent={APP_USER_AGENT_SUFFIX}
         sharedCookiesEnabled
         thirdPartyCookiesEnabled
+        allowsBackForwardNavigationGestures
         style={styles.webview}
         onNavigationStateChange={(navState) => setCanGoBack(navState.canGoBack)}
         startInLoadingState

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -18,6 +18,7 @@ import { useNotificationResponse } from './push/use-notification-response';
 
 const decideLoad = createLoadDecider(getAllowedHosts(), EXTERNAL_AUTH_HOSTS);
 const AUTH_SESSION_RETURN_URL = `${APP_SCHEME}://login/oauth2/code`;
+const SERVICE_HOST = new URL(getWebUrl()).host;
 
 export function WebViewScreen() {
   const webViewRef = useRef<WebView>(null);
@@ -93,7 +94,18 @@ export function WebViewScreen() {
           return true;
         }}
         style={styles.webview}
-        onNavigationStateChange={(navState) => setCanGoBack(navState.canGoBack)}
+        onNavigationStateChange={(navState) => {
+          setCanGoBack(navState.canGoBack);
+          // 서비스 밖 문서(OAuth 등)로 이동하면 웹 준비 상태를 해제해 대기 중인 토큰 주입을 차단.
+          // 서비스 복귀 시 웹이 WEB_READY를 다시 보낸다.
+          try {
+            if (new URL(navState.url).host !== SERVICE_HOST) {
+              webReadyRef.current = false;
+            }
+          } catch {
+            webReadyRef.current = false;
+          }
+        }}
         startInLoadingState
         renderLoading={() => (
           <View style={styles.overlay}>

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -36,6 +36,7 @@ export function WebViewScreen() {
         sharedCookiesEnabled
         thirdPartyCookiesEnabled
         allowsBackForwardNavigationGestures
+        allowFileAccess
         onShouldStartLoadWithRequest={(request) => {
           if (decideLoad(request) === 'open-external') {
             Linking.openURL(request.url).catch(() => {});

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -1,11 +1,16 @@
+import * as Linking from 'expo-linking';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, BackHandler, Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 
+import { getAllowedHosts } from './config/allowed-hosts';
 import { APP_USER_AGENT_SUFFIX } from './config/user-agent';
 import { getWebUrl } from './config/web-url';
+import { createLoadDecider } from './lib/create-should-start-load';
+
+const decideLoad = createLoadDecider(getAllowedHosts());
 
 export function WebViewScreen() {
   const webViewRef = useRef<WebView>(null);
@@ -31,6 +36,13 @@ export function WebViewScreen() {
         sharedCookiesEnabled
         thirdPartyCookiesEnabled
         allowsBackForwardNavigationGestures
+        onShouldStartLoadWithRequest={(request) => {
+          if (decideLoad(request) === 'open-external') {
+            Linking.openURL(request.url).catch(() => {});
+            return false;
+          }
+          return true;
+        }}
         style={styles.webview}
         onNavigationStateChange={(navState) => setCanGoBack(navState.canGoBack)}
         startInLoadingState

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -28,6 +28,8 @@ export function WebViewScreen() {
         ref={webViewRef}
         source={{ uri: getWebUrl() }}
         applicationNameForUserAgent={APP_USER_AGENT_SUFFIX}
+        sharedCookiesEnabled
+        thirdPartyCookiesEnabled
         style={styles.webview}
         onNavigationStateChange={(navState) => setCanGoBack(navState.canGoBack)}
         startInLoadingState

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -12,6 +12,7 @@ import { getWebUrl } from './config/web-url';
 import { createLoadDecider } from './lib/create-should-start-load';
 import { useDeepLink } from './linking/use-deep-link';
 import { getPushToken } from './push/push-token';
+import { useNotificationResponse } from './push/use-notification-response';
 
 const decideLoad = createLoadDecider(getAllowedHosts());
 
@@ -22,6 +23,7 @@ export function WebViewScreen() {
   const webReadyRef = useRef(false);
 
   useDeepLink(setSourceUri);
+  useNotificationResponse(setSourceUri);
 
   const handleWebMessage = (data: string) => {
     const message = parseWebMessage(data);

--- a/apps/mobile/src/config/allowed-hosts.ts
+++ b/apps/mobile/src/config/allowed-hosts.ts
@@ -2,6 +2,9 @@ import { getWebUrl } from './web-url';
 
 const OAUTH_HOSTS = ['kauth.kakao.com', 'accounts.kakao.com', 'nid.naver.com'];
 
+// WebView 로그인을 차단하는 제공자(구글 등) 추가 시 여기에 호스트 등록 — 외부 브라우저 인증 세션으로 우회
+export const EXTERNAL_AUTH_HOSTS: string[] = [];
+
 export function getAllowedHosts(): string[] {
   return [new URL(getWebUrl()).host, ...OAUTH_HOSTS];
 }

--- a/apps/mobile/src/config/allowed-hosts.ts
+++ b/apps/mobile/src/config/allowed-hosts.ts
@@ -1,0 +1,7 @@
+import { getWebUrl } from './web-url';
+
+const OAUTH_HOSTS = ['kauth.kakao.com', 'accounts.kakao.com', 'nid.naver.com'];
+
+export function getAllowedHosts(): string[] {
+  return [new URL(getWebUrl()).host, ...OAUTH_HOSTS];
+}

--- a/apps/mobile/src/lib/create-should-start-load.ts
+++ b/apps/mobile/src/lib/create-should-start-load.ts
@@ -1,11 +1,14 @@
-export type LoadDecision = 'allow' | 'open-external';
+export type LoadDecision = 'allow' | 'open-external' | 'open-auth-session';
 
 interface LoadRequest {
   url: string;
   isTopFrame: boolean;
 }
 
-export function createLoadDecider(allowedHosts: readonly string[]) {
+export function createLoadDecider(
+  allowedHosts: readonly string[],
+  externalAuthHosts: readonly string[] = [],
+) {
   return function decideLoad({ url, isTopFrame }: LoadRequest): LoadDecision {
     if (!isTopFrame) {
       return 'allow';
@@ -17,6 +20,9 @@ export function createLoadDecider(allowedHosts: readonly string[]) {
       return 'open-external';
     }
     const { host } = new URL(url);
+    if (externalAuthHosts.includes(host)) {
+      return 'open-auth-session';
+    }
     return allowedHosts.includes(host) ? 'allow' : 'open-external';
   };
 }

--- a/apps/mobile/src/lib/create-should-start-load.ts
+++ b/apps/mobile/src/lib/create-should-start-load.ts
@@ -1,0 +1,22 @@
+export type LoadDecision = 'allow' | 'open-external';
+
+interface LoadRequest {
+  url: string;
+  isTopFrame: boolean;
+}
+
+export function createLoadDecider(allowedHosts: readonly string[]) {
+  return function decideLoad({ url, isTopFrame }: LoadRequest): LoadDecision {
+    if (!isTopFrame) {
+      return 'allow';
+    }
+    if (url.startsWith('about:')) {
+      return 'allow';
+    }
+    if (!/^https?:\/\//.test(url)) {
+      return 'open-external';
+    }
+    const { host } = new URL(url);
+    return allowedHosts.includes(host) ? 'allow' : 'open-external';
+  };
+}

--- a/apps/mobile/src/linking/deep-link.ts
+++ b/apps/mobile/src/linking/deep-link.ts
@@ -1,0 +1,13 @@
+import { getWebUrl } from '../config/web-url';
+
+export const APP_SCHEME = 'bareun';
+
+export function mapDeepLinkToWebUrl(deepLinkUrl: string): string | null {
+  const match = deepLinkUrl.match(new RegExp(`^${APP_SCHEME}://(.*)$`));
+  if (!match) {
+    return null;
+  }
+  const pathWithQuery = match[1].replace(/^\/+/, '');
+  const base = getWebUrl().replace(/\/+$/, '');
+  return pathWithQuery ? `${base}/${pathWithQuery}` : base;
+}

--- a/apps/mobile/src/linking/use-deep-link.ts
+++ b/apps/mobile/src/linking/use-deep-link.ts
@@ -9,12 +9,14 @@ export function useDeepLink(onNavigate: (webUrl: string) => void) {
   useEffect(() => {
     if (!handledInitialUrl.current) {
       handledInitialUrl.current = true;
-      Linking.getInitialURL().then((url) => {
-        const webUrl = url ? mapDeepLinkToWebUrl(url) : null;
-        if (webUrl) {
-          onNavigate(webUrl);
-        }
-      });
+      Linking.getInitialURL()
+        .then((url) => {
+          const webUrl = url ? mapDeepLinkToWebUrl(url) : null;
+          if (webUrl) {
+            onNavigate(webUrl);
+          }
+        })
+        .catch(() => {});
     }
 
     const subscription = Linking.addEventListener('url', ({ url }) => {

--- a/apps/mobile/src/linking/use-deep-link.ts
+++ b/apps/mobile/src/linking/use-deep-link.ts
@@ -1,0 +1,28 @@
+import * as Linking from 'expo-linking';
+import { useEffect, useRef } from 'react';
+
+import { mapDeepLinkToWebUrl } from './deep-link';
+
+export function useDeepLink(onNavigate: (webUrl: string) => void) {
+  const handledInitialUrl = useRef(false);
+
+  useEffect(() => {
+    if (!handledInitialUrl.current) {
+      handledInitialUrl.current = true;
+      Linking.getInitialURL().then((url) => {
+        const webUrl = url ? mapDeepLinkToWebUrl(url) : null;
+        if (webUrl) {
+          onNavigate(webUrl);
+        }
+      });
+    }
+
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      const webUrl = mapDeepLinkToWebUrl(url);
+      if (webUrl) {
+        onNavigate(webUrl);
+      }
+    });
+    return () => subscription.remove();
+  }, [onNavigate]);
+}

--- a/apps/mobile/src/push/push-token.ts
+++ b/apps/mobile/src/push/push-token.ts
@@ -32,14 +32,15 @@ export async function getPushToken(): Promise<PushTokenResult | null> {
   if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
     return null;
   }
-  if (!(await ensurePermission())) {
-    return null;
-  }
+  // Android 13+는 알림 채널이 있어야 권한 프롬프트가 표시된다 — 권한 요청보다 먼저 생성
   if (Platform.OS === 'android') {
     await Notifications.setNotificationChannelAsync('default', {
       name: '기본 알림',
       importance: Notifications.AndroidImportance.DEFAULT,
     });
+  }
+  if (!(await ensurePermission())) {
+    return null;
   }
   // EAS projectId는 앱 아이덴티티 이슈에서 설정 — 없으면 토큰 발급이 실패하므로 null 반환
   const projectId: string | undefined = Constants.expoConfig?.extra?.eas?.projectId;

--- a/apps/mobile/src/push/push-token.ts
+++ b/apps/mobile/src/push/push-token.ts
@@ -1,0 +1,54 @@
+import Constants from 'expo-constants';
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+export interface PushTokenResult {
+  token: string;
+  platform: 'ios' | 'android';
+  tokenType: 'expo';
+}
+
+export function configureNotifications() {
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowBanner: true,
+      shouldShowList: true,
+      shouldPlaySound: false,
+      shouldSetBadge: false,
+    }),
+  });
+}
+
+async function ensurePermission(): Promise<boolean> {
+  const current = await Notifications.getPermissionsAsync();
+  if (current.granted) {
+    return true;
+  }
+  const requested = await Notifications.requestPermissionsAsync();
+  return requested.granted;
+}
+
+export async function getPushToken(): Promise<PushTokenResult | null> {
+  if (Platform.OS !== 'ios' && Platform.OS !== 'android') {
+    return null;
+  }
+  if (!(await ensurePermission())) {
+    return null;
+  }
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('default', {
+      name: '기본 알림',
+      importance: Notifications.AndroidImportance.DEFAULT,
+    });
+  }
+  // EAS projectId는 앱 아이덴티티 이슈에서 설정 — 없으면 토큰 발급이 실패하므로 null 반환
+  const projectId: string | undefined = Constants.expoConfig?.extra?.eas?.projectId;
+  try {
+    const { data } = await Notifications.getExpoPushTokenAsync(
+      projectId ? { projectId } : undefined,
+    );
+    return { token: data, platform: Platform.OS, tokenType: 'expo' };
+  } catch {
+    return null;
+  }
+}

--- a/apps/mobile/src/push/use-notification-response.ts
+++ b/apps/mobile/src/push/use-notification-response.ts
@@ -1,0 +1,48 @@
+import * as Notifications from 'expo-notifications';
+import { useEffect, useRef } from 'react';
+
+import { getWebUrl } from '../config/web-url';
+import { APP_SCHEME, mapDeepLinkToWebUrl } from '../linking/deep-link';
+
+function resolveDeepLink(data: unknown): string | null {
+  if (typeof data !== 'object' || data === null) {
+    return null;
+  }
+  const deepLink = (data as Record<string, unknown>).deepLink;
+  if (typeof deepLink !== 'string') {
+    return null;
+  }
+  if (deepLink.startsWith(`${APP_SCHEME}://`)) {
+    return mapDeepLinkToWebUrl(deepLink);
+  }
+  if (deepLink.startsWith('/')) {
+    return `${getWebUrl().replace(/\/+$/, '')}${deepLink}`;
+  }
+  return null;
+}
+
+export function useNotificationResponse(onNavigate: (webUrl: string) => void) {
+  const handledInitial = useRef(false);
+
+  useEffect(() => {
+    if (!handledInitial.current) {
+      handledInitial.current = true;
+      Notifications.getLastNotificationResponseAsync().then((response) => {
+        const webUrl = response
+          ? resolveDeepLink(response.notification.request.content.data)
+          : null;
+        if (webUrl) {
+          onNavigate(webUrl);
+        }
+      });
+    }
+
+    const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
+      const webUrl = resolveDeepLink(response.notification.request.content.data);
+      if (webUrl) {
+        onNavigate(webUrl);
+      }
+    });
+    return () => subscription.remove();
+  }, [onNavigate]);
+}

--- a/apps/mobile/src/push/use-notification-response.ts
+++ b/apps/mobile/src/push/use-notification-response.ts
@@ -27,14 +27,18 @@ export function useNotificationResponse(onNavigate: (webUrl: string) => void) {
   useEffect(() => {
     if (!handledInitial.current) {
       handledInitial.current = true;
-      Notifications.getLastNotificationResponseAsync().then((response) => {
-        const webUrl = response
-          ? resolveDeepLink(response.notification.request.content.data)
-          : null;
-        if (webUrl) {
-          onNavigate(webUrl);
-        }
-      });
+      Notifications.getLastNotificationResponseAsync()
+        .then((response) => {
+          const webUrl = response
+            ? resolveDeepLink(response.notification.request.content.data)
+            : null;
+          if (webUrl) {
+            onNavigate(webUrl);
+            // 재마운트·JS 리로드 시 같은 응답으로 중복 이동하지 않도록 소진 처리
+            void Notifications.clearLastNotificationResponseAsync().catch(() => {});
+          }
+        })
+        .catch(() => {});
     }
 
     const subscription = Notifications.addNotificationResponseReceivedListener((response) => {

--- a/apps/web/e2e/app-oauth-callback.spec.ts
+++ b/apps/web/e2e/app-oauth-callback.spec.ts
@@ -1,0 +1,55 @@
+import { devices, expect, test } from "@playwright/test";
+
+/**
+ * 앱 웹뷰 OAuth 콜백 분기 E2E (이슈 #178).
+ *
+ * 원칙: 앱에서 시작한 로그인(state `app.` 접두어)이 외부 브라우저에서 콜백에 도달하면
+ *       code를 교환하지 않고 앱 딥링크로 넘긴다(쿠키가 외부 브라우저에 남는 것 방지).
+ *       앱 웹뷰 안(UA에 BareunApp)에서는 접두어와 무관하게 정상 교환한다.
+ * 인가 리다이렉트·실제 딥링크 복귀(bareun://)는 브라우저 밖 영역이라 검증하지 않고,
+ * "교환이 실행됐는가(홈 이동 여부)"와 실패 콜백의 로그인 복귀만 검증한다.
+ */
+
+const UNAUTH_HEADER = { "x-mock-scenario": "unauthenticated" };
+
+test.describe("외부 브라우저 복귀", () => {
+  test("앱에서 시작한 로그인 콜백은 code를 교환하지 않고 홈으로 이동하지 않는다", async ({
+    page,
+    browserName,
+  }) => {
+    // webkit은 미지원 스킴(bareun://) 이동 시 동작이 달라 chromium 계열만 검증한다.
+    test.skip(browserName === "webkit", "커스텀 스킴 이동 동작이 달라 chromium만 검증");
+
+    await page.goto("/login/oauth2/code/kakao?code=valid&state=app.s1");
+
+    // 교환이 실행됐다면 code=valid는 수 초 내 홈(→고객 대시보드)으로 이동한다.
+    // 교환 차단이 정상이면 대기 화면(스피너)이 유지되고 콜백 URL에 머문다.
+    await page.waitForTimeout(3000);
+    await expect(page).toHaveURL(/\/login\/oauth2\/code\/kakao/);
+  });
+
+  test("실패 콜백(제공자 거부)은 외부 브라우저여도 로그인 화면으로 돌아간다", async ({
+    page,
+  }) => {
+    await page.setExtraHTTPHeaders(UNAUTH_HEADER);
+    await page.goto("/login/oauth2/code/kakao?error=access_denied&state=app.s1");
+
+    await expect(page).toHaveURL(/\/login/, { timeout: 15000 });
+    await expect(page.getByRole("heading", { name: "바른보상 시작하기" })).toBeVisible();
+  });
+});
+
+test.describe("앱 웹뷰 내 콜백", () => {
+  // 앱 웹뷰 판별은 UA 토큰(BareunApp) 기준 — 웹뷰 안에서는 접두어가 있어도 정상 교환.
+  test.use({
+    userAgent: `${devices["Desktop Chrome"].userAgent} BareunApp/1.0`,
+  });
+
+  test("앱 웹뷰 안에서는 state 접두어와 무관하게 교환이 완료되고 홈으로 이동한다", async ({
+    page,
+  }) => {
+    await page.goto("/login/oauth2/code/kakao?code=valid&state=app.s1");
+
+    await expect(page).toHaveURL(/\/customer\/dashboard/, { timeout: 15000 });
+  });
+});

--- a/apps/web/src/app/(auth)/login/_hooks/use-social-login.ts
+++ b/apps/web/src/app/(auth)/login/_hooks/use-social-login.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback } from "react";
+import { isAppWebViewUserAgent } from "@/shared/lib/app-webview-token";
 import type { SocialProvider } from "../../_shared/hooks/use-recent-login";
 
 const AUTHORIZE_ENDPOINT: Record<SocialProvider, string> = {
@@ -27,7 +28,10 @@ export function useSocialLogin() {
   const startLogin = useCallback((provider: SocialProvider) => {
     if (typeof window === "undefined") return;
 
-    const state = createState();
+    // 앱 웹뷰 출발 표시 — 외부 브라우저로 우회된 콜백이 앱 복귀 딥링크로 바운스할 때 판별 근거.
+    const state = isAppWebViewUserAgent(navigator.userAgent)
+      ? `app.${createState()}`
+      : createState();
     window.sessionStorage.setItem(`${OAUTH_STATE_KEY}.${provider}`, state);
 
     const params = new URLSearchParams({

--- a/apps/web/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
+++ b/apps/web/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
@@ -51,7 +51,7 @@ export default function OauthCallbackPage() {
 
   // 앱 웹뷰에서 시작해 외부 브라우저로 우회된 로그인 복귀 — 여기서 code를 교환하면
   // 쿠키가 외부 브라우저에 남으므로, 교환 없이 앱 딥링크로 code를 넘긴다.
-  const [isExternalBrowserReturn] = useState(
+  const [isAppReturnInExternalBrowser] = useState(
     () =>
       typeof navigator !== "undefined" &&
       !!state?.startsWith("app.") &&
@@ -59,10 +59,12 @@ export default function OauthCallbackPage() {
   );
 
   const invalidEntry = !code || !!oauthError || !isSupportedProvider(provider);
+  // 거부·오류·미지원 provider 콜백은 외부 브라우저여도 /login으로 — 빈 화면 방지.
+  const isExternalBrowserReturn = isAppReturnInExternalBrowser && !invalidEntry;
 
   useEffect(() => {
-    if (invalidEntry && !isExternalBrowserReturn) router.replace("/login");
-  }, [invalidEntry, isExternalBrowserReturn, router]);
+    if (invalidEntry) router.replace("/login");
+  }, [invalidEntry, router]);
 
   useEffect(() => {
     if (!isExternalBrowserReturn || !code) return;

--- a/apps/web/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
+++ b/apps/web/src/app/(auth)/login/oauth2/code/[provider]/page.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { getMe } from "@/shared/api/get-me";
+import {
+  APP_DEEP_LINK_SCHEME,
+  isAppWebViewUserAgent,
+} from "@/shared/lib/app-webview-token";
 import { Button } from "@/shared/ui/Button";
 import { maskEmail } from "../../../../_shared/lib/mask-email";
 import { saveSignupTicket } from "../../../../_shared/lib/signup-ticket";
@@ -45,15 +49,33 @@ export default function OauthCallbackPage() {
   const oauthError = searchParams.get("error");
   const state = searchParams.get("state");
 
+  // 앱 웹뷰에서 시작해 외부 브라우저로 우회된 로그인 복귀 — 여기서 code를 교환하면
+  // 쿠키가 외부 브라우저에 남으므로, 교환 없이 앱 딥링크로 code를 넘긴다.
+  const [isExternalBrowserReturn] = useState(
+    () =>
+      typeof navigator !== "undefined" &&
+      !!state?.startsWith("app.") &&
+      !isAppWebViewUserAgent(navigator.userAgent),
+  );
+
   const invalidEntry = !code || !!oauthError || !isSupportedProvider(provider);
 
   useEffect(() => {
-    if (invalidEntry) router.replace("/login");
-  }, [invalidEntry, router]);
+    if (invalidEntry && !isExternalBrowserReturn) router.replace("/login");
+  }, [invalidEntry, isExternalBrowserReturn, router]);
+
+  useEffect(() => {
+    if (!isExternalBrowserReturn || !code) return;
+    const query = new URLSearchParams({ code });
+    if (state) query.set("state", state);
+    window.location.replace(
+      `${APP_DEEP_LINK_SCHEME}://login/oauth2/code/${provider}?${query.toString()}`,
+    );
+  }, [isExternalBrowserReturn, code, state, provider]);
 
   const { data, isError, error, refetch, isFetching } = useOauthCallback({
     provider,
-    code,
+    code: isExternalBrowserReturn ? null : code,
     state,
   });
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
 import { fontVariables } from "@/shared/fonts";
+import { getIsAppWebView } from "@/shared/lib/app-webview";
+import { DeviceTokenRegistrar } from "@/shared/lib/DeviceTokenRegistrar";
 import { Providers } from "@/shared/providers";
 import "./globals.css";
 
@@ -16,11 +18,16 @@ export const viewport: Viewport = {
   viewportFit: "cover"
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const isApp = await getIsAppWebView();
+
   return (
     <html lang="ko" className={fontVariables}>
       <body className="min-h-dvh bg-paper font-sans text-ink antialiased">
-        <Providers>{children}</Providers>
+        <Providers>
+          {isApp && <DeviceTokenRegistrar />}
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/apps/web/src/shared/api/delete-device-token.ts
+++ b/apps/web/src/shared/api/delete-device-token.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { API_BASE_URL } from "@/shared/api/config";
+import { fetchJson } from "@/shared/api/fetch-json";
+
+const deleteDeviceTokenSchema = z.null().nullish();
+
+export async function deleteDeviceToken(token: string): Promise<void> {
+  await fetchJson(`${API_BASE_URL}/users/me/device-tokens`, deleteDeviceTokenSchema, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
+  });
+}

--- a/apps/web/src/shared/api/register-device-token.ts
+++ b/apps/web/src/shared/api/register-device-token.ts
@@ -1,0 +1,17 @@
+import { API_BASE_URL } from "@/shared/api/config";
+import { fetchJson } from "@/shared/api/fetch-json";
+import { deviceTokenSchema } from "@/shared/model/device-token.schema";
+import type {
+  DeviceToken,
+  RegisterDeviceTokenBody,
+} from "@/shared/model/device-token.schema";
+
+export function registerDeviceToken(
+  body: RegisterDeviceTokenBody,
+): Promise<DeviceToken> {
+  return fetchJson(`${API_BASE_URL}/users/me/device-tokens`, deviceTokenSchema, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}

--- a/apps/web/src/shared/api/use-logout.ts
+++ b/apps/web/src/shared/api/use-logout.ts
@@ -1,6 +1,12 @@
 "use client";
 
+import { isBridgeAvailable } from "@insurance/bridge/web";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  clearRegisteredDeviceToken,
+  loadRegisteredDeviceToken,
+} from "@/shared/lib/device-token-storage";
+import { deleteDeviceToken } from "./delete-device-token";
 import { logout } from "./logout";
 
 /**
@@ -11,7 +17,20 @@ export function useLogout() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: logout,
+    mutationFn: async () => {
+      // 로그아웃한 기기로 푸시가 가지 않도록 세션이 살아있을 때 기기 토큰을 먼저 해제.
+      // 해제 실패가 로그아웃을 막으면 안 되므로 best-effort.
+      if (isBridgeAvailable()) {
+        const registered = loadRegisteredDeviceToken();
+        if (registered) {
+          try {
+            await deleteDeviceToken(registered.token);
+            clearRegisteredDeviceToken();
+          } catch {}
+        }
+      }
+      return logout();
+    },
     onSettled: () => {
       queryClient.clear();
       window.location.replace("/login");

--- a/apps/web/src/shared/api/use-register-device-token.ts
+++ b/apps/web/src/shared/api/use-register-device-token.ts
@@ -1,0 +1,11 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import type { RegisterDeviceTokenBody } from "@/shared/model/device-token.schema";
+import { registerDeviceToken } from "./register-device-token";
+
+export function useRegisterDeviceToken() {
+  return useMutation({
+    mutationFn: (body: RegisterDeviceTokenBody) => registerDeviceToken(body),
+  });
+}

--- a/apps/web/src/shared/lib/DeviceTokenRegistrar.tsx
+++ b/apps/web/src/shared/lib/DeviceTokenRegistrar.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { useDeviceTokenRegistration } from "./use-device-token-registration";
+
+export function DeviceTokenRegistrar() {
+  useDeviceTokenRegistration();
+  return null;
+}

--- a/apps/web/src/shared/lib/app-webview-token.ts
+++ b/apps/web/src/shared/lib/app-webview-token.ts
@@ -1,0 +1,10 @@
+// 앱(RN WebView)이 UA에 붙이는 식별 토큰. 모바일 측 상수와 상호 참조:
+// apps/mobile/src/config/user-agent.ts (APP_USER_AGENT_SUFFIX = "BareunApp/1.0").
+export const APP_WEBVIEW_UA_TOKEN = "BareunApp";
+
+// 앱 딥링크 스킴. 모바일 측 상수와 상호 참조: apps/mobile/src/linking/deep-link.ts (APP_SCHEME).
+export const APP_DEEP_LINK_SCHEME = "bareun";
+
+export function isAppWebViewUserAgent(userAgent: string): boolean {
+  return userAgent.includes(APP_WEBVIEW_UA_TOKEN);
+}

--- a/apps/web/src/shared/lib/app-webview.ts
+++ b/apps/web/src/shared/lib/app-webview.ts
@@ -1,11 +1,10 @@
 import { headers } from "next/headers";
+import { isAppWebViewUserAgent } from "./app-webview-token";
 
-// 앱(RN WebView)이 UA에 붙이는 식별 토큰. 모바일 측 상수와 상호 참조:
-// apps/mobile/src/config/user-agent.ts (APP_USER_AGENT_SUFFIX = "BareunApp/1.0").
-export const APP_WEBVIEW_UA_TOKEN = "BareunApp";
+export { APP_WEBVIEW_UA_TOKEN } from "./app-webview-token";
 
 /** 현재 요청이 앱 WebView에서 온 요청인지 서버에서 판별한다(UA suffix 검사). */
 export async function getIsAppWebView(): Promise<boolean> {
   const userAgent = (await headers()).get("user-agent");
-  return userAgent?.includes(APP_WEBVIEW_UA_TOKEN) ?? false;
+  return userAgent !== null && isAppWebViewUserAgent(userAgent);
 }

--- a/apps/web/src/shared/lib/device-token-storage.ts
+++ b/apps/web/src/shared/lib/device-token-storage.ts
@@ -1,0 +1,37 @@
+const STORAGE_KEY = "bb.registeredDeviceToken";
+
+export interface RegisteredDeviceToken {
+  userId: string;
+  token: string;
+}
+
+export function loadRegisteredDeviceToken(): RegisteredDeviceToken | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof (parsed as RegisteredDeviceToken).userId === "string" &&
+      typeof (parsed as RegisteredDeviceToken).token === "string"
+    ) {
+      return parsed as RegisteredDeviceToken;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveRegisteredDeviceToken(entry: RegisteredDeviceToken): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+  } catch {}
+}
+
+export function clearRegisteredDeviceToken(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {}
+}

--- a/apps/web/src/shared/lib/use-device-token-registration.ts
+++ b/apps/web/src/shared/lib/use-device-token-registration.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import {
+  isBridgeAvailable,
+  sendToNative,
+  subscribeToNative,
+} from "@insurance/bridge/web";
+import { useAuthStatus } from "@/shared/api/use-auth-status";
+import { useRegisterDeviceToken } from "@/shared/api/use-register-device-token";
+
+const REGISTERED_TOKEN_STORAGE_KEY = "bb.registeredDeviceToken";
+
+export function useDeviceTokenRegistration() {
+  const auth = useAuthStatus();
+  const { mutate: registerDeviceToken } = useRegisterDeviceToken();
+  const requestedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isBridgeAvailable() || auth.status !== "authenticated") {
+      return;
+    }
+
+    const unsubscribe = subscribeToNative((message) => {
+      if (message.type !== "PUSH_TOKEN") {
+        return;
+      }
+      const { token, platform } = message.payload;
+      if (localStorage.getItem(REGISTERED_TOKEN_STORAGE_KEY) === token) {
+        return;
+      }
+      registerDeviceToken(
+        { token, platform: platform === "ios" ? "IOS" : "ANDROID" },
+        {
+          onSuccess: () => {
+            localStorage.setItem(REGISTERED_TOKEN_STORAGE_KEY, token);
+          },
+        },
+      );
+    });
+
+    sendToNative({ v: 1, type: "WEB_READY" });
+    if (!requestedRef.current) {
+      requestedRef.current = true;
+      sendToNative({ v: 1, type: "REQUEST_PUSH_TOKEN" });
+    }
+    return unsubscribe;
+  }, [auth.status, registerDeviceToken]);
+}

--- a/apps/web/src/shared/lib/use-device-token-registration.ts
+++ b/apps/web/src/shared/lib/use-device-token-registration.ts
@@ -8,8 +8,10 @@ import {
 } from "@insurance/bridge/web";
 import { useAuthStatus } from "@/shared/api/use-auth-status";
 import { useRegisterDeviceToken } from "@/shared/api/use-register-device-token";
-
-const REGISTERED_TOKEN_STORAGE_KEY = "bb.registeredDeviceToken";
+import {
+  loadRegisteredDeviceToken,
+  saveRegisteredDeviceToken,
+} from "./device-token-storage";
 
 export function useDeviceTokenRegistration() {
   const auth = useAuthStatus();
@@ -23,22 +25,21 @@ export function useDeviceTokenRegistration() {
       return;
     }
 
-    // 계정 전환 시에도 새 계정으로 등록되도록 요청 상태·저장 키를 사용자 단위로 분리.
-    const storageKey = `${REGISTERED_TOKEN_STORAGE_KEY}.${userId}`;
-
     const unsubscribe = subscribeToNative((message) => {
       if (message.type !== "PUSH_TOKEN") {
         return;
       }
       const { token, platform } = message.payload;
-      if (localStorage.getItem(storageKey) === token) {
+      // 계정 전환 시에도 새 계정으로 등록되도록 사용자+토큰 쌍으로 중복 판정.
+      const registered = loadRegisteredDeviceToken();
+      if (registered?.userId === userId && registered.token === token) {
         return;
       }
       registerDeviceToken(
         { token, platform: platform === "ios" ? "IOS" : "ANDROID" },
         {
           onSuccess: () => {
-            localStorage.setItem(storageKey, token);
+            saveRegisteredDeviceToken({ userId, token });
           },
         },
       );

--- a/apps/web/src/shared/lib/use-device-token-registration.ts
+++ b/apps/web/src/shared/lib/use-device-token-registration.ts
@@ -14,36 +14,41 @@ const REGISTERED_TOKEN_STORAGE_KEY = "bb.registeredDeviceToken";
 export function useDeviceTokenRegistration() {
   const auth = useAuthStatus();
   const { mutate: registerDeviceToken } = useRegisterDeviceToken();
-  const requestedRef = useRef(false);
+  const requestedUserIdRef = useRef<string | null>(null);
+
+  const userId = auth.status === "authenticated" ? auth.me.userId : null;
 
   useEffect(() => {
-    if (!isBridgeAvailable() || auth.status !== "authenticated") {
+    if (!isBridgeAvailable() || userId === null) {
       return;
     }
+
+    // 계정 전환 시에도 새 계정으로 등록되도록 요청 상태·저장 키를 사용자 단위로 분리.
+    const storageKey = `${REGISTERED_TOKEN_STORAGE_KEY}.${userId}`;
 
     const unsubscribe = subscribeToNative((message) => {
       if (message.type !== "PUSH_TOKEN") {
         return;
       }
       const { token, platform } = message.payload;
-      if (localStorage.getItem(REGISTERED_TOKEN_STORAGE_KEY) === token) {
+      if (localStorage.getItem(storageKey) === token) {
         return;
       }
       registerDeviceToken(
         { token, platform: platform === "ios" ? "IOS" : "ANDROID" },
         {
           onSuccess: () => {
-            localStorage.setItem(REGISTERED_TOKEN_STORAGE_KEY, token);
+            localStorage.setItem(storageKey, token);
           },
         },
       );
     });
 
     sendToNative({ v: 1, type: "WEB_READY" });
-    if (!requestedRef.current) {
-      requestedRef.current = true;
+    if (requestedUserIdRef.current !== userId) {
+      requestedUserIdRef.current = userId;
       sendToNative({ v: 1, type: "REQUEST_PUSH_TOKEN" });
     }
     return unsubscribe;
-  }, [auth.status, registerDeviceToken]);
+  }, [userId, registerDeviceToken]);
 }

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -1859,6 +1859,63 @@ export const handlers = [
     });
   }),
 
+  // 디바이스 토큰 등록 (이슈 #178)
+  http.post(`${API_BASE_URL}/users/me/device-tokens`, async ({ request }) => {
+    await delay(300);
+
+    if (request.headers.get("x-mock-failure") === "device-token") {
+      return HttpResponse.json(
+        { status: "500", code: "INTERNAL_SERVER_ERROR", message: "디바이스 토큰을 등록하지 못했습니다." },
+        { status: 500 },
+      );
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = (await request.json()) as Record<string, unknown>;
+    } catch {
+      return HttpResponse.json(
+        { status: "400", code: "INVALID_REQUEST", message: "입력 형식이 올바르지 않습니다." },
+        { status: 400 },
+      );
+    }
+
+    if (typeof body.token !== "string" || typeof body.platform !== "string") {
+      return HttpResponse.json(
+        { status: "400", code: "MISSING_REQUIRED_FIELD", message: "token과 platform은 필수입니다." },
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json({
+      status: "200",
+      message: "정상 처리되었습니다.",
+      data: camelToSnakeDeep({
+        id: "3f9f3f70-6a4b-4e6b-9a56-6f1d6c2f7d01",
+        platform: body.platform,
+        createdAt: "2026-07-26T09:00:00Z",
+      }),
+    });
+  }),
+
+  // 디바이스 토큰 해제 (이슈 #178)
+  http.delete(`${API_BASE_URL}/users/me/device-tokens`, async ({ request }) => {
+    await delay(300);
+
+    if (request.headers.get("x-mock-failure") === "device-token") {
+      return HttpResponse.json(
+        { status: "500", code: "INTERNAL_SERVER_ERROR", message: "디바이스 토큰을 해제하지 못했습니다." },
+        { status: 500 },
+      );
+    }
+
+    return HttpResponse.json({
+      status: "200",
+      message: "정상 처리되었습니다.",
+      data: null,
+    });
+  }),
+
   // 활동 카운트 (이슈 #105) — CONTRACT(명세없음-임시): GET /users/me/activity-summary
   http.get(`${API_BASE_URL}/users/me/activity-summary`, async ({ request }) => {
     await delay(300);

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -7,6 +7,7 @@ import {
   isLoggedOut,
   setLoggedOut,
 } from "@/shared/mocks/auth-token-state";
+import { registerDeviceTokenBodySchema } from "@/shared/model/device-token.schema";
 
 // 로드 시점 기준 상대 마감일(로컬 달력 날짜) — 대시보드 "오늘 마감/N일 남음" 검증용
 function addDays(base: Date, days: number): string {
@@ -1880,9 +1881,10 @@ export const handlers = [
       );
     }
 
-    if (typeof body.token !== "string" || typeof body.platform !== "string") {
+    const parsedBody = registerDeviceTokenBodySchema.safeParse(body);
+    if (!parsedBody.success) {
       return HttpResponse.json(
-        { status: "400", code: "MISSING_REQUIRED_FIELD", message: "token과 platform은 필수입니다." },
+        { status: "400", code: "VALIDATION_ERROR", message: "token·platform 값이 올바르지 않습니다." },
         { status: 400 },
       );
     }
@@ -1892,7 +1894,7 @@ export const handlers = [
       message: "정상 처리되었습니다.",
       data: camelToSnakeDeep({
         id: "3f9f3f70-6a4b-4e6b-9a56-6f1d6c2f7d01",
-        platform: body.platform,
+        platform: parsedBody.data.platform,
         createdAt: "2026-07-26T09:00:00Z",
       }),
     });

--- a/apps/web/src/shared/model/device-token.schema.ts
+++ b/apps/web/src/shared/model/device-token.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const deviceTokenPlatformSchema = z.enum(["ANDROID", "IOS", "WEB"]);
+
+export const deviceTokenSchema = z.object({
+  id: z.uuid(),
+  platform: z.string(),
+  createdAt: z.string(),
+});
+
+export const registerDeviceTokenBodySchema = z.object({
+  token: z.string().max(500),
+  platform: deviceTokenPlatformSchema,
+});
+
+export type DeviceTokenPlatform = z.infer<typeof deviceTokenPlatformSchema>;
+export type DeviceToken = z.infer<typeof deviceTokenSchema>;
+export type RegisterDeviceTokenBody = z.infer<typeof registerDeviceTokenBodySchema>;

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -11,7 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@insurance/shared": "workspace:*"
+    "@insurance/shared": "workspace:*",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^5.4.0"

--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "description": "웹 ↔ RN WebView 브릿지 (메시지 프로토콜 · 핸들러)",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./web": "./src/web.ts",
+    "./native": "./src/native.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './protocol';

--- a/packages/bridge/src/native.ts
+++ b/packages/bridge/src/native.ts
@@ -1,0 +1,21 @@
+import {
+  webToNativeMessageSchema,
+  type NativeToWebMessage,
+  type WebToNativeMessage,
+} from './protocol';
+
+export function parseWebMessage(data: string): WebToNativeMessage | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(data);
+  } catch {
+    return null;
+  }
+  const parsed = webToNativeMessageSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export function serializeToWeb(message: NativeToWebMessage): string {
+  const json = JSON.stringify(JSON.stringify(message));
+  return `window.dispatchEvent(new MessageEvent('message', { data: ${json} })); true;`;
+}

--- a/packages/bridge/src/protocol.ts
+++ b/packages/bridge/src/protocol.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+export const BRIDGE_PROTOCOL_VERSION = 1;
+
+export const webReadyMessageSchema = z.object({
+  v: z.literal(BRIDGE_PROTOCOL_VERSION),
+  type: z.literal('WEB_READY'),
+});
+
+export const requestPushTokenMessageSchema = z.object({
+  v: z.literal(BRIDGE_PROTOCOL_VERSION),
+  type: z.literal('REQUEST_PUSH_TOKEN'),
+});
+
+export const pushTokenMessageSchema = z.object({
+  v: z.literal(BRIDGE_PROTOCOL_VERSION),
+  type: z.literal('PUSH_TOKEN'),
+  payload: z.object({
+    token: z.string(),
+    platform: z.enum(['ios', 'android']),
+    tokenType: z.enum(['expo', 'device']),
+  }),
+});
+
+export const webToNativeMessageSchema = z.discriminatedUnion('type', [
+  webReadyMessageSchema,
+  requestPushTokenMessageSchema,
+]);
+
+export const nativeToWebMessageSchema = z.discriminatedUnion('type', [pushTokenMessageSchema]);
+
+export type WebToNativeMessage = z.infer<typeof webToNativeMessageSchema>;
+export type NativeToWebMessage = z.infer<typeof nativeToWebMessageSchema>;

--- a/packages/bridge/src/web.ts
+++ b/packages/bridge/src/web.ts
@@ -1,0 +1,47 @@
+import {
+  nativeToWebMessageSchema,
+  type NativeToWebMessage,
+  type WebToNativeMessage,
+} from './protocol';
+
+interface ReactNativeWebViewHandle {
+  postMessage: (message: string) => void;
+}
+
+declare global {
+  interface Window {
+    ReactNativeWebView?: ReactNativeWebViewHandle;
+  }
+}
+
+export function isBridgeAvailable(): boolean {
+  return typeof window !== 'undefined' && window.ReactNativeWebView != null;
+}
+
+export function sendToNative(message: WebToNativeMessage): void {
+  window.ReactNativeWebView?.postMessage(JSON.stringify(message));
+}
+
+export function subscribeToNative(onMessage: (message: NativeToWebMessage) => void): () => void {
+  const listener = (event: MessageEvent) => {
+    if (typeof event.data !== 'string') {
+      return;
+    }
+    let raw: unknown;
+    try {
+      raw = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+    const parsed = nativeToWebMessageSchema.safeParse(raw);
+    if (parsed.success) {
+      onMessage(parsed.data);
+    }
+  };
+  window.addEventListener('message', listener);
+  document.addEventListener('message', listener as EventListener);
+  return () => {
+    window.removeEventListener('message', listener);
+    document.removeEventListener('message', listener as EventListener);
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       expo:
         specifier: ~54.0.35
         version: 54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-linking:
+        specifier: ~8.0.12
+        version: 8.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)
@@ -71,7 +74,7 @@ importers:
         version: 2.1.1
       next:
         specifier: ^16.2.7
-        version: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -108,7 +111,7 @@ importers:
         version: 10.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       '@storybook/nextjs-vite':
         specifier: 10.4.4
-        version: 10.4.4(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 10.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(next@16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -2860,6 +2863,12 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-linking@8.0.12:
+    resolution: {integrity: sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   expo-modules-autolinking@3.0.26:
     resolution: {integrity: sha512-WOaud6UKg16ciCOj8raKcMOoKFMHLXKI29U29yhgu1lf+Y7VxJyCktUcYo6AM+ccZ7zLD1uWZdMtgnpf+95OXA==}
@@ -6523,18 +6532,18 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@storybook/nextjs-vite@10.4.4(@babel/core@7.29.7)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@storybook/nextjs-vite@10.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(next@16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@storybook/builder-vite': 10.4.4(esbuild@0.27.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       '@storybook/react': 10.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       '@storybook/react-vite': 10.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.27.7)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
-      next: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       storybook: 10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
       vite: 8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
-      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vite-plugin-storybook-nextjs: 3.3.0(next@16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -7438,6 +7447,16 @@ snapshots:
     dependencies:
       expo: 54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       react: 19.1.0
+
+  expo-linking@8.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - expo
+      - supports-color
 
   expo-modules-autolinking@3.0.26:
     dependencies:
@@ -8385,7 +8404,7 @@ snapshots:
 
   nested-error-stacks@2.0.1: {}
 
-  next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.2.7
       '@swc/helpers': 0.5.15
@@ -8394,7 +8413,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.7
       '@next/swc-darwin-x64': 16.2.7
@@ -9115,12 +9134,10 @@ snapshots:
 
   structured-headers@0.4.1: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.7):
+  styled-jsx@5.1.6(react@19.2.7):
     dependencies:
       client-only: 0.0.1
       react: 19.2.7
-    optionalDependencies:
-      '@babel/core': 7.29.7
 
   sucrase@3.35.1:
     dependencies:
@@ -9318,13 +9335,13 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  vite-plugin-storybook-nextjs@3.3.0(next@16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
+  vite-plugin-storybook-nextjs@3.3.0(next@16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)(vite@8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.2.7(@babel/core@7.29.7)(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      next: 16.2.7(@playwright/test@1.61.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       storybook: 10.4.4(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       ts-dedent: 2.3.0
       vite: 8.0.16(@types/node@20.19.42)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@insurance/bridge':
+        specifier: workspace:*
+        version: link:../../packages/bridge
       expo:
         specifier: ~54.0.35
         version: 54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)
+      expo-web-browser:
+        specifier: ~15.0.11
+        version: 15.0.11(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -2957,6 +2960,12 @@ packages:
     resolution: {integrity: sha512-xyYyVg6V1/SSOZWh4Ni3U129XHCnFHBTcUo0dhWtFDrZbNp/duw5AGsQfb2sVeU0gxWHXSY1+5F0jnKYC7WuOw==}
     peerDependencies:
       react: '*'
+      react-native: '*'
+
+  expo-web-browser@15.0.11:
+    resolution: {integrity: sha512-r2LS4Ro6DgUPZkcaEfgt8mp9eJuoA93x11Jh7S6utFe0FEzvUNn2yFhxg8XVwESaaHGt2k5V8LuK36rsp0BeIw==}
+    peerDependencies:
+      expo: '*'
       react-native: '*'
 
   expo@54.0.35:
@@ -7715,6 +7724,11 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)
+
+  expo-web-browser@15.0.11(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0)):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0)
 
   expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@insurance/shared':
         specifier: workspace:*
         version: link:../shared
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       typescript:
         specifier: ^5.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,15 @@ importers:
       expo:
         specifier: ~54.0.35
         version: 54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-constants:
+        specifier: ~18.0.13
+        version: 18.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))
       expo-linking:
         specifier: ~8.0.12
         version: 8.0.12(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)
+      expo-notifications:
+        specifier: ~0.32.17
+        version: 0.32.17(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)
@@ -978,6 +984,9 @@ packages:
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2339,6 +2348,9 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2349,6 +2361,10 @@ packages:
 
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   axe-core@4.12.0:
     resolution: {integrity: sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==}
@@ -2417,6 +2433,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -2500,6 +2519,18 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -2703,6 +2734,10 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
@@ -2710,6 +2745,10 @@ packages:
   define-lazy-prop@3.0.0:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2748,6 +2787,10 @@ packages:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2783,8 +2826,16 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.27.7:
@@ -2835,6 +2886,11 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  expo-application@7.0.8:
+    resolution: {integrity: sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==}
+    peerDependencies:
+      expo: '*'
+
   expo-asset@12.0.13:
     resolution: {integrity: sha512-x/p7WvQUnkn6K43b9eL6SPeq5Vnf1E8BDe9bDrWrvMqzyUvJnUFvl+ctg3034s/+UHe7Ne2pAmc0+yzbl8CrDQ==}
     peerDependencies:
@@ -2880,6 +2936,13 @@ packages:
   expo-modules-core@3.0.30:
     resolution: {integrity: sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-notifications@0.32.17:
+    resolution: {integrity: sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -2964,6 +3027,10 @@ packages:
   fontkit@2.0.4:
     resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   freeport-async@2.0.0:
     resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
     engines: {node: '>=8'}
@@ -2988,6 +3055,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2996,9 +3067,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
@@ -3015,6 +3094,10 @@ packages:
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -3029,6 +3112,17 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
@@ -3114,6 +3208,14 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
@@ -3132,10 +3234,18 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
     hasBin: true
+
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
 
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
@@ -3143,6 +3253,14 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
@@ -3377,6 +3495,10 @@ packages:
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   media-engine@1.0.3:
     resolution: {integrity: sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==}
@@ -3667,6 +3789,18 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -3819,6 +3953,10 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -4064,6 +4202,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -4100,6 +4242,10 @@ packages:
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -4456,6 +4602,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -4557,6 +4706,10 @@ packages:
   whatwg-url-without-unicode@8.0.0-3:
     resolution: {integrity: sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==}
     engines: {node: '>=10'}
+
+  which-typed-array@1.1.22:
+    resolution: {integrity: sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5699,6 +5852,8 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.79.0(react@19.2.7)
+
+  '@ide/backoff@1.0.0': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -6908,6 +7063,14 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   assertion-error@2.0.1: {}
 
   ast-types@0.16.1:
@@ -6915,6 +7078,10 @@ snapshots:
       tslib: 2.8.1
 
   async-limiter@1.0.1: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   axe-core@4.12.0: {}
 
@@ -7045,6 +7212,8 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
 
+  badgin@1.2.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -7126,6 +7295,23 @@ snapshots:
       run-applescript: 7.1.0
 
   bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase@5.3.1: {}
 
@@ -7308,9 +7494,21 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   depd@2.0.0: {}
 
@@ -7335,6 +7533,12 @@ snapshots:
       dotenv: 16.4.7
 
   dotenv@16.4.7: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
 
   ee-first@1.1.1: {}
 
@@ -7361,7 +7565,13 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -7413,6 +7623,10 @@ snapshots:
   event-target-shim@5.0.1: {}
 
   events@3.3.0: {}
+
+  expo-application@7.0.8(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-asset@12.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:
@@ -7474,6 +7688,22 @@ snapshots:
       invariant: 2.2.4
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0)
+
+  expo-notifications@0.32.17(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+    dependencies:
+      '@expo/image-utils': 0.8.14(typescript@5.9.3)
+      '@ide/backoff': 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-application: 7.0.8(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
+      expo-constants: 18.0.13(expo@54.0.35(@babel/core@7.29.7)(graphql@16.14.1)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   expo-server@1.0.7: {}
 
@@ -7582,6 +7812,10 @@ snapshots:
       unicode-properties: 1.4.1
       unicode-trie: 2.0.0
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
@@ -7596,11 +7830,31 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   getenv@2.0.0: {}
 
@@ -7621,6 +7875,8 @@ snapshots:
 
   globrex@0.1.2: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphql@16.14.1: {}
@@ -7628,6 +7884,16 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.4:
     dependencies:
@@ -7710,6 +7976,13 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.4
@@ -7720,13 +7993,37 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.22
 
   is-url@1.2.4: {}
 
@@ -7957,6 +8254,8 @@ snapshots:
       tmpl: 1.0.5
 
   marky@1.3.0: {}
+
+  math-intrinsics@1.1.0: {}
 
   media-engine@1.0.3: {}
 
@@ -8464,6 +8763,22 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -8650,6 +8965,8 @@ snapshots:
       fflate: 0.8.3
 
   pngjs@3.4.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
 
@@ -8948,6 +9265,12 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   sax@1.6.0: {}
 
   scheduler@0.25.0-rc-603e6108-20241029: {}
@@ -8990,6 +9313,15 @@ snapshots:
       - supports-color
 
   set-cookie-parser@3.1.0: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 
@@ -9324,6 +9656,14 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.22
+
   utils-merge@1.0.1: {}
 
   uuid@7.0.3: {}
@@ -9400,6 +9740,16 @@ snapshots:
       buffer: 5.7.1
       punycode: 2.3.1
       webidl-conversions: 5.0.0
+
+  which-typed-array@1.1.22:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #178

---

## ✅ 작업 내용

RN 웹뷰 래퍼(`apps/mobile`)에 **스토어 제출 전 필요한 네이티브 연동**을 구현했습니다.

이번 PR에서는 아래 기능을 추가했습니다.

- 로그인 세션 유지
- 외부 링크 및 소셜 로그인 처리
- 파일 업로드 권한
- 딥링크(`bareun://`)
- 웹 ↔ 네이티브 브릿지
- 푸시 알림(토큰 발급 및 웹 등록)

> 앱 아이덴티티(bundleIdentifier, package), EAS 설정 및 실제 배포는 후속 이슈에서 진행합니다.

---

## 1. 로그인 세션 유지 및 iOS 제스처

### 로그인 세션 유지

웹뷰 쿠키를 시스템 쿠키 저장소와 공유하도록 설정했습니다.

- iOS: `sharedCookiesEnabled`
- Android: `thirdPartyCookiesEnabled`

덕분에 백엔드에서 내려주는 HttpOnly `access` / `refresh` 쿠키가 유지되어 앱을 종료했다가 다시 실행해도 로그인 상태가 유지됩니다.

### iOS 스와이프 뒤로가기

`allowsBackForwardNavigationGestures`를 적용해 Safari처럼 스와이프로 뒤로 갈 수 있도록 했습니다.

---

## 2. 외부 링크 및 소셜 로그인

웹뷰에서 열어야 하는 도메인과 외부 브라우저로 보내야 하는 링크를 분리했습니다.

### 웹뷰에서 유지

- 서비스 도메인
- 카카오 OAuth
- 네이버 OAuth

### 기본 브라우저에서 열기

- 그 외 모든 http(s) 링크
- `tel:`
- `mailto:`
- 기타 커스텀 스킴

판별 로직은 순수 함수로 분리했고, **메인 프레임 요청만 검사**하도록 해 iframe 요청이 잘못 차단되지 않도록 했습니다.

```ts
export function createLoadDecider(...) {
  return function decideLoad(...) {
    // allow
    // open-external
    // open-auth-session
  };
}
```

### 구현 내용

- `allowed-hosts.ts`
  - 서비스 도메인 및 OAuth 허용 호스트 관리
- `create-should-start-load.ts`
  - 웹뷰/외부 브라우저 분기 처리

현재 카카오·네이버 로그인은 **웹뷰 안에서 OAuth → 토큰 교환 → 세션 쿠키 저장까지 모두 완료**됩니다.

---

## 3. 외부 브라우저 OAuth 대응 (현재 비활성)

향후 **구글 로그인(disallowed_useragent)** 처럼 웹뷰 로그인이 막히는 제공자를 위해 우회 경로를 미리 구현했습니다.

현재는

```ts
EXTERNAL_AUTH_HOSTS = []
```

상태라 실제로는 동작하지 않습니다.

필요 시 호스트만 추가하면 바로 활성화됩니다.

동작 흐름은 아래와 같습니다.

```
WebView
   ↓
외부 브라우저 OAuth
   ↓
OAuth Callback
   ↓
bareun://...
   ↓
앱
   ↓
WebView
   ↓
토큰 교환
```

이렇게 토큰 교환을 **웹뷰 안에서 수행**하기 때문에 세션 쿠키도 올바른 저장소에 남습니다.

### 구현 내용

- 앱 웹뷰에서 로그인 시작 시 `state`에 `app.` 접두어 추가
- OAuth Callback에서 앱 복귀 시 딥링크로 바운스
- 앱 전용 UA 토큰 및 딥링크 상수 분리

---

## 4. 파일 업로드 권한

웹뷰의 `<input type="file">`가 정상 동작하도록 권한을 추가했습니다.

### Android

- CAMERA
- READ_MEDIA_IMAGES
- READ_EXTERNAL_STORAGE

### iOS

- Photo Library
- Camera
- Microphone

`react-native-webview`가 파일 선택과 카메라 인텐트를 자체 지원하므로 `expo-image-picker`는 사용하지 않았습니다.

---

## 5. 딥링크

앱 스킴을 등록했습니다.

```
bareun://
```

수신한 딥링크를 서비스 웹 URL로 변환해 웹뷰를 이동시킵니다.

지원 범위

- 앱 최초 실행(getInitialURL)
- 실행 중(addEventListener)
- 초기 URL 중복 처리 방지

---

## 6. 웹 ↔ 네이티브 브릿지

비어 있던 `packages/bridge`를 구현했습니다.

zod의 discriminated union 기반 프로토콜을 사용하며,

- 버전(`v:1`)
- `safeParse`

를 통해 알 수 없는 메시지는 안전하게 무시합니다.

### 프로토콜

#### Web → Native

- `WEB_READY`
- `REQUEST_PUSH_TOKEN`

#### Native → Web

- `PUSH_TOKEN`

```ts
{
  token,
  platform,
  tokenType,
}
```

### 구현 내용

- `web.ts`
  - sendToNative
  - subscribeToNative
  - isBridgeAvailable

- `native.ts`
  - parseWebMessage
  - serializeToWeb

DOM 타입 의존성을 없애기 위해 web/native export도 분리했습니다.

---

## 7. 푸시 알림

### Native

웹에서 `REQUEST_PUSH_TOKEN`을 보내면

1. 권한 요청
2. Expo Push Token 발급
3. 웹으로 전달

순서로 동작합니다.

또한

- Android Notification Channel
- Foreground Notification Handler

도 함께 등록했습니다.

알림을 눌렀을 때

```
data.deepLink
```

를 웹 URL로 변환해 해당 화면으로 이동합니다.

앱이 종료된 상태에서 알림으로 실행되는 경우도 처리했습니다.

### Web

아래 조건에서만 토큰을 요청합니다.

- 앱 웹뷰
- 로그인 완료

전달받은 토큰은

```
POST /users/me/device-tokens
```

로 등록합니다.

기존 `fetchJson` 인프라(쿠키 인증, 토큰 재발급, zod 검증 등)를 그대로 재사용했습니다.

### 구현 내용

- Device Token API 추가
- MSW Mock 추가
- `use-device-token-registration`
- `DeviceTokenRegistrar`

---

## 🧪 테스트

네이티브 기능은 Playwright에서 검증하기 어려워 실기기 테스트 대상으로 정리했습니다.

- ✅ bridge typecheck
- ✅ mobile typecheck
- ✅ web typecheck
- ✅ web lint

| 확인 항목 | 방법 |
| --- | --- |
| 로그인 후 앱 재실행 시 세션 유지 | 실기기 |
| 외부 링크가 기본 브라우저에서 열림 | 실기기 |
| 카카오·네이버 로그인 | 실기기 |
| 사진 첨부(카메라/갤러리) | Dev Build |
| `bareun://notifications` 딥링크 | 에뮬레이터 |
| 푸시 토큰 등록 및 알림 이동 | Dev Build + EAS projectId |

