### PR TITLE
[Fix] 검수 대기 필터 변경 시 전체 화면 서스펜스 깜빡임 제거(web)

### DIFF
--- a/apps/web/e2e/review-filter-transition.spec.ts
+++ b/apps/web/e2e/review-filter-transition.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+import { setAuthCookie } from "./_auth-cookie-helpers";
+
+/**
+ * #216: 검수 대기 필터 전환 시 서스펜스 깜빡임 회귀 방지 E2E.
+ *
+ * PC 레이아웃 전용 — 모바일은 DesktopReviewBoundary 대상이 아님(ReviewBoundary 별도 경계).
+ */
+
+const LIST_PATH = "/partner/review";
+
+test.beforeEach(async ({ page }) => {
+  await setAuthCookie(page, "CERTIFICATED_ADJUSTER");
+});
+
+test("상태 탭 전환 중에도 통계 카드·기존 목록이 유지되다가 새 데이터로 교체된다", async ({
+  page,
+  isMobile,
+}) => {
+  test.skip(isMobile, "PC 전용 DesktopReviewBoundary 대상 회귀 테스트");
+
+  await page.goto(LIST_PATH);
+
+  const summaryCard = page.getByText("검수 대기").first();
+  await expect(summaryCard).toBeVisible();
+
+  const initialCard = page.getByRole("listitem").filter({ hasText: /우측 슬관절 인대 파열/ });
+  await expect(initialCard).toBeVisible();
+
+  const statusTabs = page.getByRole("tablist", { name: "상태 필터" });
+  const nextTab = statusTabs.getByRole("tab", { name: "전송 완료" });
+  await nextTab.click();
+
+  // 전환 중(pending): 통계 카드는 그대로, 기존 목록도 즉시 사라지지 않아야 한다.
+  await expect(summaryCard).toBeVisible();
+  await expect(initialCard).toBeVisible();
+  await expect(statusTabs).toHaveAttribute("aria-busy", "true");
+
+  // 전환 완료: 새 필터의 목록으로 교체.
+  await expect(page.getByRole("listitem").filter({ hasText: /경추 염좌/ })).toBeVisible();
+  await expect(initialCard).toHaveCount(0);
+  await expect(statusTabs).not.toHaveAttribute("aria-busy", "true");
+  await expect(summaryCard).toBeVisible();
+});

--- a/apps/web/src/app/partner/review/_components/DesktopReviewFilterSection.tsx
+++ b/apps/web/src/app/partner/review/_components/DesktopReviewFilterSection.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { AsyncBoundary } from "@/shared/ui/AsyncBoundary";
+import { useReviewList } from "../../_shared/api/use-review-list";
+import { useReviewFilter } from "../_hooks/use-review-filter";
+import { DesktopReviewCaseList } from "./DesktopReviewCaseList";
+import { ReviewDraftPanel } from "./ReviewDraftPanel";
+import { ReviewEmpty } from "./ReviewEmpty";
+import { ReviewFilterBar } from "./ReviewFilterBar";
+import { REVIEW_ERROR_MESSAGES } from "./review-error-messages";
+
+function DesktopReviewFilterSectionSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="h-9 w-full animate-pulse rounded-pill bg-line-2" />
+      <div className="grid gap-6 lg:grid-cols-[1fr_24.5rem]">
+        <div className="space-y-3">
+          <div className="h-36 animate-pulse rounded-card-lg bg-line-2" />
+          <div className="h-36 animate-pulse rounded-card-lg bg-line-2" />
+          <div className="h-36 animate-pulse rounded-card-lg bg-line-2" />
+        </div>
+        <div className="h-96 animate-pulse rounded-card-lg bg-line-2" />
+      </div>
+    </div>
+  );
+}
+
+function DesktopReviewResults() {
+  const { type, status, statusValues, region } = useReviewFilter();
+  const accidentType = type === "전체" ? undefined : type;
+  // 백엔드가 status 다중값을 못 받아 프리셋(다중)은 전체를 받아 클라이언트 필터링.
+  const statusFilter = statusValues?.length === 1 ? statusValues[0] : undefined;
+  const regionParam = region === "전체" ? undefined : region;
+
+  // 지역 드롭다운 옵션은 지역 필터를 적용하지 않은 목록에서 파생(지역 선택 시 옵션 붕괴 방지).
+  const { data: optionsData } = useReviewList({ status: statusFilter, accidentType });
+  const { data: rawData } = useReviewList({ status: statusFilter, accidentType, region: regionParam });
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const data = {
+    ...rawData,
+    list:
+      statusValues && statusValues.length > 1
+        ? rawData.list.filter((item) => !!item.status && statusValues.includes(item.status))
+        : rawData.list,
+  };
+
+  const regions = [
+    ...new Set(optionsData.list.map((item) => item.region).filter((r): r is string => !!r)),
+  ];
+  const selected =
+    data.list.find((item) => item.reportId === selectedId) ?? data.list[0] ?? null;
+
+  return (
+    <div className="space-y-6">
+      <ReviewFilterBar regions={regions} />
+
+      <div className="grid items-start gap-6 lg:grid-cols-[1fr_24.5rem]">
+        {data.list.length === 0 ? (
+          <ReviewEmpty activeType={type} activeStatus={status} />
+        ) : (
+          <DesktopReviewCaseList
+            items={data.list}
+            selectedId={selected?.reportId ?? null}
+            onSelect={setSelectedId}
+          />
+        )}
+
+        <ReviewDraftPanel item={selected} />
+      </div>
+    </div>
+  );
+}
+
+export function DesktopReviewFilterSection() {
+  return (
+    <AsyncBoundary
+      fallback={<DesktopReviewFilterSectionSkeleton />}
+      errorLayout="page"
+      errorTitle="목록을 불러오지 못했어요"
+      errorMessages={REVIEW_ERROR_MESSAGES}
+    >
+      <DesktopReviewResults />
+    </AsyncBoundary>
+  );
+}

--- a/apps/web/src/app/partner/review/_components/DesktopReviewView.tsx
+++ b/apps/web/src/app/partner/review/_components/DesktopReviewView.tsx
@@ -1,61 +1,20 @@
 "use client";
 
-import { useState } from "react";
-import { useReviewList } from "../../_shared/api/use-review-list";
 import { useReviewStatusCounts } from "../../_shared/api/use-review-status-counts";
 import { useReviewFilter } from "../_hooks/use-review-filter";
-import { DesktopReviewCaseList } from "./DesktopReviewCaseList";
-import { ReviewDraftPanel } from "./ReviewDraftPanel";
-import { ReviewEmpty } from "./ReviewEmpty";
-import { ReviewFilterBar } from "./ReviewFilterBar";
+import { DesktopReviewFilterSection } from "./DesktopReviewFilterSection";
 import { ReviewStatusTabs } from "./ReviewStatusTabs";
 import { ReviewSummaryCards } from "./ReviewSummaryCards";
 
 export function DesktopReviewView() {
-  const { type, status, setStatus, statusValues, region } = useReviewFilter();
-  const accidentType = type === "전체" ? undefined : type;
-  // 백엔드가 status 다중값을 못 받아 프리셋(다중)은 전체를 받아 클라이언트 필터링.
-  const statusFilter = statusValues?.length === 1 ? statusValues[0] : undefined;
-  const regionParam = region === "전체" ? undefined : region;
-
-  // 지역 드롭다운 옵션은 지역 필터를 적용하지 않은 목록에서 파생(지역 선택 시 옵션 붕괴 방지).
-  const { data: optionsData } = useReviewList({ status: statusFilter, accidentType });
-  const { data: rawData } = useReviewList({ status: statusFilter, accidentType, region: regionParam });
+  const { status, setStatus } = useReviewFilter();
   const { data: statusCounts } = useReviewStatusCounts();
-  const [selectedId, setSelectedId] = useState<string | null>(null);
-
-  const data = {
-    ...rawData,
-    list:
-      statusValues && statusValues.length > 1
-        ? rawData.list.filter((item) => !!item.status && statusValues.includes(item.status))
-        : rawData.list,
-  };
-  const regions = [
-    ...new Set(optionsData.list.map((item) => item.region).filter((r): r is string => !!r)),
-  ];
-  const selected =
-    data.list.find((item) => item.reportId === selectedId) ?? data.list[0] ?? null;
 
   return (
     <div className="space-y-6">
       <ReviewSummaryCards />
       <ReviewStatusTabs value={status} counts={statusCounts} onSelect={setStatus} />
-      <ReviewFilterBar regions={regions} />
-
-      <div className="grid items-start gap-6 lg:grid-cols-[1fr_24.5rem]">
-        {data.list.length === 0 ? (
-          <ReviewEmpty activeType={type} activeStatus={status} />
-        ) : (
-          <DesktopReviewCaseList
-            items={data.list}
-            selectedId={selected?.reportId ?? null}
-            onSelect={setSelectedId}
-          />
-        )}
-
-        <ReviewDraftPanel item={selected} />
-      </div>
+      <DesktopReviewFilterSection />
     </div>
   );
 }

--- a/apps/web/src/app/partner/review/_components/DesktopReviewView.tsx
+++ b/apps/web/src/app/partner/review/_components/DesktopReviewView.tsx
@@ -7,13 +7,13 @@ import { ReviewStatusTabs } from "./ReviewStatusTabs";
 import { ReviewSummaryCards } from "./ReviewSummaryCards";
 
 export function DesktopReviewView() {
-  const { status, setStatus } = useReviewFilter();
+  const { status, setStatus, isPending } = useReviewFilter();
   const { data: statusCounts } = useReviewStatusCounts();
 
   return (
     <div className="space-y-6">
       <ReviewSummaryCards />
-      <ReviewStatusTabs value={status} counts={statusCounts} onSelect={setStatus} />
+      <ReviewStatusTabs value={status} counts={statusCounts} onSelect={setStatus} isPending={isPending} />
       <DesktopReviewFilterSection />
     </div>
   );

--- a/apps/web/src/app/partner/review/_components/ReviewFilterBar.tsx
+++ b/apps/web/src/app/partner/review/_components/ReviewFilterBar.tsx
@@ -5,10 +5,13 @@ import { useReviewFilter } from "../_hooks/use-review-filter";
 import { REVIEW_TYPE_OPTIONS } from "./ReviewTypeChips";
 
 export function ReviewFilterBar({ regions }: { regions: string[] }) {
-  const { type, setType, region, setRegion } = useReviewFilter();
+  const { type, setType, region, setRegion, isPending } = useReviewFilter();
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div
+      aria-busy={isPending}
+      className={`flex flex-wrap items-center gap-2 transition-opacity ${isPending ? "opacity-60" : ""}`}
+    >
       {REVIEW_TYPE_OPTIONS.map(({ value, label }) => (
         <button
           key={value}

--- a/apps/web/src/app/partner/review/_components/ReviewStatusTabs.tsx
+++ b/apps/web/src/app/partner/review/_components/ReviewStatusTabs.tsx
@@ -23,14 +23,22 @@ interface Props {
   value: string;
   counts?: ReviewStatusCounts;
   onSelect: (value: string) => void;
+  isPending?: boolean;
 }
 
-export function ReviewStatusTabs({ value, counts, onSelect }: Props) {
+export function ReviewStatusTabs({ value, counts, onSelect, isPending }: Props) {
   // 헤더 "진행 중" 프리셋 진입 시 대응 상태 탭들을 함께 활성 표시.
   const presetValues = REVIEW_STATUS_PRESETS[value];
 
   return (
-    <div role="tablist" aria-label="상태 필터" className="flex gap-5 overflow-x-auto border-b border-line px-5 pt-3 md:px-0">
+    <div
+      role="tablist"
+      aria-label="상태 필터"
+      aria-busy={isPending}
+      className={`flex gap-5 overflow-x-auto border-b border-line px-5 pt-3 transition-opacity md:px-0 ${
+        isPending ? "opacity-60" : ""
+      }`}
+    >
       {REVIEW_STATUS_OPTIONS.map((option) => {
         const active = presetValues ? presetValues.includes(option.value) : option.value === value;
         const count = option.value === "전체" ? counts?.total : counts?.[option.value];

--- a/apps/web/src/app/partner/review/_hooks/use-review-filter.ts
+++ b/apps/web/src/app/partner/review/_hooks/use-review-filter.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
 import { z } from "zod";
 import { accidentTypeSchema } from "@/shared/model/accident-type";
 
@@ -26,7 +27,9 @@ export const REVIEW_STATUS_PRESETS: Record<string, string[]> = {
 
 export function useReviewFilter() {
   const pathname = usePathname();
+  const router = useRouter();
   const params = useSearchParams();
+  const [isPending, startTransition] = useTransition();
 
   const type = typeSchema.safeParse(params.get("type")).data ?? "전체";
   const status = statusSchema.safeParse(params.get("status")).data ?? "전체";
@@ -35,19 +38,26 @@ export function useReviewFilter() {
   // 목록 API 호출·클라이언트 필터에 쓸 실제 상태 배열(전체=undefined, 프리셋=다중, 단일=1개).
   const statusValues = REVIEW_STATUS_PRESETS[status] ?? (status === "전체" ? undefined : [status]);
 
-  // 서버 데이터가 없는 순수 클라이언트 필터라 shallow routing으로 URL만 동기화.
-  // (prod 정적 라우트에서 router.replace(pathname)가 쿼리 제거를 반영하지 않는 문제 회피)
+  // router.replace를 startTransition으로 감싸야 리스트 Suspense 재서스펜드 시
+  // React가 기존 화면을 유지한 채 pending 처리한다(window.history 직접 조작은
+  // React 트랜지션 경계 밖에서 반영돼 즉시 폴백으로 떨어짐).
+  // 단, 쿼리가 완전히 비워지는 경우(전체 복귀)는 prod 정적 라우트에서
+  // router.replace(pathname)가 쿼리 제거를 반영하지 않는 버그가 있어(#99)
+  // 그 경로만 shallow routing(history.replaceState)으로 우회한다.
   const setParam = (key: string, value: string) => {
     const next = new URLSearchParams(params);
     if (value === "전체") next.delete(key);
     else next.set(key, value);
     const query = next.toString();
-    window.history.replaceState(null, "", query ? `${pathname}?${query}` : pathname);
+    startTransition(() => {
+      if (query) router.replace(`${pathname}?${query}`, { scroll: false });
+      else window.history.replaceState(null, "", pathname);
+    });
   };
 
   const setType = (value: string) => setParam("type", value);
   const setStatus = (value: string) => setParam("status", value);
   const setRegion = (value: string) => setParam("region", value);
 
-  return { type, setType, status, setStatus, statusValues, region, setRegion };
+  return { type, setType, status, setStatus, statusValues, region, setRegion, isPending };
 }


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #216

## ✅ 작업 내용

### 1. 필터바·목록·초안 패널을 별도 Suspense 경계로 분리
* 통계 카드·상태 탭을 목록 서스펜스 경계 밖으로 분리해 필터 전환 시 함께 깜빡이지 않도록 함
* 필터바는 지역 옵션을 서스펜딩 쿼리에서 파생하므로 목록·초안 패널과 같은 내부 경계로 묶음

### 2. 필터 전환을 useTransition으로 감싸 기존 목록 유지
* `useReviewFilter`가 `router.replace`를 `startTransition`으로 감싸 필터 전환 중에도 React가 기존 목록을 유지한 채 pending 처리하도록 변경
* 쿼리가 완전히 비워지는 "전체" 복귀 케이스는 정적 라우트에서 `router.replace(pathname)`가 쿼리 제거를 반영하지 않는 기존 버그(#99)를 피해 `history.replaceState` 우회 유지

### 3. 전환 중 시각 피드백
* 상태 탭·필터바에 pending 중 opacity·`aria-busy` 반영

## 🧪 테스트

- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [x] 신규 E2E(`review-filter-transition.spec.ts`) 통과 — 필터 전환 중 통계 카드·기존 목록 유지 확인
- [x] 기존 검수 관련 E2E(`adjuster-review.spec.ts`, `review.spec.ts`) 데스크톱·모바일 전부 회귀 없음 확인