### PR TITLE
[Fix] 로그인 상태 로고 클릭 시 랜딩 경유 깜빡임 제거 및 회원가입 가드 추가(web)

### DIFF
--- a/apps/web/e2e/_capture-185.spec.ts
+++ b/apps/web/e2e/_capture-185.spec.ts
@@ -1,0 +1,32 @@
+import { test } from "@playwright/test";
+import { hideQueryDevtools } from "./_region-helpers";
+
+/** PR 스크린샷 캡처 헬퍼(#185). 테스트 아님 — CI 제외(testIgnore). */
+
+const DIR = "../../.pr-assets/issue-185";
+
+const DESKTOP = { width: 1280, height: 900 };
+
+test.beforeEach(async ({ page }) => {
+  await hideQueryDevtools(page);
+  await page.setViewportSize(DESKTOP);
+});
+
+test("01 고객 헤더 — 로고가 대시보드로 연결", async ({ page }) => {
+  await page.goto("/customer/dashboard");
+  await page.getByRole("link", { name: "바른보상" }).first().waitFor();
+  await page.locator("header").screenshot({ path: `${DIR}/01-customer-header.png` });
+});
+
+test("02 파트너 헤더 — 로고가 파트너 홈으로 연결", async ({ page }) => {
+  await page.goto("/partner");
+  await page.getByRole("link", { name: /바른보상/ }).first().waitFor();
+  await page.locator("header").screenshot({ path: `${DIR}/02-partner-header.png` });
+});
+
+test("03 로그인 상태 /signup 진입 — 대시보드 도착", async ({ page }) => {
+  await page.goto("/signup");
+  await page.waitForURL(/\/customer\/dashboard/);
+  await page.getByText("윤서").first().waitFor();
+  await page.screenshot({ path: `${DIR}/03-signup-guard-redirect.png` });
+});

--- a/apps/web/e2e/dashboard.spec.ts
+++ b/apps/web/e2e/dashboard.spec.ts
@@ -106,3 +106,14 @@ test("전부 종료: 진행 중 분석·제안이 없으면 타임라인·제안
     page.getByRole("heading", { name: "내 분석 리포트" }).filter({ visible: true }),
   ).toBeVisible();
 });
+
+test("헤더 로고를 누르면 랜딩을 거치지 않고 대시보드에 머문다", async ({ page }) => {
+  await page.goto(PATH);
+
+  const logo = page.locator("header").getByRole("link", { name: "바른보상" });
+  await expect(logo).toHaveAttribute("href", "/customer/dashboard");
+  await expect(async () => {
+    await logo.click();
+    await expect(page).toHaveURL(/\/customer\/dashboard/);
+  }).toPass({ timeout: 10000 });
+});

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -81,6 +81,8 @@ test("기존 회원 콜백이면 홈으로 이동하고 로그인 흔적이 저�
 });
 
 test("신규 회원 콜백이면 회원가입으로 이동한다", async ({ page }) => {
+  // 신규 회원은 아직 비로그인 — /signup 로그인 가드(#185)에 걸리지 않도록 시나리오 주입.
+  await page.setExtraHTTPHeaders(UNAUTH_HEADER);
   await page.goto("/login/oauth2/code/kakao?code=new&state=s1");
 
   await expect(page).toHaveURL(/\/signup/, { timeout: 15000 });

--- a/apps/web/e2e/partner-dashboard-mobile.spec.ts
+++ b/apps/web/e2e/partner-dashboard-mobile.spec.ts
@@ -97,3 +97,14 @@ test("대시보드 요약 로드에 실패하면 섹션 에러가 표시된다",
     page.getByRole("button", { name: "다시 시도" }).filter({ visible: true }),
   ).toBeVisible();
 });
+
+test("헤더 로고를 누르면 랜딩을 거치지 않고 파트너 홈에 머문다", async ({ page }) => {
+  await page.goto(PATH);
+
+  const logo = page.locator("header").getByRole("link", { name: /바른보상/ });
+  await expect(logo).toHaveAttribute("href", "/partner");
+  await expect(async () => {
+    await logo.click();
+    await expect(page).toHaveURL(/\/partner$/);
+  }).toPass({ timeout: 10000 });
+});

--- a/apps/web/e2e/signup.spec.ts
+++ b/apps/web/e2e/signup.spec.ts
@@ -10,6 +10,8 @@ import { hideQueryDevtools, selectRegion } from "./_region-helpers";
  * 응답은 기본 MSW 핸들러(POST /auth/register: 성공 201 + 토큰)가 제공.
  *   소셜 컨텍스트(socialToken/nickname/email)는 진입 쿼리로 주입(개발·E2E 경로) —
  *   컨텍스트 없이 직접 진입하면 /login으로 가드되므로 mock 폴백 없음.
+ * 로그인 가드(#185): 가입자는 비로그인이 정상 흐름 — 기본 MSW /users/me가 로그인 유저를
+ *   반환하므로 beforeEach에서 비로그인 시나리오 헤더를 주입한다(로그인 상태 진입 테스트만 예외).
  * DUPLICATE_RESOURCE는 nickname "중복닉네임" 진입 쿼리로 MSW 409 분기를 태워 검증(핸들러 override 대체).
  * 필드 형식·범위(닉네임 2~20자 등) 검증은 zod·MSW 계약에 위임(미테스트).
  */
@@ -50,6 +52,7 @@ async function fillIdentity(page: Page) {
 
 test.beforeEach(async ({ page }) => {
   await hideQueryDevtools(page);
+  await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
 });
 
 test("역할·약관 동의·본인 확인을 마치고 가입하면 완료 화면과 대시보드 이동 버튼이 보인다", async ({ page }) => {
@@ -65,6 +68,8 @@ test("역할·약관 동의·본인 확인을 마치고 가입하면 완료 화�
 
   const startButton = page.getByRole("button", { name: "보상 분석 시작" });
   await expect(startButton).toBeVisible();
+  // 가입 성공으로 로그인된 상태를 반영 — 이후 대시보드 진입이 가드에 막히지 않도록 헤더 해제.
+  await page.setExtraHTTPHeaders({});
   await expect(async () => {
     await startButton.click();
     await expect(page).toHaveURL(/\/customer\/dashboard/);
@@ -143,13 +148,18 @@ test("약관 동의 없이 본인 확인 단계로 직접 진입하면 첫 단�
 });
 
 test("소셜 인증 컨텍스트 없이 직접 진입하면 로그인으로 되돌아간다", async ({ page }) => {
-  // 로그인 화면은 비로그인 유저에게만 보인다(#108 접근 제한 가드). 기본 MSW의 /users/me는
-  // 로그인 유저를 반환하므로 비로그인 시나리오를 헤더로 주입한다.
-  await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
   await page.goto("/signup");
 
   await expect(page).toHaveURL(/\/login/, { timeout: 15000 });
   await expect(page.getByRole("heading", { name: "바른보상 시작하기" })).toBeVisible();
+});
+
+test("로그인 상태로 진입하면 역할별 홈으로 이동한다", async ({ page }) => {
+  // 기본 MSW /users/me = 로그인 유저(윤서, insured_person) — 비로그인 헤더 해제로 복원.
+  await page.setExtraHTTPHeaders({});
+  await page.goto("/signup");
+
+  await expect(page).toHaveURL(/\/customer\/dashboard/, { timeout: 15000 });
 });
 
 test("손해사정사를 선택하고 시작하면 자격 인증 안내가 노출된다", async ({ page }) => {

--- a/apps/web/src/app/(auth)/signup/_components/SignupRedirectGate.tsx
+++ b/apps/web/src/app/(auth)/signup/_components/SignupRedirectGate.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useSignupRedirect } from "../_hooks/use-signup-redirect";
+
+/**
+ * 인증 판별 client 래퍼. 로그인 유저는 홈으로 보내는 동안 가입 화면을 숨기고,
+ * 미인증(401·기타 에러 fail-open)일 때만 가입 퍼널을 표시한다.
+ */
+export function SignupRedirectGate({ children }: { children: ReactNode }) {
+  const status = useSignupRedirect();
+
+  if (status !== "unauthenticated") return null;
+
+  return <>{children}</>;
+}

--- a/apps/web/src/app/(auth)/signup/_hooks/use-signup-redirect.ts
+++ b/apps/web/src/app/(auth)/signup/_hooks/use-signup-redirect.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuthStatus } from "@/shared/api/use-auth-status";
+import { homePathByUserType } from "@/shared/model/home-path";
+
+/**
+ * 로그인 상태면 userType별 홈으로 replace. 반환값으로 가입 화면 표시 여부 판단.
+ * - "loading": 판별 중 → 가입 화면 숨김(깜빡임 방지)
+ * - "authenticated": 리다이렉트 진행 → 가입 화면 숨김
+ * - "unauthenticated"(401·기타 에러 fail-open): 가입 화면 표시
+ */
+export function useSignupRedirect() {
+  const router = useRouter();
+  const auth = useAuthStatus();
+
+  useEffect(() => {
+    if (auth.status !== "authenticated") return;
+    router.replace(homePathByUserType(auth.me.userType));
+  }, [auth, router]);
+
+  return auth.status;
+}

--- a/apps/web/src/app/(auth)/signup/_hooks/use-signup-redirect.ts
+++ b/apps/web/src/app/(auth)/signup/_hooks/use-signup-redirect.ts
@@ -1,24 +1,33 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuthStatus } from "@/shared/api/use-auth-status";
 import { homePathByUserType } from "@/shared/model/home-path";
 
 /**
- * 로그인 상태면 userType별 홈으로 replace. 반환값으로 가입 화면 표시 여부 판단.
+ * 진입 시점에 로그인 상태면 userType별 홈으로 replace. 반환값으로 가입 화면 표시 여부 판단.
  * - "loading": 판별 중 → 가입 화면 숨김(깜빡임 방지)
  * - "authenticated": 리다이렉트 진행 → 가입 화면 숨김
  * - "unauthenticated"(401·기타 에러 fail-open): 가입 화면 표시
+ *
+ * 판정은 최초 1회로 고정한다 — 가입 성공 시 users.me 갱신으로 로그인 상태가 되어도
+ * 완료 화면이 홈으로 이탈하지 않도록.
  */
 export function useSignupRedirect() {
   const router = useRouter();
   const auth = useAuthStatus();
+  const [entryStatus, setEntryStatus] = useState<
+    "loading" | "authenticated" | "unauthenticated"
+  >("loading");
 
   useEffect(() => {
-    if (auth.status !== "authenticated") return;
-    router.replace(homePathByUserType(auth.me.userType));
-  }, [auth, router]);
+    if (entryStatus !== "loading" || auth.status === "loading") return;
+    setEntryStatus(auth.status);
+    if (auth.status === "authenticated") {
+      router.replace(homePathByUserType(auth.me.userType));
+    }
+  }, [auth, entryStatus, router]);
 
-  return auth.status;
+  return entryStatus;
 }

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -13,6 +13,7 @@ import { ConsentStep } from "./_components/ConsentStep";
 import { IdentityStep } from "./_components/IdentityStep";
 import { RoleSelectStep } from "./_components/RoleSelectStep";
 import { SignupProgress } from "./_components/SignupProgress";
+import { SignupRedirectGate } from "./_components/SignupRedirectGate";
 import { useSignupFunnel, type SignupStep } from "./_hooks/use-signup-funnel";
 import { useSignupSocial } from "./_hooks/use-signup-social";
 import { isRequiredConsentMet, type ConsentState } from "./_model/consent-config";
@@ -207,8 +208,10 @@ function SignupFunnel() {
 
 export default function SignupPage() {
   return (
-    <Suspense fallback={null}>
-      <SignupFunnel />
-    </Suspense>
+    <SignupRedirectGate>
+      <Suspense fallback={null}>
+        <SignupFunnel />
+      </Suspense>
+    </SignupRedirectGate>
   );
 }

--- a/apps/web/src/app/(public)/_components/PublicChromeGate.tsx
+++ b/apps/web/src/app/(public)/_components/PublicChromeGate.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { LandingRedirectGate } from "./LandingRedirectGate";
+
+/**
+ * (public) 레이아웃 래퍼. 랜딩(/)에서만 헤더·푸터까지 인증 게이트로 감싸
+ * 로그인 유저 리다이렉트 중 온보딩 화면이 비치는 깜빡임을 막는다.
+ * 그 외 공개 페이지(about·guide·terms·privacy)는 로그인 여부와 무관하게 즉시 표시.
+ */
+export function PublicChromeGate({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+
+  if (pathname !== "/") return <>{children}</>;
+
+  return <LandingRedirectGate>{children}</LandingRedirectGate>;
+}

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -2,15 +2,18 @@ import type { ReactNode } from "react";
 import { getIsAppWebView } from "@/shared/lib/app-webview";
 import { LandingFooter } from "./_components/LandingFooter";
 import { LandingHeader } from "./_components/LandingHeader";
+import { PublicChromeGate } from "./_components/PublicChromeGate";
 
 export default async function PublicLayout({ children }: { children: ReactNode }) {
   const isApp = await getIsAppWebView();
 
   return (
-    <div className="flex min-h-dvh flex-col bg-paper">
-      {!isApp && <LandingHeader />}
-      <main className="flex-1">{children}</main>
-      {!isApp && <LandingFooter />}
-    </div>
+    <PublicChromeGate>
+      <div className="flex min-h-dvh flex-col bg-paper">
+        {!isApp && <LandingHeader />}
+        <main className="flex-1">{children}</main>
+        {!isApp && <LandingFooter />}
+      </div>
+    </PublicChromeGate>
   );
 }

--- a/apps/web/src/app/(public)/page.tsx
+++ b/apps/web/src/app/(public)/page.tsx
@@ -4,7 +4,6 @@ import { ArrowRight } from "@/shared/ui/icons/ArrowRight";
 import { CtaBandSection } from "./_components/CtaBandSection";
 import { HeroSection } from "./_components/HeroSection";
 import { HowItWorksSection } from "./_components/HowItWorksSection";
-import { LandingRedirectGate } from "./_components/LandingRedirectGate";
 import { MobileFeatureCards } from "./_components/MobileFeatureCards";
 import { MobileHero } from "./_components/MobileHero";
 import { ReportTypesSection } from "./_components/ReportTypesSection";
@@ -12,7 +11,7 @@ import { ReportTypesSection } from "./_components/ReportTypesSection";
 /** 온보딩(랜딩) 페이지. md↑ PC 시안 / md↓ 모바일 시안(문구가 다른 별도 변형). */
 export default function HomePage() {
   return (
-    <LandingRedirectGate>
+    <>
       <div className="hidden md:block">
         <HeroSection />
         <HowItWorksSection />
@@ -39,6 +38,6 @@ export default function HomePage() {
           </Link>
         </div>
       </div>
-    </LandingRedirectGate>
+    </>
   );
 }

--- a/apps/web/src/app/partner/_components/PartnerHeader.tsx
+++ b/apps/web/src/app/partner/_components/PartnerHeader.tsx
@@ -22,7 +22,10 @@ export function PartnerHeader() {
     <header className="sticky top-0 z-40 border-b border-line bg-card">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
         <div className="flex items-center gap-8">
-          <Link href="/" className="flex items-center gap-2 font-serif text-xl font-bold text-navy">
+          <Link
+            href="/partner"
+            className="flex items-center gap-2 font-serif text-xl font-bold text-navy"
+          >
             <Scale className="text-2xl text-gold" />
             바른보상
             <span className="rounded-pill bg-gold px-2 py-0.5 font-sans text-xs font-semibold text-white">

--- a/apps/web/src/shared/ui/CustomerHeader.tsx
+++ b/apps/web/src/shared/ui/CustomerHeader.tsx
@@ -20,7 +20,10 @@ export function CustomerHeader() {
     <header className="sticky top-0 z-40 border-b border-line bg-card">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
         <div className="flex items-center gap-8">
-          <Link href="/" className="flex items-center gap-2 font-serif text-xl font-bold text-navy">
+          <Link
+            href="/customer/dashboard"
+            className="flex items-center gap-2 font-serif text-xl font-bold text-navy"
+          >
             <Scale className="text-2xl text-gold" />
             바른보상
           </Link>


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #185

## ✅ 작업 내용

### 로그인 상태에서 로고를 눌러도 랜딩을 거치지 않게 하고, 회원가입에 로그인 가드를 추가했습니다

고객·파트너 헤더의 로고가 `/`로 연결돼 있어 로그인 상태에서 누르면 랜딩을 경유하며 온보딩 화면이 잠깐 비치던 문제를 로고 목적지 변경 + 랜딩 레이아웃 게이트로 제거했고, `/login`에만 있던 로그인 상태 진입 가드를 `/signup`에도 동일 정책으로 추가했습니다.

<br/>

### 1. 헤더 로고 목적지를 역할별 홈으로 변경

로그인 사용자가 로고를 누르면 랜딩(`/`)으로 갔다가 `LandingRedirectGate`가 되돌리던 왕복 자체를 없앴습니다. `CustomerHeader` 로고는 `/customer/dashboard`, `PartnerHeader` 로고는 `/partner`로 바로 이동합니다.

| 고객 헤더 | 파트너 헤더 |
| --- | --- |
| <img alt="customer-header" width="560" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/e06931d777db83120908dd9e58695528b3d5ba49/.pr-assets/issue-185/01-customer-header.png" /> | <img alt="partner-header" width="560" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/e06931d777db83120908dd9e58695528b3d5ba49/.pr-assets/issue-185/02-partner-header.png" /> |

<br/>

### 2. 랜딩 직접 진입 시 레이아웃까지 숨겨 깜빡임 제거

기존 `LandingRedirectGate`는 페이지 콘텐츠만 감싸서, 리다이렉트 중에도 `(public)` 레이아웃의 랜딩 헤더·푸터가 그대로 렌더돼 깜빡임이 남았습니다. 게이트를 레이아웃 레벨로 올리는 `PublicChromeGate`를 추가해 랜딩에서만 헤더·푸터까지 인증 판별 동안 숨깁니다.

```tsx
// app/(public)/_components/PublicChromeGate.tsx
export function PublicChromeGate({ children }: { children: ReactNode }) {
  const pathname = usePathname();

  if (pathname !== "/") return <>{children}</>;

  return <LandingRedirectGate>{children}</LandingRedirectGate>;
}
```

#### 세부 작업
* `PublicChromeGate` → 랜딩(`/`)에서만 레이아웃 전체를 `LandingRedirectGate`로 래핑, `/about` · `/guide` · `/terms` · `/privacy`는 로그인 여부와 무관하게 즉시 표시
* `(public)/layout.tsx` → 헤더·본문·푸터를 게이트 안으로 이동
* `(public)/page.tsx` → 페이지 레벨 게이트 제거(레이아웃 게이트로 일원화)

<br/>

### 3. `/signup` 로그인 가드 추가

`/login`의 `LoginRedirectGate`와 동일 정책으로, 로그인 상태로 `/signup`에 진입하면 userType별 홈으로 replace 합니다. 판별 중에는 가입 화면을 숨기고, 401·기타 에러는 fail-open으로 가입 화면을 표시합니다.

가드 판정은 **진입 시점 1회로 고정**했습니다 — 가입 성공 시 `useRegister`가 `users.me` 캐시를 갱신해 로그인 상태가 되는데, 판정을 고정하지 않으면 가입 완료 화면이 뜨자마자 홈으로 이탈하는 회귀가 생기기 때문입니다.

```ts
// app/(auth)/signup/_hooks/use-signup-redirect.ts
useEffect(() => {
  if (entryStatus !== "loading" || auth.status === "loading") return;
  setEntryStatus(auth.status);
  if (auth.status === "authenticated") {
    router.replace(homePathByUserType(auth.me.userType));
  }
}, [auth, entryStatus, router]);
```

| 로그인 상태 /signup 진입 → 대시보드 도착 |
| --- |
| <img alt="signup-guard" width="720" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/e06931d777db83120908dd9e58695528b3d5ba49/.pr-assets/issue-185/03-signup-guard-redirect.png" /> |

#### 세부 작업
* `SignupRedirectGate` / `useSignupRedirect` → 진입 시점 인증 판별·리다이렉트, 판별 결과 고정
* `signup/page.tsx` → 퍼널 전체를 게이트로 래핑

## 🧪 테스트

Playwright + MSW **E2E 4개 추가**(`dashboard.spec.ts` · `partner-dashboard-mobile.spec.ts` · `signup.spec.ts`). 로컬 chromium에서 영향 스펙 5개 35케이스 전부 통과, `pnpm typecheck` · lint 통과.

| # | 테스트 | 검증 내용 |
|---|--------|-----------|
| 1 | 고객 헤더 로고를 누르면 랜딩을 거치지 않고 대시보드에 머문다 | 로고 `href` = `/customer/dashboard` + 클릭 후 URL 유지 |
| 2 | 파트너 헤더 로고를 누르면 랜딩을 거치지 않고 파트너 홈에 머문다 | 로고 `href` = `/partner` + 클릭 후 URL 유지 |
| 3 | 로그인 상태로 `/signup`에 진입하면 역할별 홈으로 이동한다 | 가드가 `/customer/dashboard`로 replace |
| 4 | (기존 유지) 가입 퍼널 전체 흐름·신규 회원 콜백 | 가드 도입에 맞춰 비로그인 시나리오 헤더 주입으로 갱신 |

## 💬 특이사항 / 고민했던 부분 / 결정 사항

### 가입 퍼널 E2E의 인증 시나리오 정정

가입자는 비로그인이 정상 흐름인데 기존 스펙은 기본 MSW(로그인 유저 `/users/me`)로 돌고 있었습니다. 가드 도입을 계기로 `signup.spec.ts` 전체와 `login.spec.ts`의 신규 회원 콜백 테스트에 비로그인 시나리오 헤더를 주입해 실제 흐름과 일치시켰습니다. 가입 성공 이후 대시보드 이동 테스트는 헤더를 해제해 로그인 전환을 반영합니다.

### 랜딩 SSR 축소

랜딩 헤더·푸터가 클라이언트 게이트 안으로 들어가면서 랜딩(`/`)의 서버 렌더 HTML에서 빠집니다. 랜딩 본문은 이번 작업 전부터 게이트로 빠져 있었어서 실질 변화는 헤더 nav 링크 정도입니다. 근본 해결(서버 컴포넌트에서 쿠키 판별 후 `redirect()`)은 프로젝트 전반의 클라이언트 게이트 패턴 전환이 필요해 후속 이슈감으로 남깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
