### PR TITLE
[Fix] 회원 탈퇴 시 기기 푸시 토큰 미해제 수정(web)

### DIFF
--- a/apps/web/e2e/account-withdraw.spec.ts
+++ b/apps/web/e2e/account-withdraw.spec.ts
@@ -12,6 +12,8 @@ import { setAuthCookie } from "./_auth-cookie-helpers";
  * 실패는 x-mock-failure=withdraw 헤더로 500을 강제(고가치 — 실패했는데 계정이 사라진 것처럼
  * 보이면 신뢰 직타). 응답 봉투·에러코드 enum·다이얼로그 포커스 트랩은 zod·api-spec 훅·정적
  * 리뷰에 위임(의식적 미테스트).
+ * 앱 웹뷰 기기 토큰(이슈 #228): 브리지 스텁 + 저장 토큰 시드로 탈퇴 시 서버 해제(저장값 제거)와
+ * 해제 실패 시에도 탈퇴가 진행되는 best-effort를 검증 — 해제 실패는 x-mock-failure=device-token.
  * 고객 마이페이지는 PC/모바일 트리가 DOM에 공존(hidden md:* / md:hidden)하므로 보이는
  * 진입점만 filter로 지정한다.
  */
@@ -116,6 +118,51 @@ test.describe("모바일", () => {
     // 서버가 회복된 뒤 재시도하면 그대로 탈퇴가 끝난다.
     await page.setExtraHTTPHeaders({});
     await page.getByRole("button", { name: "다시 시도" }).click();
+
+    await expect(page).toHaveURL(/\/$/, { timeout: 20000 });
+    await expect(page.getByRole("heading", { name: /놓친 만큼 찾아드립니다/ })).toBeVisible({
+      timeout: 15000,
+    });
+  });
+});
+
+test.describe("앱 웹뷰 기기 토큰", () => {
+  // device-token-storage.ts의 저장 키를 거울로 사용 — 앱 웹뷰에서 등록된 토큰이 있는 상태를 재현한다.
+  const DEVICE_TOKEN_KEY = "bb.registeredDeviceToken";
+
+  test.use({ viewport: { width: 390, height: 844 } });
+  test.beforeEach(async ({ page }) => {
+    await setAuthCookie(page, "USER");
+    // 브리지 스텁 + 토큰 시드. init script는 내비게이션마다 재실행되므로
+    // 탈퇴 후 랜딩에서 재시드되지 않도록 1회만 심는다.
+    await page.addInitScript((key) => {
+      Object.assign(window, { ReactNativeWebView: { postMessage: () => {} } });
+      if (!window.localStorage.getItem("e2e.deviceTokenSeeded")) {
+        window.localStorage.setItem("e2e.deviceTokenSeeded", "1");
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({ userId: "user-e2e", token: "device-token-e2e" }),
+        );
+      }
+    }, DEVICE_TOKEN_KEY);
+  });
+
+  test("탈퇴하면 등록된 기기 푸시 토큰이 해제된다", async ({ page }) => {
+    await page.goto(WITHDRAW_PATH);
+    await openWithdrawConfirm(page);
+    await page.getByRole("button", { name: "탈퇴하기" }).click();
+
+    await expect(page).toHaveURL(/\/$/, { timeout: 20000 });
+    const remaining = await page.evaluate((key) => localStorage.getItem(key), DEVICE_TOKEN_KEY);
+    expect(remaining).toBeNull();
+  });
+
+  test("기기 토큰 해제가 실패해도 탈퇴는 그대로 진행된다", async ({ page }) => {
+    await page.setExtraHTTPHeaders({ "x-mock-failure": "device-token" });
+
+    await page.goto(WITHDRAW_PATH);
+    await openWithdrawConfirm(page);
+    await page.getByRole("button", { name: "탈퇴하기" }).click();
 
     await expect(page).toHaveURL(/\/$/, { timeout: 20000 });
     await expect(page.getByRole("heading", { name: /놓친 만큼 찾아드립니다/ })).toBeVisible({

--- a/apps/web/src/shared/api/release-registered-device-token.ts
+++ b/apps/web/src/shared/api/release-registered-device-token.ts
@@ -1,0 +1,22 @@
+import { isBridgeAvailable } from "@insurance/bridge/web";
+import {
+  clearRegisteredDeviceToken,
+  loadRegisteredDeviceToken,
+} from "@/shared/lib/device-token-storage";
+import { deleteDeviceToken } from "./delete-device-token";
+
+/**
+ * 세션이 살아있는 동안 서버에 등록된 기기 푸시 토큰을 해제한다(로그아웃·탈퇴 공용).
+ * 해제 실패가 세션 종료 자체를 막으면 안 되므로 best-effort — 오류는 삼킨다.
+ */
+export async function releaseRegisteredDeviceToken(): Promise<void> {
+  if (!isBridgeAvailable()) return;
+
+  const registered = loadRegisteredDeviceToken();
+  if (!registered) return;
+
+  try {
+    await deleteDeviceToken(registered.token);
+    clearRegisteredDeviceToken();
+  } catch {}
+}

--- a/apps/web/src/shared/api/use-logout.ts
+++ b/apps/web/src/shared/api/use-logout.ts
@@ -1,13 +1,8 @@
 "use client";
 
-import { isBridgeAvailable } from "@insurance/bridge/web";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  clearRegisteredDeviceToken,
-  loadRegisteredDeviceToken,
-} from "@/shared/lib/device-token-storage";
-import { deleteDeviceToken } from "./delete-device-token";
 import { logout } from "./logout";
+import { releaseRegisteredDeviceToken } from "./release-registered-device-token";
 
 /**
  * 로그아웃 mutation — 서버 실패 여부와 무관하게(onSettled) 캐시를 비우고 로그인 화면으로 이동한다.
@@ -19,16 +14,7 @@ export function useLogout() {
   return useMutation({
     mutationFn: async () => {
       // 로그아웃한 기기로 푸시가 가지 않도록 세션이 살아있을 때 기기 토큰을 먼저 해제.
-      // 해제 실패가 로그아웃을 막으면 안 되므로 best-effort.
-      if (isBridgeAvailable()) {
-        const registered = loadRegisteredDeviceToken();
-        if (registered) {
-          try {
-            await deleteDeviceToken(registered.token);
-            clearRegisteredDeviceToken();
-          } catch {}
-        }
-      }
+      await releaseRegisteredDeviceToken();
       return logout();
     },
     onSettled: () => {

--- a/apps/web/src/shared/api/use-withdraw.ts
+++ b/apps/web/src/shared/api/use-withdraw.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { releaseRegisteredDeviceToken } from "./release-registered-device-token";
 import { withdraw } from "./withdraw";
 
 /**
@@ -11,7 +12,11 @@ export function useWithdraw() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: withdraw,
+    mutationFn: async () => {
+      // 탈퇴한 계정의 기기로 푸시가 가지 않도록 세션이 살아있을 때 기기 토큰을 먼저 해제.
+      await releaseRegisteredDeviceToken();
+      return withdraw();
+    },
     onSuccess: () => {
       queryClient.clear();
       window.location.replace("/");


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #228

## ✅ 작업 내용

### 회원 탈퇴 시 서버에 등록된 기기 푸시 토큰을 로그아웃과 동일하게 해제하도록 수정했습니다

탈퇴(#181)와 기기 토큰 연동(#180)이 별도 PR로 들어가면서 `use-withdraw.ts`에만 해제 로직이 빠졌고, 탈퇴한 계정의 기기로 푸시가 계속 갈 수 있었습니다. 탈퇴 요청 직전에 로그아웃과 같은 경로로 토큰을 해제합니다.

<br/>

### 1. 기기 토큰 해제 로직 공용 함수 추출

`use-logout.ts`에 있던 해제 블록(브리지 확인 → 등록 토큰 조회 → 서버 해제 → 로컬 정리)을 `releaseRegisteredDeviceToken`으로 분리했습니다. 로그아웃·탈퇴가 같은 함수를 쓰므로 한쪽만 고쳐지는 재발을 막습니다.

```ts
// shared/api/release-registered-device-token.ts
export async function releaseRegisteredDeviceToken(): Promise<void> {
  if (!isBridgeAvailable()) return;

  const registered = loadRegisteredDeviceToken();
  if (!registered) return;

  try {
    await deleteDeviceToken(registered.token);
    clearRegisteredDeviceToken();
  } catch {}
}
```

<br/>

### 2. 탈퇴 mutation 훅에 해제 적용

`use-withdraw.ts`의 `mutationFn`에서 `withdraw()` 호출 직전에 공용 함수를 호출합니다. 해제 실패는 함수 안에서 삼켜 탈퇴 자체를 막지 않습니다(best-effort).

#### 세부 작업
* `release-registered-device-token.ts` → 로그아웃·탈퇴 공용 기기 토큰 해제 함수
* `use-logout.ts` → 공용 함수 호출로 교체(동작 불변)
* `use-withdraw.ts` → 탈퇴 요청 전 기기 토큰 해제 추가

## 🧪 테스트

Playwright + MSW **E2E 2개 추가**(`apps/web/e2e/account-withdraw.spec.ts`). 브리지 스텁 + 등록 토큰 시드로 앱 웹뷰 상태를 재현해 행동 기준으로 검증했습니다. chromium·mobile-chrome·mobile-safari에서 기존 탈퇴·로그아웃 스펙 포함 39개 전부 통과했습니다.

| # | 테스트 | 검증 내용 |
|---|--------|-----------|
| 1 | 탈퇴하면 등록된 기기 푸시 토큰이 해제된다 | 탈퇴 완료 후 로컬 저장 토큰이 제거된다(서버 해제 성공 후에만 지워지는 경로) |
| 2 | 기기 토큰 해제가 실패해도 탈퇴는 그대로 진행된다 | `x-mock-failure=device-token`으로 해제 500 강제 → 탈퇴 완료·랜딩 이동 |

## 💬 특이사항

### 앱 웹뷰 상태 재현 방식

브리지(`window.ReactNativeWebView`)는 앱 웹뷰에서만 존재해 E2E에서 init script로 스텁하고 localStorage에 등록 토큰을 시드했습니다. init script는 내비게이션마다 재실행되므로, 탈퇴 후 랜딩에서 토큰이 다시 심어져 해제 검증이 오염되지 않도록 1회 시드 가드를 넣었습니다.
