### PR TITLE
[Fix] 파트너 헤더 완료 탭 제거 및 진행 중 필터 프리셋 연결(web)

### DIFF
--- a/apps/web/e2e/review.spec.ts
+++ b/apps/web/e2e/review.spec.ts
@@ -146,6 +146,31 @@ test("결과 없는 status·유형 조합이면 빈 상태가 보인다", async 
 });
 
 /**
+ * 헤더 "진행 중" 프리셋 진입 (이슈 #215) — 데스크톱 내비게이션 전용.
+ */
+
+test("헤더 진행 중 탭으로 들어가면 전송 완료·상담 전환 상태만 남고 두 탭이 함께 활성화된다", async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, "헤더 내비게이션은 데스크톱(md 이상) 전용");
+  await page.goto("/partner");
+
+  await expect(async () => {
+    await page.getByRole("link", { name: "진행 중" }).click();
+    await expect(page).toHaveURL(/\/partner\/review\?status=%EC%A7%84%ED%96%89%EC%A4%91/);
+  }).toPass({ timeout: 10000 });
+
+  await expect(page.getByRole("tab", { name: /전송 완료/ })).toHaveAttribute("aria-selected", "true");
+  await expect(page.getByRole("tab", { name: /상담 전환/ })).toHaveAttribute("aria-selected", "true");
+  await expect(page.getByRole("tab", { name: /^전체/ })).toHaveAttribute("aria-selected", "false");
+
+  await expect(visibleText(page, "경추 염좌 · 향후 치료비 미반영")).toBeVisible();
+  await expect(visibleText(page, "유사암 분류 쟁점 · 진단비 과소")).toBeVisible();
+  await expect(page.getByText("우측 슬관절 인대 파열 · 등급 재산정")).toHaveCount(0);
+});
+
+/**
  * PC 레이아웃 (이슈 #94) — 요약 카드·프리뷰 패널·보류.
  */
 

--- a/apps/web/src/app/partner/_components/PartnerHeader.tsx
+++ b/apps/web/src/app/partner/_components/PartnerHeader.tsx
@@ -11,7 +11,6 @@ const NAV_ITEMS = [
   { label: "홈", href: "/partner", showCount: false },
   { label: "검수 대기", href: "/partner/review", showCount: true },
   { label: "진행 중", href: null, showCount: false },
-  { label: "완료", href: null, showCount: false },
 ] as const;
 
 export function PartnerHeader() {

--- a/apps/web/src/app/partner/_components/PartnerHeader.tsx
+++ b/apps/web/src/app/partner/_components/PartnerHeader.tsx
@@ -6,11 +6,10 @@ import { Scale } from "@/shared/ui/icons/Scale";
 import { NotificationBellMenu } from "@/shared/ui/NotificationBellMenu";
 import { useProfile } from "../_api/use-profile";
 
-// href: null → 준비 중(미구현) 탭. 링크 대신 비활성 표시로 렌더.
 const NAV_ITEMS = [
   { label: "홈", href: "/partner", showCount: false },
   { label: "검수 대기", href: "/partner/review", showCount: true },
-  { label: "진행 중", href: null, showCount: false },
+  { label: "진행 중", href: "/partner/review?status=진행중", showCount: false },
 ] as const;
 
 export function PartnerHeader() {
@@ -39,19 +38,6 @@ export function PartnerHeader() {
                   {pendingCount}
                 </span>
               );
-
-              if (item.href === null) {
-                return (
-                  <span
-                    key={item.label}
-                    aria-disabled
-                    title="준비 중"
-                    className="flex cursor-default items-center gap-1.5 text-sm text-ink-3"
-                  >
-                    {item.label}
-                  </span>
-                );
-              }
 
               return (
                 <Link

--- a/apps/web/src/app/partner/review/_components/DesktopReviewView.tsx
+++ b/apps/web/src/app/partner/review/_components/DesktopReviewView.tsx
@@ -12,17 +12,25 @@ import { ReviewStatusTabs } from "./ReviewStatusTabs";
 import { ReviewSummaryCards } from "./ReviewSummaryCards";
 
 export function DesktopReviewView() {
-  const { type, status, setStatus, region } = useReviewFilter();
+  const { type, status, setStatus, statusValues, region } = useReviewFilter();
   const accidentType = type === "전체" ? undefined : type;
-  const statusFilter = status === "전체" ? undefined : status;
+  // 백엔드가 status 다중값을 못 받아 프리셋(다중)은 전체를 받아 클라이언트 필터링.
+  const statusFilter = statusValues?.length === 1 ? statusValues[0] : undefined;
   const regionParam = region === "전체" ? undefined : region;
 
   // 지역 드롭다운 옵션은 지역 필터를 적용하지 않은 목록에서 파생(지역 선택 시 옵션 붕괴 방지).
   const { data: optionsData } = useReviewList({ status: statusFilter, accidentType });
-  const { data } = useReviewList({ status: statusFilter, accidentType, region: regionParam });
+  const { data: rawData } = useReviewList({ status: statusFilter, accidentType, region: regionParam });
   const { data: statusCounts } = useReviewStatusCounts();
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
+  const data = {
+    ...rawData,
+    list:
+      statusValues && statusValues.length > 1
+        ? rawData.list.filter((item) => !!item.status && statusValues.includes(item.status))
+        : rawData.list,
+  };
   const regions = [
     ...new Set(optionsData.list.map((item) => item.region).filter((r): r is string => !!r)),
   ];

--- a/apps/web/src/app/partner/review/_components/ReviewResults.tsx
+++ b/apps/web/src/app/partner/review/_components/ReviewResults.tsx
@@ -6,15 +6,19 @@ import { ReviewCaseList } from "./ReviewCaseList";
 import { ReviewEmpty } from "./ReviewEmpty";
 
 export function ReviewResults() {
-  const { type, status } = useReviewFilter();
+  const { type, status, statusValues } = useReviewFilter();
   const accidentType = type === "전체" ? undefined : type;
-  const statusFilter = status === "전체" ? undefined : status;
+  // 백엔드가 status 다중값을 못 받아 프리셋(다중)은 전체를 받아 클라이언트 필터링.
+  const statusFilter = statusValues?.length === 1 ? statusValues[0] : undefined;
 
   const { data } = useReviewList({ status: statusFilter, accidentType });
+  const items = statusValues && statusValues.length > 1
+    ? data.list.filter((item) => !!item.status && statusValues.includes(item.status))
+    : data.list;
 
-  if (data.list.length === 0) {
+  if (items.length === 0) {
     return <ReviewEmpty activeType={type} activeStatus={status} />;
   }
 
-  return <ReviewCaseList items={data.list} />;
+  return <ReviewCaseList items={items} />;
 }

--- a/apps/web/src/app/partner/review/_components/ReviewStatusTabs.tsx
+++ b/apps/web/src/app/partner/review/_components/ReviewStatusTabs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReviewStatusCounts } from "../../_shared/model/types";
+import { REVIEW_STATUS_PRESETS } from "../_hooks/use-review-filter";
 
 /** status 필터 탭바(단일 선택). 상태는 props로 주입받는 프레젠테이션 컴포넌트. */
 
@@ -25,10 +26,13 @@ interface Props {
 }
 
 export function ReviewStatusTabs({ value, counts, onSelect }: Props) {
+  // 헤더 "진행 중" 프리셋 진입 시 대응 상태 탭들을 함께 활성 표시.
+  const presetValues = REVIEW_STATUS_PRESETS[value];
+
   return (
     <div role="tablist" aria-label="상태 필터" className="flex gap-5 overflow-x-auto border-b border-line px-5 pt-3 md:px-0">
       {REVIEW_STATUS_OPTIONS.map((option) => {
-        const active = option.value === value;
+        const active = presetValues ? presetValues.includes(option.value) : option.value === value;
         const count = option.value === "전체" ? counts?.total : counts?.[option.value];
         return (
           <button

--- a/apps/web/src/app/partner/review/_hooks/use-review-filter.ts
+++ b/apps/web/src/app/partner/review/_hooks/use-review-filter.ts
@@ -7,10 +7,22 @@ import { accidentTypeSchema } from "@/shared/model/accident-type";
 // 사고 유형 필터 값은 명세 영문 enum + 전체.
 const typeSchema = z.enum(["전체", ...accidentTypeSchema.options]);
 
-// status 탭 값은 REPORTS.status 생명주기 중 Figma 탭 4종 + 전체(파라미터 생략).
-const statusSchema = z.enum(["전체", "AWAITING_ADOPTION", "COUNSELING", "NOT_SELECTED", "CLOSED"]);
+// status 탭 값은 REPORTS.status 생명주기 중 Figma 탭 4종 + 전체(파라미터 생략) + 진행중 프리셋(헤더 진입용).
+const statusSchema = z.enum([
+  "전체",
+  "AWAITING_ADOPTION",
+  "COUNSELING",
+  "NOT_SELECTED",
+  "CLOSED",
+  "진행중",
+]);
 
 export type ReviewStatusTabValue = z.infer<typeof statusSchema>;
+
+// 백엔드가 status 다중값을 못 받아 프리셋은 클라이언트에서 이 상태들로 필터링.
+export const REVIEW_STATUS_PRESETS: Record<string, string[]> = {
+  진행중: ["AWAITING_ADOPTION", "COUNSELING"],
+};
 
 export function useReviewFilter() {
   const pathname = usePathname();
@@ -19,6 +31,9 @@ export function useReviewFilter() {
   const type = typeSchema.safeParse(params.get("type")).data ?? "전체";
   const status = statusSchema.safeParse(params.get("status")).data ?? "전체";
   const region = params.get("region") ?? "전체";
+
+  // 목록 API 호출·클라이언트 필터에 쓸 실제 상태 배열(전체=undefined, 프리셋=다중, 단일=1개).
+  const statusValues = REVIEW_STATUS_PRESETS[status] ?? (status === "전체" ? undefined : [status]);
 
   // 서버 데이터가 없는 순수 클라이언트 필터라 shallow routing으로 URL만 동기화.
   // (prod 정적 라우트에서 router.replace(pathname)가 쿼리 제거를 반영하지 않는 문제 회피)
@@ -34,5 +49,5 @@ export function useReviewFilter() {
   const setStatus = (value: string) => setParam("status", value);
   const setRegion = (value: string) => setParam("region", value);
 
-  return { type, setType, status, setStatus, region, setRegion };
+  return { type, setType, status, setStatus, statusValues, region, setRegion };
 }


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #215

## ✅ 작업 내용

### 파트너 헤더 완료 탭 제거

사용하지 않는 완료 탭을 헤더에서 제거했습니다.

<br/>

### 진행 중 프리셋 필터 추가

진행 중 메뉴에서 전송 완료와 상담 전환 상태를 함께 조회할 수 있도록 프리셋 필터를 추가했습니다.

백엔드에서 여러 상태를 한 번에 조회할 수 없어 진행 중 프리셋인 경우에는 전체 목록을 조회한 뒤 클라이언트에서 전송 완료와 상담 전환 상태만 필터링하도록 처리했습니다.

#### 변경 사항

- 진행 중 프리셋 추가
- 진행 중 선택 시 전송 완료와 상담 전환 탭이 함께 활성화되도록 변경
- 진행 중 프리셋에서는 클라이언트 필터링 적용
- 헤더의 진행 중 메뉴를 검수 페이지와 연결하고 모든 메뉴를 링크 방식으로 통일



## 🧪 테스트

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] E2E: 헤더 진행 중 메뉴 진입 시 전송 완료·상담 전환 탭 활성화 및 해당 상태만 표시되는 것 확인
- [x] E2E: 기존 `review.spec.ts` 회귀 테스트 통과 (33 passed / 5 skipped)