### PR TITLE
[Fix] 채팅 메시지 정렬 순서 뒤집힘 수정(web)

### DIFF
--- a/apps/web/src/shared/api/chat/use-chat-messages.ts
+++ b/apps/web/src/shared/api/chat/use-chat-messages.ts
@@ -24,7 +24,7 @@ export function useChatMessages(chatRoomId: string) {
 
   // pages[0]=최신 → 뒤 페이지일수록 과거. 화면은 과거→최신 순이므로 역순으로 이어붙인다.
   const messages = useMemo<ChatMessage[]>(
-    () => query.data.pages.toReversed().flatMap((page) => page.messages),
+    () => query.data.pages.toReversed().flatMap((page) => page.messages.toReversed()),
     [query.data.pages],
   );
 

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -1203,7 +1203,7 @@ export const handlers = [
   }),
 
   // 메시지 히스토리 (이슈 #48) — 커서 페이지네이션(?cursor&size, 기본 30).
-  // 최신 size건을 시간순으로 반환, cursor는 "이 메시지보다 오래된 것" 기준. CLOSED 방도 조회 가능.
+  // 페이지 내부는 최신순으로 반환, cursor는 "이 메시지보다 오래된 것" 기준. CLOSED 방도 조회 가능.
   http.get(`${API_BASE_URL}/chats/:chatRoomId/messages`, async ({ request, params }) => {
     await delay(400);
 
@@ -1229,7 +1229,7 @@ export const handlers = [
       status: "200",
       message: "정상 처리되었습니다.",
       data: camelToSnakeDeep({
-        messages: page.map(toChatMessageDto),
+        messages: page.toReversed().map(toChatMessageDto),
         nextCursor,
         hasNext,
       }),


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #211

## ✅ 작업 내용

### 파트너 채팅방 메시지가 과거→최신 순으로 표시되도록 정렬 순서를 수정했습니다

실 배포 환경에서 채팅 메시지가 최신이 위, 과거가 아래로 뒤집혀 표시되는 문제였습니다. `GET /chats/{chatRoomId}/messages`는 페이지 내부를 최신순으로 반환하는데, 조회 훅이 페이지 순서만 뒤집고 페이지 내부 순서는 그대로 둬서 발생했습니다. MSW 목은 반대로(과거→최신) 내려주고 있어 로컬 개발 중에는 재현되지 않았습니다.

### 1. 조회 훅 페이지 내부 정렬 수정

```ts
// shared/api/chat/use-chat-messages.ts
const messages = useMemo<ChatMessage[]>(
  () => query.data.pages.toReversed().flatMap((page) => page.messages.toReversed()),
  [query.data.pages],
);
```

#### 세부 작업
* `use-chat-messages.ts` → 페이지 순서 반전에 더해 페이지 내부 메시지도 반전해 과거→최신 순으로 평탄화

### 2. MSW 메시지 목 응답 정정

#### 세부 작업
* `handlers.ts` → 채팅 메시지 목 핸들러가 페이지 내부를 최신순으로 반환하도록 수정해 실 서버 응답과 동일하게 재현되도록 함

## 🧪 테스트

- [x] `pnpm typecheck` 통과
- [ ] 실 배포에서 채팅방 메시지가 과거→최신 순으로 정상 표시되는지 확인
