### PR TITLE
[Settings] 앱 패키지명·EAS 빌드 설정 추가(app)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -14,7 +14,6 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.brbosang.app",
-      "buildNumber": "1",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "사진 첨부를 위해 사진 보관함 접근 권한이 필요합니다.",
         "NSCameraUsageDescription": "사진 촬영 후 첨부를 위해 카메라 접근 권한이 필요합니다.",
@@ -30,7 +29,6 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 1,
       "permissions": [
         "android.permission.CAMERA",
         "android.permission.READ_MEDIA_IMAGES",

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "mobile",
+    "name": "바른보상",
     "slug": "mobile",
     "version": "1.0.0",
     "scheme": "bareun",
@@ -13,6 +13,8 @@
     "userInterfaceStyle": "light",
     "ios": {
       "supportsTablet": true,
+      "bundleIdentifier": "com.brbosang.app",
+      "buildNumber": "1",
       "infoPlist": {
         "NSPhotoLibraryUsageDescription": "사진 첨부를 위해 사진 보관함 접근 권한이 필요합니다.",
         "NSCameraUsageDescription": "사진 촬영 후 첨부를 위해 카메라 접근 권한이 필요합니다.",
@@ -20,6 +22,7 @@
       }
     },
     "android": {
+      "package": "com.brbosang.app",
       "adaptiveIcon": {
         "backgroundColor": "#2f3648",
         "foregroundImage": "./assets/android-icon-foreground.png",
@@ -27,6 +30,7 @@
         "monochromeImage": "./assets/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
+      "versionCode": 1,
       "permissions": [
         "android.permission.CAMERA",
         "android.permission.READ_MEDIA_IMAGES",
@@ -35,6 +39,12 @@
     },
     "web": {
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "extra": {
+      "eas": {
+        "projectId": "e452ee69-2a3a-439a-90f8-4239eeddd608"
+      }
+    },
+    "owner": "teambrbosang"
   }
 }

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "바른보상",
     "slug": "mobile",
     "version": "1.0.0",
-    "scheme": "bareun",
+    "scheme": "brbosang",
     "plugins": [
       "expo-notifications",
       "expo-web-browser"

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,7 +1,7 @@
 {
   "cli": {
     "version": ">= 16.0.0",
-    "appVersionSource": "local"
+    "appVersionSource": "remote"
   },
   "build": {
     "base": {

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -28,6 +28,13 @@
       "env": {
         "EXPO_PUBLIC_WEB_URL": "https://www.brbosang.com"
       }
+    },
+    "production-apk": {
+      "extends": "production",
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
     }
   },
   "submit": {

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,36 @@
+{
+  "cli": {
+    "version": ">= 16.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "base": {
+      "node": "24.16.0"
+    },
+    "development": {
+      "extends": "base",
+      "developmentClient": true,
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_WEB_URL": "http://localhost:3000"
+      }
+    },
+    "preview": {
+      "extends": "base",
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_WEB_URL": "https://REPLACE_WITH_STAGING_URL"
+      }
+    },
+    "production": {
+      "extends": "base",
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_WEB_URL": "https://www.brbosang.com"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/apps/mobile/src/WebViewScreen.tsx
+++ b/apps/mobile/src/WebViewScreen.tsx
@@ -7,7 +7,7 @@ import { ActivityIndicator, BackHandler, Pressable, StyleSheet, Text, View } fro
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
 
-import { EXTERNAL_AUTH_HOSTS, getAllowedHosts } from './config/allowed-hosts';
+import { EXTERNAL_AUTH_HOSTS, getAllowedHosts, getServiceHosts } from './config/allowed-hosts';
 import { APP_USER_AGENT_SUFFIX } from './config/user-agent';
 import { getWebUrl } from './config/web-url';
 import { createLoadDecider } from './lib/create-should-start-load';
@@ -18,7 +18,7 @@ import { useNotificationResponse } from './push/use-notification-response';
 
 const decideLoad = createLoadDecider(getAllowedHosts(), EXTERNAL_AUTH_HOSTS);
 const AUTH_SESSION_RETURN_URL = `${APP_SCHEME}://login/oauth2/code`;
-const SERVICE_HOST = new URL(getWebUrl()).host;
+const SERVICE_HOSTS = getServiceHosts();
 
 export function WebViewScreen() {
   const webViewRef = useRef<WebView>(null);
@@ -99,7 +99,7 @@ export function WebViewScreen() {
           // 서비스 밖 문서(OAuth 등)로 이동하면 웹 준비 상태를 해제해 대기 중인 토큰 주입을 차단.
           // 서비스 복귀 시 웹이 WEB_READY를 다시 보낸다.
           try {
-            if (new URL(navState.url).host !== SERVICE_HOST) {
+            if (!SERVICE_HOSTS.includes(new URL(navState.url).host)) {
               webReadyRef.current = false;
             }
           } catch {

--- a/apps/mobile/src/config/allowed-hosts.ts
+++ b/apps/mobile/src/config/allowed-hosts.ts
@@ -5,6 +5,18 @@ const OAUTH_HOSTS = ['kauth.kakao.com', 'accounts.kakao.com', 'nid.naver.com', '
 // WebView 로그인을 차단하는 제공자(구글 등) 추가 시 여기에 호스트 등록 — 외부 브라우저 인증 세션으로 우회
 export const EXTERNAL_AUTH_HOSTS: string[] = [];
 
+const IP_OR_LOCALHOST = /^(localhost|\d+\.\d+\.\d+\.\d+)(:\d+)?$/;
+
+// apex·www 양쪽이 리다이렉트 없이 서비스를 응답하므로 둘 다 서비스 호스트로 취급한다.
+// 한쪽만 인정하면 나머지로 들어온 링크가 외부 브라우저로 빠지고 서비스 이탈로 오판된다.
+export function getServiceHosts(): string[] {
+  const host = new URL(getWebUrl()).host;
+  if (IP_OR_LOCALHOST.test(host)) {
+    return [host];
+  }
+  return host.startsWith('www.') ? [host, host.slice(4)] : [host, `www.${host}`];
+}
+
 export function getAllowedHosts(): string[] {
-  return [new URL(getWebUrl()).host, ...OAUTH_HOSTS];
+  return [...getServiceHosts(), ...OAUTH_HOSTS];
 }

--- a/apps/mobile/src/linking/deep-link.ts
+++ b/apps/mobile/src/linking/deep-link.ts
@@ -1,6 +1,6 @@
 import { getWebUrl } from '../config/web-url';
 
-export const APP_SCHEME = 'bareun';
+export const APP_SCHEME = 'brbosang';
 
 export function mapDeepLinkToWebUrl(deepLinkUrl: string): string | null {
   const match = deepLinkUrl.match(new RegExp(`^${APP_SCHEME}://(.*)$`));

--- a/apps/mobile/src/push/push-token.ts
+++ b/apps/mobile/src/push/push-token.ts
@@ -42,7 +42,6 @@ export async function getPushToken(): Promise<PushTokenResult | null> {
   if (!(await ensurePermission())) {
     return null;
   }
-  // EAS projectId는 앱 아이덴티티 이슈에서 설정 — 없으면 토큰 발급이 실패하므로 null 반환
   const projectId: string | undefined = Constants.expoConfig?.extra?.eas?.projectId;
   try {
     const { data } = await Notifications.getExpoPushTokenAsync(

--- a/apps/web/e2e/app-oauth-callback.spec.ts
+++ b/apps/web/e2e/app-oauth-callback.spec.ts
@@ -7,7 +7,7 @@ import { setAuthCookie } from "./_auth-cookie-helpers";
  * 원칙: 앱에서 시작한 로그인(state `app.` 접두어)이 외부 브라우저에서 콜백에 도달하면
  *       code를 교환하지 않고 앱 딥링크로 넘긴다(쿠키가 외부 브라우저에 남는 것 방지).
  *       앱 웹뷰 안(UA에 BareunApp)에서는 접두어와 무관하게 정상 교환한다.
- * 인가 리다이렉트·실제 딥링크 복귀(bareun://)는 브라우저 밖 영역이라 검증하지 않고,
+ * 인가 리다이렉트·실제 딥링크 복귀(brbosang://)는 브라우저 밖 영역이라 검증하지 않고,
  * "교환이 실행됐는가(홈 이동 여부)"와 실패 콜백의 로그인 복귀만 검증한다.
  */
 
@@ -18,7 +18,7 @@ test.describe("외부 브라우저 복귀", () => {
     page,
     browserName,
   }) => {
-    // webkit은 미지원 스킴(bareun://) 이동 시 동작이 달라 chromium 계열만 검증한다.
+    // webkit은 미지원 스킴(brbosang://) 이동 시 동작이 달라 chromium 계열만 검증한다.
     test.skip(browserName === "webkit", "커스텀 스킴 이동 동작이 달라 chromium만 검증");
 
     await page.goto("/login/oauth2/code/kakao?code=valid&state=app.s1");

--- a/apps/web/src/shared/lib/app-webview-token.ts
+++ b/apps/web/src/shared/lib/app-webview-token.ts
@@ -3,7 +3,7 @@
 export const APP_WEBVIEW_UA_TOKEN = "BareunApp";
 
 // 앱 딥링크 스킴. 모바일 측 상수와 상호 참조: apps/mobile/src/linking/deep-link.ts (APP_SCHEME).
-export const APP_DEEP_LINK_SCHEME = "bareun";
+export const APP_DEEP_LINK_SCHEME = "brbosang";
 
 export function isAppWebViewUserAgent(userAgent: string): boolean {
   return userAgent.includes(APP_WEBVIEW_UA_TOKEN);


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #238

## ✅ 작업 내용

- `android.package`·`ios.bundleIdentifier`를 `com.brbosang.app`으로 지정
- `expo.name`을 실제 표시명 "바른보상"으로 변경
- `eas init`으로 EAS 프로젝트 연결(`extra.eas.projectId`·`owner` 추가)
- `eas.json` production 프로필의 `EXPO_PUBLIC_WEB_URL`을 `https://www.brbosang.com`으로 지정
- 빌드 서버 Node 버전을 `24.16.0`으로 고정(`base` 프로필 상속)
- 앱 버전 관리를 `appVersionSource: "remote"`로 전환
- 딥링크 스킴을 `bareun`에서 `brbosang`으로 변경(패키지명·도메인 표기와 일치)
- 기기 설치용 `production-apk` 프로필 추가(production 설정 상속, 내부 배포 APK)
- 웹뷰 서비스 호스트를 apex·www 양쪽으로 확장

## ✅ 검증

production 프로필로 Android 빌드를 실행해 성공까지 확인했습니다. ([빌드 로그](https://expo.dev/accounts/teambrbosang/projects/mobile/builds/98eed7e8-3ab4-433c-89a4-b42fa40bc772))

- `Installing node v24.16.0` → `pnpm install --frozen-lockfile` 통과 → `BUILD SUCCESSFUL`, `.aab` 산출
- 빌드 환경에 `EXPO_PUBLIC_WEB_URL=https://www.brbosang.com` 주입 확인
- 앱 설정에 `"name": "바른보상"` 반영 확인
- `https://www.brbosang.com` 응답 200 확인
- remote 버전 소스 전환 후 재빌드해 서버 측 versionCode 증가 및 `app.json` 무변경 확인

## 📌 참고

- 첫 빌드는 의존성 설치 단계에서 실패했습니다. EAS 기본 이미지의 Node 20에서 레포가 고정한 pnpm 11(`packageManager: pnpm@11.5.2`)이 `node:sqlite`를 찾지 못해 죽는 문제라, `eas.json`에 Node 버전을 박아 해결했습니다.
- `preview` 프로필의 `EXPO_PUBLIC_WEB_URL`은 스테이징 주소 확정 전이라 placeholder를 유지했습니다. 이슈에 "스테이징 주소 확정 후 반영"으로 명시된 항목입니다.
- 웹뷰 실제 동작과 앱 표시 이름은 기기 설치 후 확인이 필요합니다. `.aab`는 스토어 업로드용이라 기기에 직접 설치할 수 없습니다.

- 딥링크 스킴 변경은 웹·앱 양쪽 상수를 함께 바꿔야 동작합니다. 스킴은 외부 OAuth 콘솔에 등록되는 값이 아니라(카카오·애플에 등록된 redirect URI는 웹 주소입니다) 웹 콜백 페이지가 앱을 깨울 때만 쓰는 내부 약속이라, 두 상수와 `app.json`만 맞추면 됩니다.
- Expo 프로젝트 `slug`는 `mobile`로 유지했습니다. 실제 프로젝트 연결은 `projectId`가 하므로 앱 동작·빌드에 영향이 없습니다.
- UA 토큰 `BareunApp/1.0`은 스킴과 별개 식별자라 이번 변경에 포함하지 않았습니다.
- `brbosang.com`·`www.brbosang.com` 두 도메인이 리다이렉트 없이 각각 200을 반환합니다. 운영 URL을 `www`로 정하면서 apex로 들어온 링크가 허용 호스트 밖으로 밀려나 외부 브라우저로 빠지고, 서비스 이탈로 오판돼 토큰 주입까지 막히는 문제가 있어 양쪽을 서비스 호스트로 취급하도록 고쳤습니다. 다만 근본 해결은 인프라에서 apex를 www로 301 리다이렉트하는 것이라, 정본 도메인 확정은 별도로 필요합니다.
