### PR TITLE
[Fix] 검수 상세 title null 응답 스키마 수정(web)

### DIFF
--- a/apps/web/src/app/partner/review/[reportId]/_model/review-detail.schema.ts
+++ b/apps/web/src/app/partner/review/[reportId]/_model/review-detail.schema.ts
@@ -65,7 +65,8 @@ export const reviewProgressSchema = z.object({
 export const reviewDetailSchema = z.object({
   reportId: z.uuid(),
   caseNo: z.string(),
-  title: z.string(),
+  // 제목 미배정 케이스는 null.
+  title: z.string().nullable(),
   // 백엔드 report.getAccidentType() null 가능(사고유형 미확정).
   accidentType: z.string().nullable(),
   region: z.string(),


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #226

## ✅ 작업 내용

### 1. 검수 상세 응답 스키마의 title nullable 허용

* 제목 미배정 리포트는 검수 상세 응답의 `title`이 null로 내려와 `reviewDetailSchema` zod 파싱이 실패하고 상세 페이지가 로딩되지 않던 문제를 수정했습니다.
* `title`을 `z.string().nullable()`로 변경했습니다. 검수 상세 화면은 헤더에 `diagnosis`를 사용하고 `title`을 렌더하지 않아 UI 변경은 없습니다.

## 🧪 테스트

- [x] `pnpm typecheck` 통과
- [x] `pnpm lint` 통과
- [ ] 이슈의 report_id로 검수 상세 페이지 정상 로딩 확인(dev 백엔드)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 제목이 지정되지 않은 리뷰에서도 상세 정보를 정상적으로 표시할 수 있도록 지원합니다.
  * 제목이 없는 경우에도 관련 데이터가 올바르게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->