### PR TITLE
[Fix] 온보딩 히어로 신뢰 배지 제거 및 추천 사정사 빈 상태 추가(web)

### DIFF
--- a/apps/web/e2e/_capture-239.spec.ts
+++ b/apps/web/e2e/_capture-239.spec.ts
@@ -1,0 +1,36 @@
+import { test } from "@playwright/test";
+import { setAuthCookie } from "./_auth-cookie-helpers";
+
+/** PR #239 스크린샷 캡처 전용(CI 제외). */
+
+const PATH = "/customer/dashboard";
+
+test.use({ viewport: { width: 1280, height: 900 } });
+
+test.beforeEach(async ({ page }) => {
+  await setAuthCookie(page, "USER");
+});
+
+test("01 온보딩 히어로 배지 제거", async ({ page }) => {
+  await page.setExtraHTTPHeaders({ "x-mock-scenario": "dashboard-onboarding" });
+  await page.goto(PATH);
+  await page.waitForTimeout(2500);
+  await page.screenshot({ path: ".gallery/239-01-hero.png", fullPage: false });
+});
+
+test("02 추천 사정사 빈 상태(온보딩)", async ({ page }) => {
+  await page.setExtraHTTPHeaders({
+    "x-mock-scenario": "dashboard-onboarding",
+    "x-mock-adjusters": "empty",
+  });
+  await page.goto(PATH);
+  await page.waitForTimeout(2500);
+  await page.screenshot({ path: ".gallery/239-02-onboarding-empty.png", fullPage: true });
+});
+
+test("03 추천 카드 빈 상태(대시보드)", async ({ page }) => {
+  await page.setExtraHTTPHeaders({ "x-mock-adjusters": "empty" });
+  await page.goto(PATH);
+  await page.waitForTimeout(2500);
+  await page.screenshot({ path: ".gallery/239-03-recommend-empty.png", fullPage: true });
+});

--- a/apps/web/e2e/dashboard.spec.ts
+++ b/apps/web/e2e/dashboard.spec.ts
@@ -45,6 +45,33 @@ test("온보딩: 리포트 0건이면 온보딩 구성이 보이고 첫 분석 �
   }).toPass({ timeout: 10000 });
 });
 
+test("온보딩: 추천 사정사가 0건이면 빈 상태 안내와 전체 둘러보기가 보인다", async ({ page }) => {
+  await page.setExtraHTTPHeaders({
+    "x-mock-scenario": "dashboard-onboarding",
+    "x-mock-adjusters": "empty",
+  });
+  await page.goto(PATH);
+
+  await expect(
+    page.getByText("아직 등록된 사정사님이 없어요").filter({ visible: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: /전체 둘러보기/ }).filter({ visible: true }),
+  ).toBeVisible();
+});
+
+test("추천 사정사가 0건이면 추천 카드에도 빈 상태 안내가 보인다", async ({ page }) => {
+  await page.setExtraHTTPHeaders({ "x-mock-adjusters": "empty" });
+  await page.goto(PATH);
+
+  await expect(
+    page.getByRole("heading", { name: "이런 사정사는 어때요?" }).filter({ visible: true }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("아직 등록된 사정사님이 없어요").filter({ visible: true }),
+  ).toBeVisible();
+});
+
 test("제안 도착: 액션센터 새 제안 3건과 제안 비교 카드가 보이고 비교하기가 받은 제안 목록으로 이동한다", async ({
   page,
 }) => {

--- a/apps/web/src/app/customer/dashboard/_components/AdjusterEmpty.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/AdjusterEmpty.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import { buttonVariants } from "@/shared/ui/Button";
+import { Scale } from "@/shared/ui/icons/Scale";
+import { DASHBOARD_LINKS } from "../_model/dashboard-links";
+
+export function AdjusterEmpty() {
+  return (
+    <div className="flex h-full flex-col items-center justify-center rounded-input border border-dashed border-line-2 bg-paper-2 px-6 py-10 text-center">
+      <span className="flex size-12 items-center justify-center rounded-full bg-gold-soft text-[1.375rem] text-gold-ink">
+        <Scale />
+      </span>
+      <p className="mt-3.5 text-[0.9375rem] font-semibold text-ink">
+        아직 등록된 사정사님이 없어요
+      </p>
+      <p className="mt-1.5 text-[0.8125rem] leading-[1.6] text-ink-3">
+        검수를 맡을 손해사정사가 등록되면
+        <br />
+        이곳에서 먼저 소개해 드릴게요.
+      </p>
+      <Link
+        href={DASHBOARD_LINKS.adjusterFinder}
+        className={buttonVariants({ variant: "outline", size: "sm", className: "mt-5 bg-card" })}
+      >
+        손해사정사 둘러보기
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/customer/dashboard/_components/AdjusterRecommendCard.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/AdjusterRecommendCard.tsx
@@ -5,7 +5,7 @@ import { getInitial } from "@/shared/lib/initial";
 import { useRecommendedAdjusters } from "@/app/customer/_shared/api/use-recommended-adjusters";
 import type { AdjusterListItem } from "@/app/customer/_shared/model/adjuster-list.schema";
 import { DASHBOARD_LINKS } from "../_model/dashboard-links";
-import { EmptyState } from "./EmptyState";
+import { AdjusterEmpty } from "./AdjusterEmpty";
 
 const RECOMMEND_COUNT = 3;
 
@@ -26,7 +26,7 @@ export function AdjusterRecommendCard() {
 
       {adjusters.length === 0 ? (
         <div className="mt-4">
-          <EmptyState message="아직 등록된 사정사님이 없어요" />
+          <AdjusterEmpty />
         </div>
       ) : (
         <ul className="mt-2 divide-y divide-line-2">

--- a/apps/web/src/app/customer/dashboard/_components/AdjusterRecommendCard.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/AdjusterRecommendCard.tsx
@@ -5,6 +5,7 @@ import { getInitial } from "@/shared/lib/initial";
 import { useRecommendedAdjusters } from "@/app/customer/_shared/api/use-recommended-adjusters";
 import type { AdjusterListItem } from "@/app/customer/_shared/model/adjuster-list.schema";
 import { DASHBOARD_LINKS } from "../_model/dashboard-links";
+import { EmptyState } from "./EmptyState";
 
 const RECOMMEND_COUNT = 3;
 
@@ -23,11 +24,17 @@ export function AdjusterRecommendCard() {
         </Link>
       </header>
 
-      <ul className="mt-2 divide-y divide-line-2">
-        {adjusters.map((adjuster) => (
-          <AdjusterRecommendRow key={adjuster.adjusterId} adjuster={adjuster} />
-        ))}
-      </ul>
+      {adjusters.length === 0 ? (
+        <div className="mt-4">
+          <EmptyState message="아직 등록된 사정사님이 없어요" />
+        </div>
+      ) : (
+        <ul className="mt-2 divide-y divide-line-2">
+          {adjusters.map((adjuster) => (
+            <AdjusterRecommendRow key={adjuster.adjusterId} adjuster={adjuster} />
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/apps/web/src/app/customer/dashboard/_components/onboarding/OnboardingAdjusters.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/onboarding/OnboardingAdjusters.tsx
@@ -5,7 +5,7 @@ import { getInitial } from "@/shared/lib/initial";
 import { useRecommendedAdjusters } from "@/app/customer/_shared/api/use-recommended-adjusters";
 import type { AdjusterListItem } from "@/app/customer/_shared/model/adjuster-list.schema";
 import { DASHBOARD_LINKS } from "../../_model/dashboard-links";
-import { EmptyState } from "../EmptyState";
+import { AdjusterEmpty } from "../AdjusterEmpty";
 
 const MOBILE_VISIBLE_COUNT = 3;
 
@@ -13,7 +13,7 @@ export function OnboardingAdjusters() {
   const adjusters = useRecommendedAdjusters();
 
   return (
-    <section className="rounded-card border border-line bg-card p-[1.6875rem]">
+    <section className="flex h-full flex-col rounded-card border border-line bg-card p-[1.6875rem]">
       <header className="flex items-center justify-between">
         <h2 className="text-base font-bold text-ink">어떤 사정사가 함께하나요?</h2>
         <Link
@@ -25,8 +25,8 @@ export function OnboardingAdjusters() {
       </header>
 
       {adjusters.length === 0 ? (
-        <div className="mt-4">
-          <EmptyState message="아직 등록된 사정사님이 없어요" />
+        <div className="mt-4 flex-1">
+          <AdjusterEmpty />
         </div>
       ) : (
         <ul className="mt-4 grid gap-3 md:grid-cols-2">

--- a/apps/web/src/app/customer/dashboard/_components/onboarding/OnboardingAdjusters.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/onboarding/OnboardingAdjusters.tsx
@@ -5,6 +5,7 @@ import { getInitial } from "@/shared/lib/initial";
 import { useRecommendedAdjusters } from "@/app/customer/_shared/api/use-recommended-adjusters";
 import type { AdjusterListItem } from "@/app/customer/_shared/model/adjuster-list.schema";
 import { DASHBOARD_LINKS } from "../../_model/dashboard-links";
+import { EmptyState } from "../EmptyState";
 
 const MOBILE_VISIBLE_COUNT = 3;
 
@@ -23,15 +24,21 @@ export function OnboardingAdjusters() {
         </Link>
       </header>
 
-      <ul className="mt-4 grid gap-3 md:grid-cols-2">
-        {adjusters.map((adjuster, index) => (
-          <AdjusterMiniCard
-            key={adjuster.adjusterId}
-            adjuster={adjuster}
-            hiddenOnMobile={index >= MOBILE_VISIBLE_COUNT}
-          />
-        ))}
-      </ul>
+      {adjusters.length === 0 ? (
+        <div className="mt-4">
+          <EmptyState message="아직 등록된 사정사님이 없어요" />
+        </div>
+      ) : (
+        <ul className="mt-4 grid gap-3 md:grid-cols-2">
+          {adjusters.map((adjuster, index) => (
+            <AdjusterMiniCard
+              key={adjuster.adjusterId}
+              adjuster={adjuster}
+              hiddenOnMobile={index >= MOBILE_VISIBLE_COUNT}
+            />
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/apps/web/src/app/customer/dashboard/_components/onboarding/OnboardingHero.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/onboarding/OnboardingHero.tsx
@@ -52,21 +52,7 @@ export function OnboardingHero() {
             진행 과정 알아보기
           </a>
         </div>
-
-        <div className="mt-4 flex flex-wrap justify-center gap-2.5">
-          <TrustChip label="매칭 전 비용" highlight="0원" />
-          <TrustChip label="여러 제안" highlight="한눈에 비교" />
-        </div>
       </div>
     </section>
-  );
-}
-
-function TrustChip({ label, highlight }: { label: string; highlight: string }) {
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-pill border border-white/12 bg-white/6 px-3.5 py-2">
-      <span className="text-[0.78125rem] font-medium text-white/78">{label}</span>
-      <span className="text-[0.78125rem] font-semibold text-gold-2">{highlight}</span>
-    </span>
   );
 }

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -2827,6 +2827,8 @@ export const handlers = [
   ),
 
   // 손해사정사 목록 조회 (이슈 #47) — 반드시 :adjusterId 핸들러보다 앞에 등록
+  //   x-mock-adjusters=empty → 0건 빈 상태 검증(이슈 #239). 대시보드 상태(x-mock-scenario)와
+  //   조합해야 하므로 x-mock-failure처럼 별도 축 헤더로 둔다.
   http.get(`${API_BASE_URL}/adjusters`, async ({ request }) => {
     await delay(400);
 
@@ -2843,6 +2845,23 @@ export const handlers = [
         },
         { status: 500 },
       );
+    }
+
+    if (request.headers.get("x-mock-adjusters") === "empty") {
+      return HttpResponse.json({
+        status: "200",
+        message: "정상 처리되었습니다.",
+        data: {
+          list: [],
+          pagination: { page: 1, size: 20, totalElements: 0, totalPages: 0, hasNext: false },
+          meta: {
+            totalAdjusterCount: 0,
+            averageRating: 0,
+            totalConsultCount: 0,
+            averageCareer: 0,
+          },
+        },
+      });
     }
 
     const specialty = (url.searchParams.get("specialty") ?? "").trim();


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #239

## ✅ 작업 내용

### 온보딩 히어로의 신뢰 배지를 제거하고, 추천 사정사가 없을 때의 빈 상태를 추가했습니다
<img width="1000" alt="온보딩 히어로" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/34878e0ea0dad343280d10a9bcc71bb3f4979dc6/.pr-assets/issue-239/239-01-hero.png" />

첫 방문 고객이 보는 `/customer/dashboard` 온보딩 화면입니다. 근거 없는 마케팅 문구를 걷어내고, 등록된 사정사가 0건일 때 빈 카드가 노출되던 문제를 함께 고쳤습니다.

<br/>

### 1. 히어로 신뢰 배지 제거

"매칭 전 비용 0원", "여러 제안 한눈에 비교" 배지를 노출하지 않기로 해서 `TrustChip`과 사용처를 삭제했습니다. 하단 여백은 섹션 자체 패딩이 담당하므로 별도 조정은 하지 않았습니다.

#### 세부 작업
* `OnboardingHero.tsx` → 배지 영역과 `TrustChip` 제거

<br/>

### 2. 추천 사정사 빈 상태 추가

추천 목록을 그대로 `map`만 하고 있어 사정사가 없으면 제목과 "전체 둘러보기"만 남은 빈 카드가 보였습니다. 0건이면 목록 대신 안내 문구를 띄우고, 제목과 링크는 그대로 유지합니다.

<img width="1000" alt="온보딩 추천 사정사 빈 상태" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/34878e0ea0dad343280d10a9bcc71bb3f4979dc6/.pr-assets/issue-239/239-02-onboarding-empty.png" />

```tsx
// onboarding/OnboardingAdjusters.tsx
{adjusters.length === 0 ? (
  <div className="mt-4">
    <EmptyState message="아직 등록된 사정사님이 없어요" />
  </div>
) : (
  <ul className="mt-4 grid gap-3 md:grid-cols-2">...</ul>
)}
```

빈 상태는 저울 아이콘·안내 문구·"손해사정사 둘러보기" 버튼을 담아 카드 높이를 채웁니다. 두 카드가 같은 화면을 쓰므로 `AdjusterEmpty`로 분리했습니다.

#### 세부 작업
* `AdjusterEmpty.tsx` → 추천 사정사 빈 상태 화면
* `OnboardingAdjusters.tsx` → 0건 분기 추가, 카드 높이를 채우도록 세로 배치 변경

<br/>

### 3. 대시보드 추천 카드 빈 상태 추가

같은 조회 훅(`useRecommendedAdjusters`)을 쓰는 "이런 사정사는 어때요?" 카드에도 동일한 결함이 있어 함께 고쳤습니다. 이슈 범위 밖이지만 원인이 같아 별도 커밋으로 분리했습니다.

<img width="1000" alt="대시보드 추천 카드 빈 상태" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/34878e0ea0dad343280d10a9bcc71bb3f4979dc6/.pr-assets/issue-239/239-03-recommend-empty.png" />

#### 세부 작업
* `AdjusterRecommendCard.tsx` → 0건 분기 추가

## 🧪 테스트

Playwright + MSW **E2E 2개**(`apps/web/e2e/dashboard.spec.ts`). 핵심 사용자 흐름을 행동 기준으로 검증했습니다.

| # | 테스트 | 검증 내용 |
|---|--------|-----------|
| 1 | 온보딩에서 추천 사정사가 0건이면 빈 상태 안내와 전체 둘러보기가 보인다 | 빈 응답 시 안내 문구 노출, 제목·링크 유지 |
| 2 | 추천 사정사가 0건이면 추천 카드에도 빈 상태 안내가 보인다 | 대시보드 추천 카드의 동일 분기 |

사정사가 있을 때 기존 카드 리스트가 그대로 보이는 것은 기존 온보딩 테스트가 이미 검증합니다.
