### PR TITLE
[Fix] 제안 비교 카드 금액 null 가드 복구(web)

### DIFF
--- a/apps/web/src/app/customer/dashboard/_components/ProposalCompareCard.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/ProposalCompareCard.tsx
@@ -26,20 +26,23 @@ export function ProposalCompareCard() {
         </Link>
       </header>
 
-      <div className="mt-[1.125rem] flex items-end justify-between">
-        <div>
-          <p className="text-[0.75rem] font-medium text-ink-3">최저 제안가</p>
-          <p className="mt-1 font-serif text-[1.375rem] font-bold text-ink">
-            {formatManwon(summary.minAmount)}만원
-          </p>
-        </div>
-        <div className="text-right">
-          <p className="text-[0.75rem] font-medium text-ink-3">최고 제안가</p>
-          <p className="mt-1 font-serif text-[1.375rem] font-bold text-gold-ink">
-            {formatManwon(summary.maxAmount)}만원
-          </p>
-        </div>
-      </div>
+      {/* 견적 미기입 제안만 있으면 집계 금액이 null — 금액 블록을 접고 건수만 표시 */}
+      {summary.minAmount != null && summary.maxAmount != null ? (
+        <>
+          <div className="mt-[1.125rem] flex items-end justify-between">
+            <div>
+              <p className="text-[0.75rem] font-medium text-ink-3">최저 제안가</p>
+              <p className="mt-1 font-serif text-[1.375rem] font-bold text-ink">
+                {formatManwon(summary.minAmount)}만원
+              </p>
+            </div>
+            <div className="text-right">
+              <p className="text-[0.75rem] font-medium text-ink-3">최고 제안가</p>
+              <p className="mt-1 font-serif text-[1.375rem] font-bold text-gold-ink">
+                {formatManwon(summary.maxAmount)}만원
+              </p>
+            </div>
+          </div>
 
           <div className="mt-3">
             <OfferRangeBar
@@ -50,10 +53,16 @@ export function ProposalCompareCard() {
             />
           </div>
 
-      <div className="mt-2 flex items-center justify-between text-[0.75rem] text-ink-3">
-        <span>제안 {summary.count}건</span>
-        <span>평균 {formatManwon(summary.avgAmount)}만원</span>
-      </div>
+          <div className="mt-2 flex items-center justify-between text-[0.75rem] text-ink-3">
+            <span>제안 {summary.count}건</span>
+            <span>{summary.avgAmount != null ? `평균 ${formatManwon(summary.avgAmount)}만원` : ""}</span>
+          </div>
+        </>
+      ) : (
+        <p className="mt-[1.125rem] text-[0.8125rem] text-ink-3">
+          제안 {summary.count}건 · 견적은 상담에서 안내돼요
+        </p>
+      )}
 
       <ul className="mt-[1.125rem] hidden border-t border-line-2 md:block">
         {summary.items.map((item) => (
@@ -78,11 +87,15 @@ export function ProposalCompareCard() {
                 최고가
               </span>
             )}
-            <span
-              className={`ml-auto font-serif text-base font-bold ${item.estimateMaxAmount === summary.maxAmount ? "text-gold-ink" : "text-ink"}`}
-            >
-              {formatManwon(item.estimateMaxAmount)}만원
-            </span>
+            {item.estimateMaxAmount != null ? (
+              <span
+                className={`ml-auto font-serif text-base font-bold ${item.estimateMaxAmount === summary.maxAmount ? "text-gold-ink" : "text-ink"}`}
+              >
+                {formatManwon(item.estimateMaxAmount)}만원
+              </span>
+            ) : (
+              <span className="ml-auto text-[0.8125rem] text-ink-3">견적 미제시</span>
+            )}
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #198

## ✅ 작업 내용

### dev typecheck를 깨뜨린 병합 충돌을 복구했습니다

#197(대시보드 금액 nullable)과 #192(금액 포맷 유틸 단일화)는 각각 CI green으로 머지됐지만, #192 브랜치가 #197 이전 코드 기반이라 병합 결과에서 `ProposalCompareCard`의 금액 null 가드가 사라졌습니다. 그 결과 dev에서 `formatManwon(won: number)`에 `number | null`을 넘기는 6곳이 typecheck 실패로 CI red가 됐습니다.

#197의 null 분기 구조(집계 금액 없으면 "제안 N건 · 견적은 상담에서 안내돼요", 항목별 "견적 미제시")를 #192의 `formatManwon` 유틸 기준으로 그대로 복원했습니다. UI는 #197 머지 시점과 동일해 스크린샷은 PR #197을 참조하면 됩니다.

## 🧪 테스트

- `pnpm typecheck` · lint 통과 — dev red의 직접 원인 해소
- 대시보드 E2E는 CI에서 검증(로직 변경 없이 #197 상태 복원)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 최저가·최고가 정보가 유효한 경우에만 표시되도록 변경했습니다.
  * 평균 금액이 없을 때도 적절한 대체 안내 문구를 제공합니다.
  * 제안자별 금액이 없으면 ‘견적 미제시’로 표시됩니다.
  * 제안자 목록에서 ‘최고가’ 배지 표시를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->