### PR TITLE
[Fix] 토큰 재발급 동시 만료 E2E mobile-safari 플레이크 안정화(web)

### DIFF
--- a/apps/web/e2e/token-reissue.spec.ts
+++ b/apps/web/e2e/token-reissue.spec.ts
@@ -8,6 +8,8 @@ import { setAuthCookie } from "./_auth-cookie-helpers";
  * 만료는 MSW 시나리오 주입(localStorage "mock:tokenExpired": "once" | "refresh-expired").
  * 보호 엔드포인트 GET /users/me·GET /reports가 401 EXPIRED_TOKEN을 주고, POST /auth/reissue 실제 호출
  * 횟수는 localStorage "mock:reissueCount"에 누적된다(단일-flight 관측 채널).
+ * 401 응답 횟수도 MSW가 localStorage "mock:expiredResponseCount"에 누적한다(#224) —
+ * page.on("response")는 WebKit에서 서비스워커 경유 응답 이벤트를 흘리지 않아 관측 채널로 못 쓴다.
  * 동시 401은 대시보드가 프로덕션 경로 그대로 만든다 — 진입 시 useMe(/users/me)와 useReportList(/reports)가
  * 나란히 나가고 둘 다 401을 받으므로, fetchJson 두 곳이 같은 재발급 promise를 공유하는지 검증된다.
  * 재발급 응답 형식·에러코드 enum 검증은 zod·api-spec 훅에 위임(미테스트).
@@ -17,6 +19,7 @@ const DASHBOARD_PATH = "/customer/dashboard";
 const LOGIN_PATH = "/login";
 const SCENARIO_KEY = "mock:tokenExpired";
 const REISSUE_COUNT_KEY = "mock:reissueCount";
+const EXPIRED_COUNT_KEY = "mock:expiredResponseCount";
 const RECENT_LOGIN_KEY = "bb.recentLogin";
 
 // 대시보드 데스크톱 뷰(<md는 모바일 홈)를 기준으로 검증한다 — dashboard.spec.ts와 동일 패턴.
@@ -26,12 +29,13 @@ type Page = import("@playwright/test").Page;
 
 async function injectScenario(page: Page, scenario: string | null) {
   await page.addInitScript(
-    ([scenarioKey, countKey, value]) => {
+    ([scenarioKey, countKey, expiredKey, value]) => {
       window.localStorage.removeItem(countKey);
+      window.localStorage.removeItem(expiredKey);
       if (value === null) window.localStorage.removeItem(scenarioKey);
       else window.localStorage.setItem(scenarioKey, value);
     },
-    [SCENARIO_KEY, REISSUE_COUNT_KEY, scenario] as const,
+    [SCENARIO_KEY, REISSUE_COUNT_KEY, EXPIRED_COUNT_KEY, scenario] as const,
   );
 }
 
@@ -58,15 +62,6 @@ test("여러 요청이 동시에 만료 응답을 받아도 재발급은 한 번
   await setAuthCookie(page, "USER");
   await injectScenario(page, "once");
 
-  // 실제로 두 개 이상의 요청이 401을 받았는지(=동시 만료 상황이 재현됐는지) 확인해 둔다.
-  // 이게 없으면 요청 하나만 401을 받고도 테스트가 통과해 단일-flight를 검증하지 못한다.
-  let expiredResponses = 0;
-  page.on("response", (response) => {
-    if (response.status() === 401 && !response.url().includes("/auth/reissue")) {
-      expiredResponses += 1;
-    }
-  });
-
   await page.goto(DASHBOARD_PATH);
 
   // 인사말(/users/me)과 리포트 목록(/reports)이 모두 재시도로 살아났다 = 두 요청 다 401 → 재발급 → 재시도.
@@ -79,7 +74,12 @@ test("여러 요청이 동시에 만료 응답을 받아도 재발급은 한 번
     expect(await reissueCount(page)).toBe("1");
   }).toPass({ timeout: 10000 });
 
-  expect(expiredResponses).toBeGreaterThanOrEqual(2);
+  // 실제로 두 개 이상의 요청이 401을 받았는지(=동시 만료 상황이 재현됐는지) 확인해 둔다.
+  // 이게 없으면 요청 하나만 401을 받고도 테스트가 통과해 단일-flight를 검증하지 못한다.
+  await expect(async () => {
+    const count = await page.evaluate((key) => window.localStorage.getItem(key), EXPIRED_COUNT_KEY);
+    expect(Number(count ?? "0")).toBeGreaterThanOrEqual(2);
+  }).toPass({ timeout: 10000 });
 });
 
 test("리프레시 토큰까지 만료되면 로그인 안내 화면을 거쳐 로그인 화면에 최근 로그인 카드가 남는다", async ({

--- a/apps/web/src/shared/mocks/auth-token-state.ts
+++ b/apps/web/src/shared/mocks/auth-token-state.ts
@@ -4,12 +4,16 @@
  * - `mock:tokenExpired` = "once"            → 보호 엔드포인트 첫 호출 401 EXPIRED_TOKEN, 재발급 성공 후 200
  * - `mock:tokenExpired` = "refresh-expired" → 보호 엔드포인트 401 EXPIRED_TOKEN, 재발급도 401 EXPIRED_TOKEN
  * - `mock:reissueCount`                     → /auth/reissue 실제 호출 횟수(단일-flight 검증용)
+ * - `mock:expiredResponseCount`             → 보호 엔드포인트가 401 EXPIRED_TOKEN을 돌려준 횟수(#224).
+ *   Playwright `page.on("response")`는 WebKit에서 서비스워커 경유 응답 이벤트를 흘리지 않아
+ *   E2E 관측 채널을 MSW 쪽 localStorage로 둔다.
  * - `mock:loggedOut` = "true"               → 로그아웃 상태(#155), 보호 엔드포인트가 401 LOGIN_REQUIRED
  *
  * 플래그가 없으면 만료 없음 = 기존 동작 그대로.
  */
 const SCENARIO_KEY = "mock:tokenExpired";
 const REISSUE_COUNT_KEY = "mock:reissueCount";
+const EXPIRED_COUNT_KEY = "mock:expiredResponseCount";
 const LOGGED_OUT_KEY = "mock:loggedOut";
 
 type TokenScenario = "once" | "refresh-expired";
@@ -64,6 +68,31 @@ export function isLoggedOut(): boolean {
 export function reissueCallCount(): number {
   const count = Number.parseInt(read(REISSUE_COUNT_KEY) ?? "0", 10);
   return Number.isNaN(count) ? 0 : count;
+}
+
+export function recordExpiredResponse(): void {
+  write(EXPIRED_COUNT_KEY, String(expiredResponseCount() + 1));
+}
+
+export function expiredResponseCount(): number {
+  const count = Number.parseInt(read(EXPIRED_COUNT_KEY) ?? "0", 10);
+  return Number.isNaN(count) ? 0 : count;
+}
+
+/**
+ * 보호 엔드포인트 만료 응답이 min회 쌓일 때까지 재발급 완료를 미룬다(#224).
+ * 재발급이 먼저 끝나 만료 플래그가 풀리면 나중에 나간 요청이 401 없이 200을 받아
+ * "동시 만료" 전제가 타이밍에 따라 무너지므로 붙인 대기다.
+ * 동시 만료를 검증하는 "once" 시나리오에서만 돌고(refresh-expired는 보호 요청이 1개인
+ * 화면도 거쳐 대기가 지연만 만든다), 상한을 넘기면 그대로 진행해 다른 흐름을 막지 않는다.
+ */
+export async function waitForExpiredResponses(min: number, timeoutMs: number): Promise<void> {
+  if (readScenario() !== "once") return;
+
+  const deadline = Date.now() + timeoutMs;
+  while (expiredResponseCount() < min && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
 }
 
 /** 재발급 1회 처리. "once"면 만료 상태를 해제해 이후 보호 엔드포인트가 200을 돌려준다. */

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -5,7 +5,9 @@ import {
   consumeReissue,
   isAccessTokenExpired,
   isLoggedOut,
+  recordExpiredResponse,
   setLoggedOut,
+  waitForExpiredResponses,
 } from "@/shared/mocks/auth-token-state";
 import { registerDeviceTokenBodySchema } from "@/shared/model/device-token.schema";
 
@@ -1960,6 +1962,10 @@ export const handlers = [
   // E2E 주입: localStorage["mock:tokenExpired"]="once"(재발급 성공) | "refresh-expired"(재발급 실패).
   // 실제 호출 횟수는 localStorage["mock:reissueCount"]에 누적 — 동시 401 다발 시 단일-flight 검증용.
   http.post(`${API_BASE_URL}/auth/reissue`, async () => {
+    // 대시보드 동시 만료 E2E(#224): useMe·useReportList 둘 다 401을 받은 뒤에 재발급을 끝내
+    // 늦게 나간 요청이 401 없이 200을 받는 타이밍 편차를 없앤다(상한 2초).
+    await waitForExpiredResponses(2, 2000);
+    // 두 번째 401을 받은 클라이언트가 진행 중 재발급 promise에 합류할 시간을 준다(단일-flight 검증 창).
     await delay(200);
 
     const outcome = consumeReissue();
@@ -2018,6 +2024,7 @@ export const handlers = [
     }
     // 액세스 토큰 만료 주입 (#109) — 재발급 성공 시 플래그가 해제돼 이후 호출은 200.
     if (isAccessTokenExpired()) {
+      recordExpiredResponse();
       return HttpResponse.json(
         { status: "401", code: "EXPIRED_TOKEN", message: "토큰이 만료되었습니다." },
         { status: 401 },
@@ -2261,6 +2268,7 @@ export const handlers = [
 
     // 액세스 토큰 만료 주입 (#109) — /users/me와 동시에 401을 받게 해 단일-flight 재발급을 검증한다.
     if (isAccessTokenExpired()) {
+      recordExpiredResponse();
       return HttpResponse.json(
         { status: "401", code: "EXPIRED_TOKEN", message: "토큰이 만료되었습니다." },
         { status: 401 },


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #224

## ✅ 작업 내용

### mobile-safari에서만 떨어지던 token-reissue E2E를 안정화했습니다

PR #223 CI에서 "여러 요청이 동시에 만료 응답을 받아도 재발급은 한 번만 호출된다" 케이스가 mobile-safari에서 재시도까지 6회 연속 떨어졌습니다. dev CI에도 같은 실패 이력이 있습니다(run 30451841733). 실패 지점은 401 응답 수를 세는 `expect(expiredResponses).toBeGreaterThanOrEqual(2)`였습니다.

원인은 관측 채널입니다. 401 횟수는 Playwright `page.on("response")` 이벤트로 세는데, WebKit은 서비스워커(MSW)를 거친 응답을 네트워크 이벤트로 흘릴 때가 있고 안 흘릴 때가 있습니다. 실제로 401이 났는데도 카운트가 빠지는 겁니다. 그래서 기능 검증(재발급 1회 호출·화면 정상 표시)은 통과합니다.

### 1. 관측 채널을 MSW 쪽 localStorage로 이동

* `mock:expiredResponseCount` — 보호 엔드포인트(`/users/me`·`/reports`)가 401 EXPIRED_TOKEN을 돌려줄 때마다 누적(기존 `mock:reissueCount`와 같은 패턴)
* 스펙은 `page.on("response")` 대신 이 키를 폴링해 2회 이상인지 확인

### 2. 재발급 완료를 두 번째 401 이후로 지연

* 재발급이 먼저 끝나면 늦게 나간 요청이 401 없이 200을 받아 "동시 만료" 전제가 타이밍에 따라 무너짐
* 이를 막기 위해 once 시나리오에서만 두 요청이 모두 만료 응답을 받을 때까지 기다린 뒤(상한 2초) 재발급 완료
* refresh-expired 시나리오는 보호 요청이 1개뿐인 화면(`/login`)도 거치므로 대기 대상에서 제외

## ✅ 검증

- `token-reissue.spec.ts` `--repeat-each=4` — 3개 브라우저 프로젝트 60/60 통과(수정 전에는 같은 조건에서 mobile-safari 실패가 재현됨)
- `pnpm typecheck` · lint 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 액세스 토큰이 동시에 만료되는 상황에서 요청 재시도와 토큰 재발급이 보다 안정적으로 처리되도록 개선했습니다.
  * 다양한 브라우저 환경에서 인증 만료 응답을 정확히 감지해 비정상적인 재발급 동작을 줄였습니다.

* **테스트**
  * 동시 만료 및 재발급 시나리오에 대한 검증을 강화했습니다.
  * 토큰 만료 응답 횟수와 재발급 흐름을 보다 일관되게 확인하도록 테스트를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->