### PR TITLE
[Feature] 채팅방 신고하기 기능 추가(web)

### DIFF
--- a/.claude/skills/frontend-feature/references/naming-dictionary.md
+++ b/.claude/skills/frontend-feature/references/naming-dictionary.md
@@ -91,6 +91,11 @@ body: `adjusterId` → resp: `reportId` · `adjusterId` · `status`(`AWAITING_AD
 ### chat — `GET /chats`
 items[]{ `chatRoomId` · `participants`(uuid[]) · `lastMessage` · `updatedAt` } — 메시지 송수신은 WebSocket(본 API는 목록만)
 
+### chat(신고) — `POST /chats/{chatRoomId}/report` (이슈 #244, 명세없음 → FE 초안, 사용자 확정 2026-08-04)
+- req `reason`(`ChatReportReason` enum: `SPAM`|`ABUSE`|`FRAUD`|`PRIVACY_VIOLATION`|`OTHER`) · `reasonDetail`(string, 최대 500자, `OTHER` 선택 시 필수)
+- resp 201 `chatReportId`(uuid) · `chatRoomId` · `reason` · `createdAt`
+- 중복 신고 제한 없음(횟수 무제한 재신고 허용, 409/`DUPLICATE_RESOURCE` 처리 없음) — 사용자 확정
+
 ### payment — `GET /payments/history`
 items[]{ `paymentId` · `amount`(int) · `type`(`SUBSCRIPTION`) · `status`(`PAID`) · `paidAt` } + `page` · `totalCount`
 - `POST /subscriptions`: `tier`(`BASIC`|`PRO`) · `paymentMethod`(PG 토큰) → resp `subscriptionId` · `tier` · `status`(`ACTIVE`) · `expiresAt`

--- a/apps/web/e2e/_capture-187.spec.ts
+++ b/apps/web/e2e/_capture-187.spec.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test";
 import { setAuthCookie } from "./_auth-cookie-helpers";
 import { hideQueryDevtools } from "./_region-helpers";
+import { openChatHeaderMenu } from "./_chat-header-helpers";
 
 /** PR 스크린샷 캡처 헬퍼(#187 채팅 공유 리포트). 테스트 아님 — CI 제외(testIgnore). */
 
@@ -15,10 +16,11 @@ test.beforeEach(async ({ page }) => {
   await hideQueryDevtools(page);
 });
 
-test("01 채팅방 리포트 보기 버튼(데스크톱)", async ({ page }) => {
+test("01 채팅방 리포트 보기 항목(데스크톱)", async ({ page }) => {
   await page.setViewportSize(DESKTOP);
   await page.goto(`/customer/chat/${ROOM_1}`);
-  await page.getByRole("link", { name: "리포트 보기" }).waitFor({ timeout: 15000 });
+  const menu = await openChatHeaderMenu(page);
+  await menu.getByRole("menuitem", { name: "리포트 보기" }).waitFor({ timeout: 15000 });
   await page.screenshot({ path: `${DIR}/01-chat-report-button-desktop.png` });
 });
 

--- a/apps/web/e2e/_capture-244.spec.ts
+++ b/apps/web/e2e/_capture-244.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { setAuthCookie } from "./_auth-cookie-helpers";
+import { openChatHeaderMenu } from "./_chat-header-helpers";
 import { hideQueryDevtools } from "./_region-helpers";
 
 /** PR 스크린샷 캡처 헬퍼(#244). 테스트 아님 — CI 제외(testIgnore). */
@@ -11,16 +12,17 @@ const MOBILE = { width: 390, height: 844 };
 
 const ROOM_1 = "e1000000-0000-4000-8000-000000000001";
 const CUSTOMER_ROOM = `/customer/chat/${ROOM_1}`;
+const DIALOG_TITLE = "이 대화를 신고할까요?";
 
 test.beforeEach(async ({ page }) => {
   await hideQueryDevtools(page);
   await setAuthCookie(page, "USER");
 });
 
-test("01 데스크톱 헤더 신고 버튼", async ({ page }) => {
+test("01 데스크톱 헤더 더보기 패널", async ({ page }) => {
   await page.setViewportSize(DESKTOP);
   await page.goto(CUSTOMER_ROOM);
-  await expect(page.getByRole("button", { name: "신고", exact: true })).toBeVisible();
+  await openChatHeaderMenu(page);
   await page.screenshot({ path: `${DIR}/244-01-header-desktop.png` });
 });
 
@@ -28,12 +30,10 @@ test("02 신고 다이얼로그 사유 선택", async ({ page }) => {
   await page.setViewportSize(DESKTOP);
   await page.goto(CUSTOMER_ROOM);
 
-  const dialog = page.getByRole("dialog", { name: "이 대화를 신고할까요?" });
-  await expect(async () => {
-    await page.getByRole("button", { name: "신고", exact: true }).click();
-    await expect(dialog).toBeVisible();
-  }).toPass({ timeout: 10000 });
+  const menu = await openChatHeaderMenu(page);
+  await menu.getByRole("menuitem", { name: "신고" }).click();
 
+  const dialog = page.getByRole("dialog", { name: DIALOG_TITLE });
   await dialog.getByText("욕설·비방·괴롭힘", { exact: true }).click();
   await expect(dialog.getByRole("radio", { name: "욕설·비방·괴롭힘" })).toBeChecked();
   await page.screenshot({ path: `${DIR}/244-02-dialog-reason.png` });
@@ -43,20 +43,18 @@ test("03 기타 사유 상세 입력", async ({ page }) => {
   await page.setViewportSize(DESKTOP);
   await page.goto(CUSTOMER_ROOM);
 
-  const dialog = page.getByRole("dialog", { name: "이 대화를 신고할까요?" });
-  await expect(async () => {
-    await page.getByRole("button", { name: "신고", exact: true }).click();
-    await expect(dialog).toBeVisible();
-  }).toPass({ timeout: 10000 });
+  const menu = await openChatHeaderMenu(page);
+  await menu.getByRole("menuitem", { name: "신고" }).click();
 
+  const dialog = page.getByRole("dialog", { name: DIALOG_TITLE });
   await dialog.getByText("기타", { exact: true }).click();
   await dialog.getByLabel(/상세 사유/).fill("상담 중 반복적인 욕설이 있었습니다.");
   await page.screenshot({ path: `${DIR}/244-03-dialog-other.png` });
 });
 
-test("04 모바일 헤더 아이콘 버튼", async ({ page }) => {
+test("04 모바일 헤더 더보기 패널", async ({ page }) => {
   await page.setViewportSize(MOBILE);
   await page.goto(CUSTOMER_ROOM);
-  await expect(page.getByRole("button", { name: "신고하기" }).first()).toBeVisible();
+  await openChatHeaderMenu(page);
   await page.screenshot({ path: `${DIR}/244-04-header-mobile.png`, fullPage: true });
 });

--- a/apps/web/e2e/_capture-244.spec.ts
+++ b/apps/web/e2e/_capture-244.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+import { setAuthCookie } from "./_auth-cookie-helpers";
+import { hideQueryDevtools } from "./_region-helpers";
+
+/** PR 스크린샷 캡처 헬퍼(#244). 테스트 아님 — CI 제외(testIgnore). */
+
+const DIR = "../../.pr-assets/issue-244";
+
+const DESKTOP = { width: 1280, height: 900 };
+const MOBILE = { width: 390, height: 844 };
+
+const ROOM_1 = "e1000000-0000-4000-8000-000000000001";
+const CUSTOMER_ROOM = `/customer/chat/${ROOM_1}`;
+
+test.beforeEach(async ({ page }) => {
+  await hideQueryDevtools(page);
+  await setAuthCookie(page, "USER");
+});
+
+test("01 데스크톱 헤더 신고 버튼", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+  await expect(page.getByRole("button", { name: "신고", exact: true })).toBeVisible();
+  await page.screenshot({ path: `${DIR}/244-01-header-desktop.png` });
+});
+
+test("02 신고 다이얼로그 사유 선택", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+
+  const dialog = page.getByRole("dialog", { name: "이 대화를 신고할까요?" });
+  await expect(async () => {
+    await page.getByRole("button", { name: "신고", exact: true }).click();
+    await expect(dialog).toBeVisible();
+  }).toPass({ timeout: 10000 });
+
+  await dialog.getByText("욕설·비방·괴롭힘", { exact: true }).click();
+  await expect(dialog.getByRole("radio", { name: "욕설·비방·괴롭힘" })).toBeChecked();
+  await page.screenshot({ path: `${DIR}/244-02-dialog-reason.png` });
+});
+
+test("03 기타 사유 상세 입력", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+
+  const dialog = page.getByRole("dialog", { name: "이 대화를 신고할까요?" });
+  await expect(async () => {
+    await page.getByRole("button", { name: "신고", exact: true }).click();
+    await expect(dialog).toBeVisible();
+  }).toPass({ timeout: 10000 });
+
+  await dialog.getByText("기타", { exact: true }).click();
+  await dialog.getByLabel(/상세 사유/).fill("상담 중 반복적인 욕설이 있었습니다.");
+  await page.screenshot({ path: `${DIR}/244-03-dialog-other.png` });
+});
+
+test("04 모바일 헤더 아이콘 버튼", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto(CUSTOMER_ROOM);
+  await expect(page.getByRole("button", { name: "신고하기" }).first()).toBeVisible();
+  await page.screenshot({ path: `${DIR}/244-04-header-mobile.png`, fullPage: true });
+});

--- a/apps/web/e2e/_chat-header-helpers.ts
+++ b/apps/web/e2e/_chat-header-helpers.ts
@@ -1,0 +1,26 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * 채팅 스레드 헤더 보조 액션은 전부 "더보기" 패널 안에 있다(데스크톱·모바일 동일).
+ * 하이드레이션 전 클릭은 유실되므로 패널이 열릴 때까지 재시도한다.
+ */
+export async function openChatHeaderMenu(page: Page) {
+  const trigger = page.getByRole("button", { name: "더보기" });
+  const menu = page.getByRole("menu");
+
+  await expect(async () => {
+    if ((await trigger.getAttribute("aria-expanded")) !== "true") {
+      await trigger.click();
+    }
+    await expect(trigger).toHaveAttribute("aria-expanded", "true");
+  }).toPass({ timeout: 15000 });
+  await expect(menu).toBeVisible();
+
+  return menu;
+}
+
+/** 더보기를 열고 해당 항목을 누른다. */
+export async function clickChatHeaderAction(page: Page, name: string) {
+  const menu = await openChatHeaderMenu(page);
+  await menu.getByRole("menuitem", { name, exact: true }).click();
+}

--- a/apps/web/e2e/chat-report.spec.ts
+++ b/apps/web/e2e/chat-report.spec.ts
@@ -137,8 +137,13 @@ test("상담이 종료된 방에서도 신고 항목은 그대로 남는다", as
   await expect(menu.getByRole("menuitem", { name: "신고" })).toBeVisible();
 
   // 매칭 거절로 방을 종료(roomStatus CLOSED) — 매칭 액션은 사라져도 신고는 남아야 한다
-  await menu.getByRole("menuitem", { name: "매칭 거절" }).click();
-  await page.getByRole("dialog").getByRole("button", { name: "매칭 거절" }).click();
+  // 하이드레이션 전 클릭 유실 가드(openReportDialog와 동일 패턴)
+  const rejectDialog = page.getByRole("dialog");
+  await expect(async () => {
+    await menu.getByRole("menuitem", { name: "매칭 거절" }).click();
+    await expect(rejectDialog).toBeVisible();
+  }).toPass({ timeout: 10000 });
+  await rejectDialog.getByRole("button", { name: "매칭 거절" }).click();
   await expect(page.getByRole("textbox", { name: "메시지 입력" })).toBeDisabled();
 
   const dialog = await openReportDialog(page);

--- a/apps/web/e2e/chat-report.spec.ts
+++ b/apps/web/e2e/chat-report.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test, type Page } from "@playwright/test";
+import { setAuthCookie } from "./_auth-cookie-helpers";
+
+/**
+ * 채팅방 신고 E2E (이슈 #244).
+ * 원칙: 핵심 사용자 흐름만 — 신고 접수(고객·파트너 공통), 노출 조건 회귀 가드, 실패 후 재제출.
+ * 응답은 기본 MSW 핸들러가 제공(항상 201 접수, 중복 제한 없음). 실패는 x-mock-failure=chat-report로 500 강제
+ * (MSW 워커가 fetch를 가로채 page.route 불가 — repo 표준 주입 방식).
+ * 회귀 가드: 신고 버튼은 roomStatus(CLOSED 포함)·mobileActions와 무관하게 항상 노출돼야 한다.
+ * 정적 위임(미테스트): reason enum·reasonDetail 500자 제한 등 형식 검증은 zod·TS가 강제.
+ */
+
+const ROOM_1 = "e1000000-0000-4000-8000-000000000001";
+const CUSTOMER_ROOM = `/customer/chat/${ROOM_1}`;
+const PARTNER_ROOM = `/partner/chat/${ROOM_1}`;
+
+const DESKTOP = { width: 1280, height: 900 };
+const MOBILE = { width: 390, height: 844 };
+
+const DIALOG_TITLE = "이 대화를 신고할까요?";
+const SUCCESS_TOAST = "신고가 접수됐어요. 운영팀이 확인 후 안내드릴게요.";
+const FAIL_MESSAGE = "신고 접수에 실패했어요. 잠시 후 다시 시도해 주세요.";
+const DETAIL_TEXT = "상담 중 반복적인 욕설이 있었습니다.";
+
+test.beforeEach(async ({ page }) => {
+  await setAuthCookie(page, "USER");
+});
+
+/** 데스크톱 헤더의 `신고` pill을 눌러 다이얼로그를 연다(하이드레이션 전 클릭 유실 가드). */
+async function openReportDialog(page: Page) {
+  const dialog = page.getByRole("dialog", { name: DIALOG_TITLE });
+
+  await expect(async () => {
+    await page.getByRole("button", { name: "신고", exact: true }).click();
+    await expect(dialog).toBeVisible();
+  }).toPass({ timeout: 10000 });
+
+  return dialog;
+}
+
+/** 사유는 사용자처럼 라벨(카드)을 눌러 고른다 — 라디오 자체는 시각적으로 감춰져 있다. */
+async function selectReason(dialog: ReturnType<Page["getByRole"]>, label: string) {
+  await dialog.getByText(label, { exact: true }).click();
+  await expect(dialog.getByRole("radio", { name: label })).toBeChecked();
+}
+
+test("사유를 고르고 신고하면 다이얼로그가 닫히고 접수 안내가 보인다", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+
+  const dialog = await openReportDialog(page);
+  await expect(
+    dialog.getByText("신고 내용은 운영팀만 확인하며, 상대방에게는 알려지지 않아요."),
+  ).toBeVisible();
+
+  await selectReason(dialog, "욕설·비방·괴롭힘");
+  await dialog.getByRole("button", { name: "신고하기" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText(SUCCESS_TOAST).first()).toBeVisible();
+});
+
+test("사유를 고르지 않으면 신고하기 버튼을 누를 수 없다", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+
+  const dialog = await openReportDialog(page);
+  await expect(dialog.getByRole("button", { name: "신고하기" })).toBeDisabled();
+
+  await selectReason(dialog, "사기 의심");
+  await expect(dialog.getByRole("button", { name: "신고하기" })).toBeEnabled();
+});
+
+test("기타를 고르면 상세 사유를 적어야 신고할 수 있다", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+
+  const dialog = await openReportDialog(page);
+  const submit = dialog.getByRole("button", { name: "신고하기" });
+  const detail = dialog.getByLabel(/상세 사유/);
+
+  await selectReason(dialog, "기타");
+  await expect(submit).toBeDisabled();
+
+  await detail.fill("   ");
+  await expect(submit).toBeDisabled();
+
+  await detail.fill(DETAIL_TEXT);
+  await expect(submit).toBeEnabled();
+});
+
+test("접수에 실패하면 입력값이 남은 채 안내가 뜨고 다시 보내면 접수된다", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.setExtraHTTPHeaders({ "x-mock-failure": "chat-report" });
+  await page.goto(CUSTOMER_ROOM);
+
+  const dialog = await openReportDialog(page);
+  await selectReason(dialog, "개인정보 침해");
+  await dialog.getByLabel(/상세 사유/).fill(DETAIL_TEXT);
+  await dialog.getByRole("button", { name: "신고하기" }).click();
+
+  // 다이얼로그는 열린 채 인라인 안내 + 입력값 보존(재제출 가능)
+  await expect(dialog.getByRole("alert")).toHaveText(FAIL_MESSAGE);
+  await expect(dialog.getByRole("radio", { name: "개인정보 침해" })).toBeChecked();
+  await expect(dialog.getByLabel(/상세 사유/)).toHaveValue(DETAIL_TEXT);
+
+  // 실패 주입을 걷어내고 그대로 재제출 → 접수 성공
+  await page.setExtraHTTPHeaders({});
+  await dialog.getByRole("button", { name: "신고하기" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText(SUCCESS_TOAST).first()).toBeVisible();
+});
+
+test("같은 방을 연달아 두 번 신고해도 매번 접수된다", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+
+  for (const reason of ["스팸·광고", "사기 의심"]) {
+    const dialog = await openReportDialog(page);
+    await selectReason(dialog, reason);
+    await dialog.getByRole("button", { name: "신고하기" }).click();
+
+    // 닫힘 = 성공(실패면 인라인 안내와 함께 열린 채로 남는다)
+    await expect(dialog).toBeHidden();
+    await expect(page.getByText(FAIL_MESSAGE)).toHaveCount(0);
+  }
+
+  await expect(page.getByText(SUCCESS_TOAST).first()).toBeVisible();
+});
+
+test("상담이 종료된 방에서도 신고 버튼은 그대로 남는다", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto(CUSTOMER_ROOM);
+
+  const reportButton = page.getByRole("button", { name: "신고", exact: true });
+  await expect(reportButton).toBeVisible();
+
+  // 매칭 거절로 방을 종료(roomStatus CLOSED) — 상담 종료 액션은 사라져도 신고는 남아야 한다
+  await page.getByRole("button", { name: "매칭 거절" }).click();
+  await page.getByRole("dialog").getByRole("button", { name: "매칭 거절" }).click();
+  await expect(page.getByRole("textbox", { name: "메시지 입력" })).toBeDisabled();
+
+  await expect(reportButton).toBeVisible();
+  const dialog = await openReportDialog(page);
+  await selectReason(dialog, "스팸·광고");
+  await dialog.getByRole("button", { name: "신고하기" }).click();
+  await expect(dialog).toBeHidden();
+});
+
+test("파트너 방에서도 상대를 신고할 수 있다", async ({ page }) => {
+  await setAuthCookie(page, "CERTIFICATED_ADJUSTER");
+  await page.setViewportSize(DESKTOP);
+  await page.goto(PARTNER_ROOM);
+
+  const dialog = await openReportDialog(page);
+  await selectReason(dialog, "스팸·광고");
+  await dialog.getByRole("button", { name: "신고하기" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText(SUCCESS_TOAST).first()).toBeVisible();
+});
+
+test("모바일에서는 신고하기 아이콘 버튼으로 다이얼로그를 연다", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto(CUSTOMER_ROOM);
+
+  const dialog = page.getByRole("dialog", { name: DIALOG_TITLE });
+  // 헤더 아이콘 버튼(DOM 선두) — 다이얼로그 제출 버튼과 이름이 같아 첫 번째로 좁힌다
+  const mobileReport = page.getByRole("button", { name: "신고하기" }).first();
+
+  await expect(mobileReport).toBeVisible();
+  await expect(async () => {
+    await mobileReport.click();
+    await expect(dialog).toBeVisible();
+  }).toPass({ timeout: 10000 });
+
+  await selectReason(dialog, "욕설·비방·괴롭힘");
+  await dialog.getByRole("button", { name: "신고하기" }).click();
+  await expect(dialog).toBeHidden();
+});

--- a/apps/web/e2e/chat-report.spec.ts
+++ b/apps/web/e2e/chat-report.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test, type Page } from "@playwright/test";
 import { setAuthCookie } from "./_auth-cookie-helpers";
+import { clickChatHeaderAction, openChatHeaderMenu } from "./_chat-header-helpers";
 
 /**
  * 채팅방 신고 E2E (이슈 #244).
  * 원칙: 핵심 사용자 흐름만 — 신고 접수(고객·파트너 공통), 노출 조건 회귀 가드, 실패 후 재제출.
  * 응답은 기본 MSW 핸들러가 제공(항상 201 접수, 중복 제한 없음). 실패는 x-mock-failure=chat-report로 500 강제
  * (MSW 워커가 fetch를 가로채 page.route 불가 — repo 표준 주입 방식).
- * 회귀 가드: 신고 버튼은 roomStatus(CLOSED 포함)·mobileActions와 무관하게 항상 노출돼야 한다.
+ * 회귀 가드: 신고 항목은 roomStatus(CLOSED 포함)·뷰포트와 무관하게 헤더 "더보기"에 항상 있어야 한다.
  * 정적 위임(미테스트): reason enum·reasonDetail 500자 제한 등 형식 검증은 zod·TS가 강제.
  */
 
@@ -26,14 +27,12 @@ test.beforeEach(async ({ page }) => {
   await setAuthCookie(page, "USER");
 });
 
-/** 데스크톱 헤더의 `신고` pill을 눌러 다이얼로그를 연다(하이드레이션 전 클릭 유실 가드). */
+/** 헤더 "더보기"를 열고 `신고` 항목을 눌러 다이얼로그를 연다. */
 async function openReportDialog(page: Page) {
   const dialog = page.getByRole("dialog", { name: DIALOG_TITLE });
 
-  await expect(async () => {
-    await page.getByRole("button", { name: "신고", exact: true }).click();
-    await expect(dialog).toBeVisible();
-  }).toPass({ timeout: 10000 });
+  await clickChatHeaderAction(page, "신고");
+  await expect(dialog).toBeVisible();
 
   return dialog;
 }
@@ -129,19 +128,18 @@ test("같은 방을 연달아 두 번 신고해도 매번 접수된다", async (
   await expect(page.getByText(SUCCESS_TOAST).first()).toBeVisible();
 });
 
-test("상담이 종료된 방에서도 신고 버튼은 그대로 남는다", async ({ page }) => {
+test("상담이 종료된 방에서도 신고 항목은 그대로 남는다", async ({ page }) => {
   await page.setViewportSize(DESKTOP);
   await page.goto(CUSTOMER_ROOM);
 
-  const reportButton = page.getByRole("button", { name: "신고", exact: true });
-  await expect(reportButton).toBeVisible();
+  const menu = await openChatHeaderMenu(page);
+  await expect(menu.getByRole("menuitem", { name: "신고" })).toBeVisible();
 
-  // 매칭 거절로 방을 종료(roomStatus CLOSED) — 상담 종료 액션은 사라져도 신고는 남아야 한다
-  await page.getByRole("button", { name: "매칭 거절" }).click();
+  // 매칭 거절로 방을 종료(roomStatus CLOSED) — 매칭 액션은 사라져도 신고는 남아야 한다
+  await menu.getByRole("menuitem", { name: "매칭 거절" }).click();
   await page.getByRole("dialog").getByRole("button", { name: "매칭 거절" }).click();
   await expect(page.getByRole("textbox", { name: "메시지 입력" })).toBeDisabled();
 
-  await expect(reportButton).toBeVisible();
   const dialog = await openReportDialog(page);
   await selectReason(dialog, "스팸·광고");
   await dialog.getByRole("button", { name: "신고하기" }).click();
@@ -161,20 +159,11 @@ test("파트너 방에서도 상대를 신고할 수 있다", async ({ page }) =
   await expect(page.getByText(SUCCESS_TOAST).first()).toBeVisible();
 });
 
-test("모바일에서는 신고하기 아이콘 버튼으로 다이얼로그를 연다", async ({ page }) => {
+test("모바일에서도 같은 더보기 항목으로 신고할 수 있다", async ({ page }) => {
   await page.setViewportSize(MOBILE);
   await page.goto(CUSTOMER_ROOM);
 
-  const dialog = page.getByRole("dialog", { name: DIALOG_TITLE });
-  // 헤더 아이콘 버튼(DOM 선두) — 다이얼로그 제출 버튼과 이름이 같아 첫 번째로 좁힌다
-  const mobileReport = page.getByRole("button", { name: "신고하기" }).first();
-
-  await expect(mobileReport).toBeVisible();
-  await expect(async () => {
-    await mobileReport.click();
-    await expect(dialog).toBeVisible();
-  }).toPass({ timeout: 10000 });
-
+  const dialog = await openReportDialog(page);
   await selectReason(dialog, "욕설·비방·괴롭힘");
   await dialog.getByRole("button", { name: "신고하기" }).click();
   await expect(dialog).toBeHidden();

--- a/apps/web/e2e/chat-report.spec.ts
+++ b/apps/web/e2e/chat-report.spec.ts
@@ -129,7 +129,8 @@ test("같은 방을 연달아 두 번 신고해도 매번 접수된다", async (
 });
 
 test("상담이 종료된 방에서도 신고 항목은 그대로 남는다", async ({ page }) => {
-  await page.setViewportSize(DESKTOP);
+  // 매칭 거절은 데스크톱 더보기에서 뺐다(팀 결정) — 모바일 뷰포트로 방을 종료시킨다.
+  await page.setViewportSize(MOBILE);
   await page.goto(CUSTOMER_ROOM);
 
   const menu = await openChatHeaderMenu(page);

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { setAuthCookie } from "./_auth-cookie-helpers";
+import { clickChatHeaderAction, openChatHeaderMenu } from "./_chat-header-helpers";
 
 /**
  * 채팅(상담) E2E — 비교→매칭 마켓플레이스 재설계(이슈 #48).
@@ -7,11 +8,11 @@ import { setAuthCookie } from "./_auth-cookie-helpers";
  * customer 흐름: 목록 상태 그룹(상담 중·비교 N) → 스레드 진입(히스토리·날짜 구분선·mine/theirs)
  *   → 전송(낙관적 append·롤백) → 매칭 완료(모달·형제 자동종료 캐스케이드)·매칭 거절(단일 종료)
  *   → 매칭 후 사건 진행 보기 → 공유 리포트 열기.
- * partner 무회귀: 평면 목록(그룹 없음)·헤더 상담 종료 버튼·상담 종료 흐름 그대로.
+ * partner 무회귀: 평면 목록(그룹 없음)·헤더 더보기 상담 종료·상담 종료 흐름 그대로.
  *
  * 시드(기본 MSW): 같은 reportId·caseNo 3방(김도현·정우성·윤지후) 전부 ACTIVE.
  * 김도현·정우성 COUNSELING, 윤지후 SENT(#231 선생성 방) — 셋 다 그룹은 "비교 중"으로 동일.
- * 전송 실패는 x-mock-failure 헤더로 강제. 매칭 액션 버튼은 데스크톱 헤더(md+) 전용 → 뷰포트 확대.
+ * 전송 실패는 x-mock-failure 헤더로 강제. 헤더 보조 액션은 데스크톱·모바일 모두 "더보기" 패널 안에 있다.
  */
 
 const CUSTOMER_LIST = "/customer/chat";
@@ -180,35 +181,35 @@ test("이전 대화는 위로 스크롤하면 이어서 불러온다", async ({ 
   await expect(page.getByText("이전 답변 내용 1번입니다.")).toBeVisible();
 });
 
-test("비교 중 방 헤더에는 매칭 거절·매칭 완료 버튼이 보인다", async ({ page }) => {
-  // 매칭 액션은 데스크톱 헤더(md+) 전용
+test("비교 중 방 헤더 더보기에는 매칭 거절·매칭 완료 항목이 보인다", async ({ page }) => {
   await page.setViewportSize(DESKTOP);
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
-  await expect(page.getByRole("button", { name: "매칭 거절" }).first()).toBeVisible();
-  await expect(page.getByRole("button", { name: "매칭 완료" }).first()).toBeVisible();
+  const menu = await openChatHeaderMenu(page);
+  await expect(menu.getByRole("menuitem", { name: "매칭 거절" })).toBeVisible();
+  await expect(menu.getByRole("menuitem", { name: "매칭 완료" })).toBeVisible();
   // 비교 배너(스레드 상단)
   await expect(page.getByText(/명과 상담 중 · 마음에 들면/)).toBeVisible();
 });
 
-test("모바일에서도 헤더 매칭 버튼으로 매칭을 완료할 수 있다", async ({ page }) => {
+test("모바일에서도 헤더 더보기로 매칭을 완료할 수 있다", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 });
 
   // 목록 상단 비교 배너(모바일 전용 문구)
   await page.goto(CUSTOMER_LIST);
   await expect(page.getByText(/3명과 상담 중이에요/)).toBeVisible();
 
-  // 스레드 헤더 컴팩트 매칭 버튼 → 모달 → 확정
+  // 스레드 헤더 더보기 → 매칭 완료 → 모달 → 확정
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
-  await expect(page.getByRole("button", { name: "매칭 거절" })).toBeVisible();
-  await page.getByRole("button", { name: "매칭 완료" }).click();
+  await clickChatHeaderAction(page, "매칭 완료");
 
   const dialog = page.getByRole("dialog");
   await expect(dialog.getByText("함께 종료되는 상담 2건")).toBeVisible();
   await dialog.getByRole("button", { name: "매칭 완료" }).click();
 
-  // 매칭 후 — 모바일 헤더에 사건 진행 링크
-  await expect(page.getByRole("link", { name: /사건 진행/ })).toBeVisible();
+  // 매칭 후 — 더보기 항목이 사건 진행 보기로 바뀐다
+  const menu = await openChatHeaderMenu(page);
+  await expect(menu.getByRole("menuitem", { name: "사건 진행 보기" })).toBeVisible();
 });
 
 test("매칭 완료를 확정하면 형제 상담이 종료되고 매칭 완료로 바뀐다", async ({
@@ -217,7 +218,7 @@ test("매칭 완료를 확정하면 형제 상담이 종료되고 매칭 완료�
   await page.setViewportSize(DESKTOP);
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
-  await page.getByRole("button", { name: "매칭 완료" }).click();
+  await clickChatHeaderAction(page, "매칭 완료");
 
   // 확인 모달 — 함께 종료되는 상담 2건(정우성·윤지후)
   const dialog = page.getByRole("dialog");
@@ -233,10 +234,8 @@ test("매칭 완료를 확정하면 형제 상담이 종료되고 매칭 완료�
   await expect(page.getByText("종료된 상담", { exact: true })).toBeVisible();
 
   // 매칭 후 사건 진행 보기 → 방 공유 리포트(사정사 검수 결과) 이동
-  await expect(async () => {
-    await page.getByRole("link", { name: "사건 진행 보기" }).click();
-    await expect(page).toHaveURL(new RegExp(`/customer/chat/${ROOM_1}/shared-report`));
-  }).toPass({ timeout: 10000 });
+  await clickChatHeaderAction(page, "사건 진행 보기");
+  await expect(page).toHaveURL(new RegExp(`/customer/chat/${ROOM_1}/shared-report`));
 });
 
 test("매칭 거절을 누르면 그 방만 종료되고 입력이 차단된다", async ({ page }) => {
@@ -245,7 +244,7 @@ test("매칭 거절을 누르면 그 방만 종료되고 입력이 차단된다"
 
   const input = page.getByRole("textbox", { name: "메시지 입력" });
   await expect(input).toBeEnabled();
-  await page.getByRole("button", { name: "매칭 거절" }).click();
+  await clickChatHeaderAction(page, "매칭 거절");
 
   // 거절도 확인 모달을 거친다(비가역 액션)
   const rejectDialog = page.getByRole("dialog");
@@ -267,7 +266,7 @@ test("종료된 상담 그룹은 기본으로 접혀 있고 헤더를 누르면 
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
   // 김도현 방을 거절(확인 모달 경유)해 종료 그룹 생성
-  await page.getByRole("button", { name: "매칭 거절" }).click();
+  await clickChatHeaderAction(page, "매칭 거절");
   await page.getByRole("dialog").getByRole("button", { name: "매칭 거절" }).click();
   const endedHeader = page.getByRole("button", { name: /종료된 상담/ });
   await expect(endedHeader).toBeVisible();
@@ -323,14 +322,11 @@ test("데스크톱에서는 목록과 스레드가 분할 뷰로 함께 보이�
 });
 
 test("고객 방에서 공유 리포트를 열면 방 검수 결과로 이동한다", async ({ page }) => {
-  // 비교 중 모바일 헤더는 매칭 버튼이 리포트 아이콘을 대체(Figma 1012:9931) — 리포트 보기는 데스크톱 헤더에서
   await page.setViewportSize(DESKTOP);
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
-  await expect(async () => {
-    await page.getByRole("link", { name: "리포트 보기" }).click();
-    await expect(page).toHaveURL(new RegExp(`/customer/chat/${ROOM_1}/shared-report`));
-  }).toPass({ timeout: 10000 });
+  await clickChatHeaderAction(page, "리포트 보기");
+  await expect(page).toHaveURL(new RegExp(`/customer/chat/${ROOM_1}/shared-report`));
 });
 
 test("파트너 채팅은 그룹 없는 평면 목록·상담 종료 흐름을 유지한다(무회귀)", async ({
@@ -345,12 +341,13 @@ test("파트너 채팅은 그룹 없는 평면 목록·상담 종료 흐름을 �
   await expect(page.getByText("상담 중 · 비교", { exact: true })).toHaveCount(0);
   await expect(page.getByText("진행 중 · 매칭 완료", { exact: true })).toHaveCount(0);
 
-  // 스레드 — partner는 상담 종료 버튼(매칭 아님) 유지
+  // 스레드 — partner 더보기는 상담 종료(매칭 아님) 유지
   await page.goto(`${PARTNER_LIST}/${ROOM_1}`);
-  await expect(page.getByRole("button", { name: "매칭 완료" })).toHaveCount(0);
   await expect(page.getByRole("textbox", { name: "메시지 입력" })).toBeVisible();
 
-  await page.getByRole("button", { name: "상담 종료" }).click();
+  const menu = await openChatHeaderMenu(page);
+  await expect(menu.getByRole("menuitem", { name: "매칭 완료" })).toHaveCount(0);
+  await menu.getByRole("menuitem", { name: "상담 종료" }).click();
   const input = page.getByRole("textbox", { name: "메시지 입력" });
   await expect(input).toBeDisabled();
   await expect(input).toHaveAttribute(
@@ -363,8 +360,6 @@ test("파트너 방에서 공유 리포트를 열면 파트너 검수로 이동�
   await setAuthCookie(page, "CERTIFICATED_ADJUSTER");
   await page.goto(`${PARTNER_LIST}/${ROOM_1}`);
 
-  await expect(async () => {
-    await page.getByRole("link", { name: "리포트 보기" }).click();
-    await expect(page).toHaveURL(new RegExp(`/partner/review/${SHARED_REPORT_ID}`));
-  }).toPass({ timeout: 10000 });
+  await clickChatHeaderAction(page, "리포트 보기");
+  await expect(page).toHaveURL(new RegExp(`/partner/review/${SHARED_REPORT_ID}`));
 });

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -12,7 +12,8 @@ import { clickChatHeaderAction, openChatHeaderMenu } from "./_chat-header-helper
  *
  * 시드(기본 MSW): 같은 reportId·caseNo 3방(김도현·정우성·윤지후) 전부 ACTIVE.
  * 김도현·정우성 COUNSELING, 윤지후 SENT(#231 선생성 방) — 셋 다 그룹은 "비교 중"으로 동일.
- * 전송 실패는 x-mock-failure 헤더로 강제. 헤더 보조 액션은 데스크톱·모바일 모두 "더보기" 패널 안에 있다.
+ * 전송 실패는 x-mock-failure 헤더로 강제. 헤더 보조 액션은 "더보기" 패널 안에 있다 — 단, 매칭 완료는
+ * 데스크톱 비교 배너에 전용 버튼이 있어 더보기에서 빠지고, 매칭 거절은 데스크톱에 접근 경로가 없다(모바일 더보기 전용, 팀 결정).
  */
 
 const CUSTOMER_LIST = "/customer/chat";
@@ -26,6 +27,7 @@ const ROOM_1 = "e1000000-0000-4000-8000-000000000001";
 const SHARED_REPORT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 
 const DESKTOP = { width: 1280, height: 900 };
+const MOBILE = { width: 390, height: 844 };
 
 // 기본은 고객 흐름(USER) — 파트너 무회귀 테스트 2건은 각자 CERTIFICATED_ADJUSTER로 덮어쓴다.
 test.beforeEach(async ({ page }) => {
@@ -56,7 +58,7 @@ test("검색어를 입력하면 이름·마지막 메시지로 필터되고 없�
   page,
 }) => {
   // 대화 검색은 모바일 전용 UI(Figma 데스크톱 목록엔 검색창 없음)
-  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setViewportSize(MOBILE);
   await page.goto(CUSTOMER_LIST);
 
   const search = page.getByRole("searchbox", { name: "대화 검색" });
@@ -181,19 +183,35 @@ test("이전 대화는 위로 스크롤하면 이어서 불러온다", async ({ 
   await expect(page.getByText("이전 답변 내용 1번입니다.")).toBeVisible();
 });
 
-test("비교 중 방 헤더 더보기에는 매칭 거절·매칭 완료 항목이 보인다", async ({ page }) => {
+test("데스크톱 비교 배너에는 매칭 완료 버튼이 있고 더보기엔 매칭 액션이 없다", async ({
+  page,
+}) => {
   await page.setViewportSize(DESKTOP);
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
+  // 비교 배너(스레드 상단) 안의 전용 버튼 — 더보기를 거치지 않는다
+  await expect(
+    page.getByText(/명과 상담 중 · 마음에 들면 매칭 완료를 누르세요/),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "매칭 완료" })).toBeVisible();
+
+  // 더보기엔 매칭 완료·매칭 거절 둘 다 없음(매칭 거절은 데스크톱 접근 경로 자체가 없다, 팀 결정)
   const menu = await openChatHeaderMenu(page);
-  await expect(menu.getByRole("menuitem", { name: "매칭 거절" })).toBeVisible();
+  await expect(menu.getByRole("menuitem", { name: "매칭 완료" })).toHaveCount(0);
+  await expect(menu.getByRole("menuitem", { name: "매칭 거절" })).toHaveCount(0);
+});
+
+test("모바일 헤더 더보기에는 매칭 완료·매칭 거절이 모두 있다", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
+
+  const menu = await openChatHeaderMenu(page);
   await expect(menu.getByRole("menuitem", { name: "매칭 완료" })).toBeVisible();
-  // 비교 배너(스레드 상단)
-  await expect(page.getByText(/명과 상담 중 · 마음에 들면/)).toBeVisible();
+  await expect(menu.getByRole("menuitem", { name: "매칭 거절" })).toBeVisible();
 });
 
 test("모바일에서도 헤더 더보기로 매칭을 완료할 수 있다", async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 });
+  await page.setViewportSize(MOBILE);
 
   // 목록 상단 비교 배너(모바일 전용 문구)
   await page.goto(CUSTOMER_LIST);
@@ -218,7 +236,8 @@ test("매칭 완료를 확정하면 형제 상담이 종료되고 매칭 완료�
   await page.setViewportSize(DESKTOP);
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
-  await clickChatHeaderAction(page, "매칭 완료");
+  // 데스크톱은 더보기가 아니라 비교 배너의 전용 버튼으로 매칭 완료를 연다
+  await page.getByRole("button", { name: "매칭 완료" }).click();
 
   // 확인 모달 — 함께 종료되는 상담 2건(정우성·윤지후)
   const dialog = page.getByRole("dialog");
@@ -244,12 +263,16 @@ test("매칭 거절을 누르면 그 방만 종료되고 입력이 차단된다"
 
   const input = page.getByRole("textbox", { name: "메시지 입력" });
   await expect(input).toBeEnabled();
+
+  // 매칭 거절은 데스크톱에 접근 경로가 없다(팀 결정) — 잠깐 모바일 뷰포트로 거절만 실행하고 되돌아온다.
+  await page.setViewportSize(MOBILE);
   await clickChatHeaderAction(page, "매칭 거절");
 
   // 거절도 확인 모달을 거친다(비가역 액션)
   const rejectDialog = page.getByRole("dialog");
   await expect(rejectDialog.getByText(/상담을 종료할까요\?/)).toBeVisible();
   await rejectDialog.getByRole("button", { name: "매칭 거절" }).click();
+  await page.setViewportSize(DESKTOP);
 
   // 거절한 방은 종료 — 입력·전송이 회색 비활성으로 잠김, 나머지 비교 유지
   await expect(input).toBeDisabled();
@@ -265,9 +288,13 @@ test("종료된 상담 그룹은 기본으로 접혀 있고 헤더를 누르면 
   await page.setViewportSize(DESKTOP);
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
-  // 김도현 방을 거절(확인 모달 경유)해 종료 그룹 생성
+  // 매칭 거절은 데스크톱에 접근 경로가 없다(팀 결정) — 잠깐 모바일 뷰포트로 거절만 실행하고 되돌아온다.
+  // 뒤이은 목록 접힘/펼침 검증은 데스크톱 분할 뷰가 필요하다.
+  await page.setViewportSize(MOBILE);
   await clickChatHeaderAction(page, "매칭 거절");
   await page.getByRole("dialog").getByRole("button", { name: "매칭 거절" }).click();
+  await page.setViewportSize(DESKTOP);
+
   const endedHeader = page.getByRole("button", { name: /종료된 상담/ });
   await expect(endedHeader).toBeVisible();
 

--- a/apps/web/e2e/shared-report.spec.ts
+++ b/apps/web/e2e/shared-report.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { setAuthCookie } from "./_auth-cookie-helpers";
+import { clickChatHeaderAction } from "./_chat-header-helpers";
 
 /**
  * 채팅방 공유 리포트(사정사 검수 결과) E2E — 이슈 #187.
@@ -21,14 +22,12 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("상담방에서 리포트 보기를 누르면 공유 리포트로 이동한다", async ({ page }) => {
-  // 비교 중 모바일 헤더는 매칭 버튼이 리포트 아이콘을 대체 — 리포트 보기는 데스크톱 헤더에서
+  // 리포트 보기는 헤더 "더보기" 패널 안(데스크톱·모바일 동일)
   await page.setViewportSize(DESKTOP);
   await page.goto(`${CUSTOMER_LIST}/${ROOM_1}`);
 
-  await expect(async () => {
-    await page.getByRole("link", { name: "리포트 보기" }).click();
-    await expect(page).toHaveURL(new RegExp(`${ROOM_1}/shared-report`));
-  }).toPass({ timeout: 10000 });
+  await clickChatHeaderAction(page, "리포트 보기");
+  await expect(page).toHaveURL(new RegExp(`${ROOM_1}/shared-report`));
 
   await expect(page.getByText("김도현 손해사정사")).toBeVisible();
 });

--- a/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
@@ -20,7 +20,7 @@ import { X } from "@/shared/ui/icons/X";
 import { ChatComparisonBanner } from "@/shared/ui/chat/ChatComparisonBanner";
 import {
   ChatThreadHeader,
-  type ChatThreadHeaderMenuAction,
+  type ChatThreadHeaderMenuAction
 } from "@/shared/ui/chat/ChatThreadHeader";
 import { ChatThreadView } from "@/shared/ui/chat/ChatThreadView";
 import { MatchConfirmModal } from "@/shared/ui/chat/MatchConfirmModal";
@@ -44,7 +44,7 @@ export interface CustomerChatThreadContentProps {
  */
 export function CustomerChatThreadContent({
   chatRoomId,
-  chatBasePath,
+  chatBasePath
 }: CustomerChatThreadContentProps) {
   const router = useRouter();
   const { data: room } = useChatRoom(chatRoomId);
@@ -56,7 +56,7 @@ export function CustomerChatThreadContent({
   const accept = useAcceptChat(chatRoomId);
   const reject = useRejectChat(chatRoomId);
   const { mutate: markRead } = useReadChat(chatRoomId);
-  const report = useReportChatDialog(chatRoomId);
+  const reportDialog = useReportChatDialog(chatRoomId);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [rejectOpen, setRejectOpen] = useState(false);
 
@@ -66,35 +66,26 @@ export function CustomerChatThreadContent({
 
   const group = toMatchGroup(room.matchStatus, room.roomStatus);
   // 원본 리포트가 아니라 사정사 검수 결과(공유 리포트)로 이동. 사정사 검색 방은 공유 리포트가 없어 비활성.
-  const sharedReportHref = room.reportId
-    ? `${chatBasePath}/${chatRoomId}/shared-report`
-    : "#";
+  const sharedReportHref = room.reportId ? `${chatBasePath}/${chatRoomId}/shared-report` : "#";
   const matchPending = accept.isPending || reject.isPending;
 
   // 목록 응답에 현재 방이 아직 없어도(딥링크 직진입) 비교 수에 자신은 포함
-  const listSiblings = room.reportId
-    ? rooms.filter((item) => item.reportId === room.reportId)
-    : [];
-  const siblings = listSiblings.some(
-    (item) => item.chatRoomId === room.chatRoomId,
-  )
+  const listSiblings = room.reportId ? rooms.filter((item) => item.reportId === room.reportId) : [];
+  const siblings = listSiblings.some((item) => item.chatRoomId === room.chatRoomId)
     ? listSiblings
     : [room, ...listSiblings];
   const comparingCount = siblings.filter(
-    (item) => toMatchGroup(item.matchStatus, item.roomStatus) === "comparing",
+    (item) => toMatchGroup(item.matchStatus, item.roomStatus) === "comparing"
   ).length;
   const endingConsultations = siblings
     .filter(
       (item) =>
         item.chatRoomId !== room.chatRoomId &&
-        toMatchGroup(item.matchStatus, item.roomStatus) === "comparing",
+        toMatchGroup(item.matchStatus, item.roomStatus) === "comparing"
     )
     .map((item) => ({ name: item.counterpart.name }));
 
-  const subtitle = [
-    room.caseNo,
-    SUBTITLE_SUFFIX[group] ?? ROOM_STATUS_META[room.roomStatus].label,
-  ]
+  const subtitle = [room.caseNo, SUBTITLE_SUFFIX[group] ?? ROOM_STATUS_META[room.roomStatus].label]
     .filter(Boolean)
     .join(" · ");
 
@@ -103,14 +94,12 @@ export function CustomerChatThreadContent({
   const confirmReject = () =>
     reject.mutate(undefined, {
       onSuccess: () => setRejectOpen(false),
-      onError: () =>
-        toast.error("매칭 거절에 실패했어요. 잠시 후 다시 시도해 주세요."),
+      onError: () => toast.error("매칭 거절에 실패했어요. 잠시 후 다시 시도해 주세요.")
     });
   const confirmMatch = () =>
     accept.mutate(undefined, {
       onSuccess: () => setConfirmOpen(false),
-      onError: () =>
-        toast.error("매칭 완료에 실패했어요. 잠시 후 다시 시도해 주세요."),
+      onError: () => toast.error("매칭 완료에 실패했어요. 잠시 후 다시 시도해 주세요.")
     });
 
   const matchActions: ChatThreadHeaderMenuAction[] =
@@ -123,7 +112,7 @@ export function CustomerChatThreadContent({
             onClick: () => setConfirmOpen(true),
             disabled: matchPending,
             // 데스크톱은 비교 배너에 전용 버튼이 있어 더보기에선 모바일에만 노출
-            mobileOnly: true,
+            mobileOnly: true
           },
           {
             key: "reject",
@@ -133,8 +122,8 @@ export function CustomerChatThreadContent({
             tone: "danger",
             disabled: matchPending,
             // 데스크톱에선 접근 경로 없음(모바일 더보기 전용) — 팀 결정
-            mobileOnly: true,
-          },
+            mobileOnly: true
+          }
         ]
       : group === "matched"
         ? [
@@ -142,15 +131,15 @@ export function CustomerChatThreadContent({
               key: "progress",
               label: "사건 진행 보기",
               icon: <ArrowRight />,
-              href: sharedReportHref,
-            },
+              href: sharedReportHref
+            }
           ]
         : [];
 
   const menuActions: ChatThreadHeaderMenuAction[] = [
     { key: "report", label: "리포트 보기", icon: <FileText />, href: sharedReportHref },
     ...matchActions,
-    { key: "report-chat", label: "신고", icon: <AlertTriangle />, onClick: report.openDialog },
+    { key: "report-chat", label: "신고", icon: <AlertTriangle />, onClick: reportDialog.openDialog }
   ];
 
   return (
@@ -203,8 +192,7 @@ export function CustomerChatThreadContent({
         sendFailed={sendMessage.isError}
         onPickFile={(file) =>
           sendAttachment.mutate(file, {
-            onError: () =>
-              toast.error("파일 전송에 실패했어요. 잠시 후 다시 시도해 주세요."),
+            onError: () => toast.error("파일 전송에 실패했어요. 잠시 후 다시 시도해 주세요.")
           })
         }
         attachPending={sendAttachment.isPending}
@@ -228,12 +216,12 @@ export function CustomerChatThreadContent({
       />
 
       <ReportChatDialog
-        open={report.open}
+        open={reportDialog.open}
         counterpartName={room.counterpart.name}
-        pending={report.pending}
-        errorMessage={report.errorMessage}
-        onSubmit={report.submit}
-        onClose={report.closeDialog}
+        pending={reportDialog.pending}
+        errorMessage={reportDialog.errorMessage}
+        onSubmit={reportDialog.submit}
+        onClose={reportDialog.closeDialog}
       />
     </div>
   );
@@ -241,5 +229,5 @@ export function CustomerChatThreadContent({
 
 const SUBTITLE_SUFFIX: Partial<Record<ReturnType<typeof toMatchGroup>, string>> = {
   comparing: "상담 중 · 비교 중",
-  matched: "매칭 완료 · 진행 중",
+  matched: "매칭 완료 · 진행 중"
 };

--- a/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useChatList } from "@/shared/api/chat/use-chat-list";
@@ -13,11 +12,16 @@ import { useReadChat } from "@/shared/api/chat/use-read-chat";
 import { useRejectChat } from "@/shared/api/chat/use-reject-chat";
 import { useSendChatAttachment } from "@/shared/api/chat/use-send-chat-attachment";
 import { useSendChatMessage } from "@/shared/api/chat/use-send-chat-message";
+import { AlertTriangle } from "@/shared/ui/icons/AlertTriangle";
 import { ArrowRight } from "@/shared/ui/icons/ArrowRight";
 import { CheckCircle } from "@/shared/ui/icons/CheckCircle";
+import { FileText } from "@/shared/ui/icons/FileText";
 import { X } from "@/shared/ui/icons/X";
 import { ChatComparisonBanner } from "@/shared/ui/chat/ChatComparisonBanner";
-import { ChatThreadHeader } from "@/shared/ui/chat/ChatThreadHeader";
+import {
+  ChatThreadHeader,
+  type ChatThreadHeaderMenuAction,
+} from "@/shared/ui/chat/ChatThreadHeader";
 import { ChatThreadView } from "@/shared/ui/chat/ChatThreadView";
 import { MatchConfirmModal } from "@/shared/ui/chat/MatchConfirmModal";
 import { MatchRejectConfirmModal } from "@/shared/ui/chat/MatchRejectConfirmModal";
@@ -109,70 +113,41 @@ export function CustomerChatThreadContent({
         toast.error("매칭 완료에 실패했어요. 잠시 후 다시 시도해 주세요."),
     });
 
-  const actions =
-    group === "comparing" ? (
-      // Figma 1012:11044/11042 — 매칭 완료(primary·ink)가 앞, 매칭 거절(terra)이 뒤
-      <>
-        <button
-          type="button"
-          onClick={() => setConfirmOpen(true)}
-          disabled={matchPending}
-          className="flex items-center gap-1.5 rounded-full bg-ink px-3.5 py-1.5 text-[0.8125rem] font-semibold text-white transition hover:brightness-[.96] disabled:cursor-not-allowed disabled:opacity-[.42]"
-        >
-          매칭 완료
-          <CheckCircle className="text-[0.9375rem]" />
-        </button>
-        <button
-          type="button"
-          onClick={rejectMatch}
-          disabled={matchPending}
-          className="flex items-center gap-1.5 rounded-full bg-terra px-3.5 py-1.5 text-[0.8125rem] font-semibold text-white transition hover:brightness-[.96] disabled:cursor-not-allowed disabled:opacity-[.42]"
-        >
-          매칭 거절
-          <X className="text-[0.875rem]" />
-        </button>
-      </>
-    ) : group === "matched" ? (
-      <Link
-        href={sharedReportHref}
-        className="flex items-center gap-1.5 rounded-full bg-ink px-3.5 py-1.5 text-[0.8125rem] font-semibold text-white transition hover:brightness-[.96]"
-      >
-        사건 진행 보기
-        <ArrowRight className="text-[0.9375rem]" />
-      </Link>
-    ) : null;
+  const matchActions: ChatThreadHeaderMenuAction[] =
+    group === "comparing"
+      ? [
+          {
+            key: "accept",
+            label: "매칭 완료",
+            icon: <CheckCircle />,
+            onClick: () => setConfirmOpen(true),
+            disabled: matchPending,
+          },
+          {
+            key: "reject",
+            label: "매칭 거절",
+            icon: <X />,
+            onClick: rejectMatch,
+            tone: "danger",
+            disabled: matchPending,
+          },
+        ]
+      : group === "matched"
+        ? [
+            {
+              key: "progress",
+              label: "사건 진행 보기",
+              icon: <ArrowRight />,
+              href: sharedReportHref,
+            },
+          ]
+        : [];
 
-  // Figma 1012:9931 — 모바일 헤더 매칭 버튼(거절=terra-soft·완료=navy, 컴팩트). 데스크톱 actions보다 작고 순서·톤 상이
-  const mobileActions =
-    group === "comparing" ? (
-      <>
-        <button
-          type="button"
-          onClick={rejectMatch}
-          disabled={matchPending}
-          className="rounded-button bg-terra-soft px-2.5 py-2 text-[0.75rem] font-bold text-terra transition hover:brightness-[.97] disabled:cursor-not-allowed disabled:opacity-[.42]"
-        >
-          매칭 거절
-        </button>
-        <button
-          type="button"
-          onClick={() => setConfirmOpen(true)}
-          disabled={matchPending}
-          className="flex items-center gap-1 rounded-button bg-navy px-2.5 py-2 text-[0.75rem] font-bold text-white transition hover:brightness-[.96] disabled:cursor-not-allowed disabled:opacity-[.42]"
-        >
-          <CheckCircle className="text-[0.9375rem]" />
-          매칭 완료
-        </button>
-      </>
-    ) : group === "matched" ? (
-      <Link
-        href={sharedReportHref}
-        className="flex items-center gap-1 rounded-button bg-navy px-2.5 py-2 text-[0.75rem] font-bold text-white transition hover:brightness-[.96]"
-      >
-        사건 진행
-        <ArrowRight className="text-[0.9375rem]" />
-      </Link>
-    ) : null;
+  const menuActions: ChatThreadHeaderMenuAction[] = [
+    { key: "report", label: "리포트 보기", icon: <FileText />, href: sharedReportHref },
+    ...matchActions,
+    { key: "report-chat", label: "신고", icon: <AlertTriangle />, onClick: report.openDialog },
+  ];
 
   return (
     <div className="flex h-full flex-col">
@@ -180,15 +155,12 @@ export function CustomerChatThreadContent({
         name={room.counterpart.name}
         caseNo={room.caseNo}
         roomStatus={room.roomStatus}
-        reportHref={sharedReportHref}
         // customer 방의 상대는 항상 사정사 — counterpart.userId가 곧 adjusterId
         profileHref={`/customer/adjusters/${room.counterpart.userId}`}
         subtitle={subtitle}
         badge={group === "matched" ? <MatchStatusBadge group={group} /> : undefined}
-        actions={actions}
-        mobileActions={mobileActions}
+        menuActions={menuActions}
         onBack={() => router.push(chatBasePath)}
-        onReport={report.openDialog}
       />
 
       {/* Figma 1012:9931 — 모바일 스레드엔 배너 없음(목록 배너·헤더 버튼이 대체). 데스크톱만 노출 */}

--- a/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
@@ -122,6 +122,8 @@ export function CustomerChatThreadContent({
             icon: <CheckCircle />,
             onClick: () => setConfirmOpen(true),
             disabled: matchPending,
+            // 데스크톱은 비교 배너에 전용 버튼이 있어 더보기에선 모바일에만 노출
+            mobileOnly: true,
           },
           {
             key: "reject",
@@ -130,6 +132,8 @@ export function CustomerChatThreadContent({
             onClick: rejectMatch,
             tone: "danger",
             disabled: matchPending,
+            // 데스크톱에선 접근 경로 없음(모바일 더보기 전용) — 팀 결정
+            mobileOnly: true,
           },
         ]
       : group === "matched"
@@ -170,6 +174,8 @@ export function CustomerChatThreadContent({
             variant="comparing"
             reportTypeLabel={accidentTypeLabel(room.reportTypeLabel)}
             comparingCount={comparingCount}
+            onMatchComplete={() => setConfirmOpen(true)}
+            matchCompletePending={matchPending}
           />
         </div>
       )}

--- a/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
@@ -23,6 +23,8 @@ import { MatchConfirmModal } from "@/shared/ui/chat/MatchConfirmModal";
 import { MatchRejectConfirmModal } from "@/shared/ui/chat/MatchRejectConfirmModal";
 import { MatchStatusBadge } from "@/shared/ui/chat/MatchStatusBadge";
 import { MessageInputBar } from "@/shared/ui/chat/MessageInputBar";
+import { ReportChatDialog } from "@/shared/ui/chat/ReportChatDialog";
+import { useReportChatDialog } from "@/shared/ui/chat/use-report-chat-dialog";
 import { ROOM_STATUS_META } from "@/shared/ui/chat/room-status";
 import { toast } from "@/shared/ui/toast";
 
@@ -50,6 +52,7 @@ export function CustomerChatThreadContent({
   const accept = useAcceptChat(chatRoomId);
   const reject = useRejectChat(chatRoomId);
   const { mutate: markRead } = useReadChat(chatRoomId);
+  const report = useReportChatDialog(chatRoomId);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [rejectOpen, setRejectOpen] = useState(false);
 
@@ -185,6 +188,7 @@ export function CustomerChatThreadContent({
         actions={actions}
         mobileActions={mobileActions}
         onBack={() => router.push(chatBasePath)}
+        onReport={report.openDialog}
       />
 
       {/* Figma 1012:9931 — 모바일 스레드엔 배너 없음(목록 배너·헤더 버튼이 대체). 데스크톱만 노출 */}
@@ -243,6 +247,15 @@ export function CustomerChatThreadContent({
         pending={matchPending}
         onConfirm={confirmReject}
         onCancel={() => setRejectOpen(false)}
+      />
+
+      <ReportChatDialog
+        open={report.open}
+        counterpartName={room.counterpart.name}
+        pending={report.pending}
+        errorMessage={report.errorMessage}
+        onSubmit={report.submit}
+        onClose={report.closeDialog}
       />
     </div>
   );

--- a/apps/web/src/shared/api/chat/chat.schema.ts
+++ b/apps/web/src/shared/api/chat/chat.schema.ts
@@ -3,6 +3,7 @@ import { accidentTypeSchema } from "@/shared/model/accident-type";
 import type {
   Attachment,
   ChatMessageResponse as GenChatMessageResponse,
+  ChatReportResponse,
   ChatRoomSummaryResponse,
   ConsultationDecisionResponse,
   ReadResponse,
@@ -139,6 +140,35 @@ export const readChatResponseSchema = z.object({
   readAt: z.string(),
 });
 
+// POST /chats/{chatRoomId}/report — 백엔드가 OpenAPI 스펙에 반영(2026-08-06 dev #248 코드젠 확인), FE 확정 계약과 필드 일치. 중복 신고 제한 없음.
+export const chatReportReasonSchema = z.enum([
+  "SPAM",
+  "ABUSE",
+  "FRAUD",
+  "PRIVACY_VIOLATION",
+  "OTHER",
+]);
+
+export const REPORT_DETAIL_MAX_LENGTH = 500;
+
+export const reportChatBodySchema = z
+  .object({
+    reason: chatReportReasonSchema,
+    reasonDetail: z.string().max(REPORT_DETAIL_MAX_LENGTH).nullable(),
+  })
+  .refine(
+    (body) =>
+      body.reason !== "OTHER" || (body.reasonDetail?.trim().length ?? 0) > 0,
+    { message: "기타 사유는 상세 내용을 입력해 주세요.", path: ["reasonDetail"] },
+  );
+
+export const reportChatResponseSchema = z.object({
+  chatReportId: z.uuid(),
+  chatRoomId: z.uuid(),
+  reason: chatReportReasonSchema,
+  createdAt: z.string(),
+});
+
 export type RoomStatus = z.infer<typeof roomStatusSchema>;
 export type MatchStatus = z.infer<typeof matchStatusSchema>;
 export type ChatRoom = z.infer<typeof chatRoomSchema>;
@@ -157,6 +187,9 @@ export type UploadChatAttachmentResponse = z.infer<
 export type AcceptChatResponse = z.infer<typeof acceptChatResponseSchema>;
 export type RejectChatResponse = z.infer<typeof rejectChatResponseSchema>;
 export type ReadChatResponse = z.infer<typeof readChatResponseSchema>;
+export type ChatReportReason = z.infer<typeof chatReportReasonSchema>;
+export type ReportChatBody = z.infer<typeof reportChatBodySchema>;
+export type ReportChatResponse = z.infer<typeof reportChatResponseSchema>;
 
 // counterpart는 nested 커스텀 스키마라 얕은 키 대조 대상에서 제외.
 type _ChatRoomDriftCheck = ExpectDriftCheck<
@@ -179,4 +212,7 @@ type _RejectChatResponseDriftCheck = ExpectDriftCheck<
 >;
 type _ReadChatResponseDriftCheck = ExpectDriftCheck<
   AssertFieldsExistInSpec<ReadChatResponse, ReadResponse>
+>;
+type _ReportChatResponseDriftCheck = ExpectDriftCheck<
+  AssertFieldsExistInSpec<ReportChatResponse, ChatReportResponse>
 >;

--- a/apps/web/src/shared/api/chat/report-chat.ts
+++ b/apps/web/src/shared/api/chat/report-chat.ts
@@ -1,20 +1,17 @@
-import { API_BASE_URL } from "@/shared/api/config";
-import { fetchJson } from "@/shared/api/fetch-json";
+import "@/shared/api/client";
+import { report as reportChatRequest } from "@/shared/api/generated/sdk.gen";
 import { reportChatResponseSchema } from "./chat.schema";
 import type { ReportChatBody, ReportChatResponse } from "./chat.schema";
 
-// CONTRACT: 명세없음-초안(#244) — POST /chats/{id}/report. 중복 신고 제한 없음.
-export function reportChat(
+// POST /chats/{id}/report — 채팅 상대 신고. 중복 신고 제한 없음(매번 새 접수).
+export async function reportChat(
   chatRoomId: string,
   body: ReportChatBody,
 ): Promise<ReportChatResponse> {
-  return fetchJson(
-    `${API_BASE_URL}/chats/${chatRoomId}/report`,
-    reportChatResponseSchema,
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    },
-  );
+  const { data } = await reportChatRequest({
+    throwOnError: true,
+    path: { chatRoomId },
+    body: { reason: body.reason, reasonDetail: body.reasonDetail ?? undefined },
+  });
+  return reportChatResponseSchema.parse(data);
 }

--- a/apps/web/src/shared/api/chat/report-chat.ts
+++ b/apps/web/src/shared/api/chat/report-chat.ts
@@ -1,0 +1,20 @@
+import { API_BASE_URL } from "@/shared/api/config";
+import { fetchJson } from "@/shared/api/fetch-json";
+import { reportChatResponseSchema } from "./chat.schema";
+import type { ReportChatBody, ReportChatResponse } from "./chat.schema";
+
+// CONTRACT: 명세없음-초안(#244) — POST /chats/{id}/report. 중복 신고 제한 없음.
+export function reportChat(
+  chatRoomId: string,
+  body: ReportChatBody,
+): Promise<ReportChatResponse> {
+  return fetchJson(
+    `${API_BASE_URL}/chats/${chatRoomId}/report`,
+    reportChatResponseSchema,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}

--- a/apps/web/src/shared/api/chat/use-report-chat.ts
+++ b/apps/web/src/shared/api/chat/use-report-chat.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { reportChat } from "./report-chat";
+import type { ReportChatBody } from "./chat.schema";
+
+/** 채팅 상대 신고. 방·목록 상태를 바꾸지 않아 무효화 대상이 없다. */
+export function useReportChat(chatRoomId: string) {
+  return useMutation({
+    mutationFn: (body: ReportChatBody) => reportChat(chatRoomId, body),
+  });
+}

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -1520,6 +1520,51 @@ export const handlers = [
     });
   }),
 
+  // 채팅 상대 신고 (POST /chats/{id}/report, 이슈 #244) — 매 요청 새 접수(중복 제한 없음, 방 상태 불변).
+  //  - x-mock-failure: chat-report → 500 INTERNAL_SERVER_ERROR(E2E 실패·재제출 시나리오)
+  http.post(`${API_BASE_URL}/chats/:chatRoomId/report`, async ({ params, request }) => {
+    await delay(300);
+
+    if (request.headers.get("x-mock-failure") === "chat-report") {
+      return HttpResponse.json(
+        { status: "500", code: "INTERNAL_SERVER_ERROR", message: "신고를 접수하지 못했습니다." },
+        { status: 500 },
+      );
+    }
+
+    const chatRoomId = String(params.chatRoomId);
+    const room = chatRooms.find((r) => r.chatRoomId === chatRoomId);
+    if (!room) {
+      return HttpResponse.json(
+        { status: "404", code: "CHAT_ROOM_NOT_FOUND", message: "채팅방을 찾을 수 없습니다." },
+        { status: 404 },
+      );
+    }
+
+    const body = (await request.json()) as { reason?: string };
+    const reasons = ["SPAM", "ABUSE", "FRAUD", "PRIVACY_VIOLATION", "OTHER"];
+    if (!body.reason || !reasons.includes(body.reason)) {
+      return HttpResponse.json(
+        { status: "400", code: "VALIDATION_ERROR", message: "신고 사유를 확인해 주세요." },
+        { status: 400 },
+      );
+    }
+
+    return HttpResponse.json(
+      {
+        status: "201",
+        message: "신고가 접수되었습니다.",
+        data: camelToSnakeDeep({
+          chatReportId: crypto.randomUUID(),
+          chatRoomId,
+          reason: body.reason,
+          createdAt: new Date().toISOString(),
+        }),
+      },
+      { status: 201 },
+    );
+  }),
+
   // 공유 리포트 (GET /chats/{id}/shared-report, 이슈 #187) — 방에 공유된 사정사 검수 결과.
   //  - x-mock-failure: shared-report-forbidden → 403 CHAT_NOT_A_MEMBER
   //  - x-mock-failure: shared-report-missing   → 404 REPORT_NOT_FOUND(검수 리포트 미등록)

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { delay, http, HttpResponse } from "msw";
 import { z } from "zod";
 import { camelToSnakeDeep, toSnakeKey } from "@/shared/api/case-convert";
+import { chatReportReasonSchema } from "@/shared/api/chat/chat.schema";
 import { API_BASE_URL } from "@/shared/api/config";
 import {
   consumeReissue,
@@ -1541,9 +1542,13 @@ export const handlers = [
       );
     }
 
-    const body = (await request.json()) as { reason?: string };
-    const reasons = ["SPAM", "ABUSE", "FRAUD", "PRIVACY_VIOLATION", "OTHER"];
-    if (!body.reason || !reasons.includes(body.reason)) {
+    const body = (await request.json()) as {
+      reason?: string;
+      reason_detail?: string | null;
+    };
+    const reasons: string[] = chatReportReasonSchema.options;
+    const detailMissing = body.reason === "OTHER" && !body.reason_detail?.trim();
+    if (!body.reason || !reasons.includes(body.reason) || detailMissing) {
       return HttpResponse.json(
         { status: "400", code: "VALIDATION_ERROR", message: "신고 사유를 확인해 주세요." },
         { status: 400 },

--- a/apps/web/src/shared/ui/Textarea.stories.tsx
+++ b/apps/web/src/shared/ui/Textarea.stories.tsx
@@ -50,3 +50,14 @@ export const InsideCounter: Story = {
   args: { value: "", onChange: () => {} },
   render: () => <InsideCounterDemo />,
 };
+
+/** 제출 중 등 입력 잠금. */
+export const Disabled: Story = {
+  args: {
+    value: "상담 중 반복적인 욕설이 있었습니다.",
+    onChange: () => {},
+    maxLength: 500,
+    rows: 4,
+    disabled: true,
+  },
+};

--- a/apps/web/src/shared/ui/Textarea.tsx
+++ b/apps/web/src/shared/ui/Textarea.tsx
@@ -22,6 +22,8 @@ export interface TextareaProps {
   counterPlacement?: "outside" | "inside";
   /** 세로 리사이즈 허용 여부. inside 카운터가 핸들 자리와 겹치면 끈다. */
   resizable?: boolean;
+  /** 입력 잠금(제출 중 등) */
+  disabled?: boolean;
   className?: string;
 }
 
@@ -38,6 +40,7 @@ export function Textarea({
   counterClassName,
   counterPlacement = "outside",
   resizable = true,
+  disabled = false,
   className,
 }: TextareaProps) {
   const showCounter = maxLength != null;
@@ -60,8 +63,9 @@ export function Textarea({
           rows={rows}
           placeholder={placeholder}
           aria-label={ariaLabel}
+          disabled={disabled}
           className={cn(
-            "w-full rounded-input border border-line bg-card px-3.5 py-3 text-[0.9375rem] leading-relaxed text-ink outline-none transition placeholder:text-ink-3 focus:border-gold focus:ring-[3px] focus:ring-gold-soft",
+            "w-full rounded-input border border-line bg-card px-3.5 py-3 text-[0.9375rem] leading-relaxed text-ink outline-none transition placeholder:text-ink-3 focus:border-gold focus:ring-[3px] focus:ring-gold-soft disabled:cursor-not-allowed disabled:opacity-[.42]",
             resizable ? "resize-y" : "resize-none",
             insideCounter && "pb-8", // 카운터가 겹쳐 앉는 자리 확보
           )}

--- a/apps/web/src/shared/ui/chat/ChatComparisonBanner.tsx
+++ b/apps/web/src/shared/ui/chat/ChatComparisonBanner.tsx
@@ -10,6 +10,9 @@ export interface ChatComparisonBannerProps {
   comparingCount?: number;
   /** matched 변형에서 "진행 보기" 링크(사건 진행). */
   progressHref?: string;
+  /** comparing 변형에서 "매칭 완료" 버튼 — 데스크톱 전용 배너라 이 버튼도 데스크톱에만 노출된다 */
+  onMatchComplete?: () => void;
+  matchCompletePending?: boolean;
 }
 
 /**
@@ -23,6 +26,8 @@ export function ChatComparisonBanner({
   reportTypeLabel,
   comparingCount = 0,
   progressHref,
+  onMatchComplete,
+  matchCompletePending,
 }: ChatComparisonBannerProps) {
   if (variant === "matched") {
     return (
@@ -48,9 +53,19 @@ export function ChatComparisonBanner({
     <div className="flex items-center gap-2.5 border-b border-line-2 bg-gold-soft px-4 py-2.5 md:px-5.5">
       <CheckCircle className="shrink-0 text-[1rem] text-gold-ink" />
       <p className="min-w-0 flex-1 text-[0.75rem] text-gold-ink">
-        {reportTypeLabel} 건으로 {comparingCount}명과 상담 중 · 마음에 들면 상단 ‘매칭 완료’를
-        누르세요
+        {reportTypeLabel} 건으로 {comparingCount}명과 상담 중 · 마음에 들면 매칭 완료를 누르세요
       </p>
+      {onMatchComplete && (
+        <button
+          type="button"
+          onClick={onMatchComplete}
+          disabled={matchCompletePending}
+          className="flex shrink-0 items-center gap-1 rounded-full bg-ink px-3 py-1.5 text-[0.75rem] font-bold text-white transition hover:brightness-[.96] disabled:cursor-not-allowed disabled:opacity-[.42]"
+        >
+          <CheckCircle className="text-[0.875rem]" />
+          매칭 완료
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/shared/ui/chat/ChatThreadContent.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadContent.tsx
@@ -12,6 +12,8 @@ import { toast } from "@/shared/ui/toast";
 import { ChatThreadHeader } from "./ChatThreadHeader";
 import { ChatThreadView } from "./ChatThreadView";
 import { MessageInputBar } from "./MessageInputBar";
+import { ReportChatDialog } from "./ReportChatDialog";
+import { useReportChatDialog } from "./use-report-chat-dialog";
 
 export interface ChatThreadContentProps {
   chatRoomId: string;
@@ -34,6 +36,7 @@ export function ChatThreadContent({
   // 상담 종료 UX는 명세상 reject(방 종료)로 매핑. 형제 방 유지·서버 미러.
   const endChat = useRejectChat(chatRoomId);
   const { mutate: markRead } = useReadChat(chatRoomId);
+  const report = useReportChatDialog(chatRoomId);
 
   useEffect(() => {
     markRead();
@@ -56,6 +59,7 @@ export function ChatThreadContent({
           })
         }
         closePending={endChat.isPending}
+        onReport={report.openDialog}
       />
 
       <ChatThreadView
@@ -77,6 +81,15 @@ export function ChatThreadContent({
           })
         }
         attachPending={sendAttachment.isPending}
+      />
+
+      <ReportChatDialog
+        open={report.open}
+        counterpartName={room.counterpart.name}
+        pending={report.pending}
+        errorMessage={report.errorMessage}
+        onSubmit={report.submit}
+        onClose={report.closeDialog}
       />
     </div>
   );

--- a/apps/web/src/shared/ui/chat/ChatThreadContent.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadContent.tsx
@@ -29,7 +29,7 @@ export interface ChatThreadContentProps {
 export function ChatThreadContent({
   chatRoomId,
   chatBasePath,
-  reportBasePath,
+  reportBasePath
 }: ChatThreadContentProps) {
   const router = useRouter();
   const { data: room } = useChatRoom(chatRoomId);
@@ -39,7 +39,7 @@ export function ChatThreadContent({
   // 상담 종료 UX는 명세상 reject(방 종료)로 매핑. 형제 방 유지·서버 미러.
   const endChat = useRejectChat(chatRoomId);
   const { mutate: markRead } = useReadChat(chatRoomId);
-  const report = useReportChatDialog(chatRoomId);
+  const reportDialog = useReportChatDialog(chatRoomId);
 
   useEffect(() => {
     markRead();
@@ -49,7 +49,7 @@ export function ChatThreadContent({
 
   const endChatConsultation = () =>
     endChat.mutate(undefined, {
-      onError: () => toast.error("상담 종료에 실패했어요. 잠시 후 다시 시도해 주세요."),
+      onError: () => toast.error("상담 종료에 실패했어요. 잠시 후 다시 시도해 주세요.")
     });
 
   const menuActions: ChatThreadHeaderMenuAction[] = [
@@ -57,7 +57,7 @@ export function ChatThreadContent({
       key: "report",
       label: "리포트 보기",
       icon: <FileText />,
-      href: room.reportId ? `${reportBasePath}/${room.reportId}` : "#",
+      href: room.reportId ? `${reportBasePath}/${room.reportId}` : "#"
     },
     ...(room.roomStatus === "ACTIVE"
       ? [
@@ -67,16 +67,16 @@ export function ChatThreadContent({
             icon: <X />,
             onClick: endChatConsultation,
             tone: "danger" as const,
-            disabled: endChat.isPending,
-          },
+            disabled: endChat.isPending
+          }
         ]
       : []),
     {
       key: "report-chat",
       label: "신고",
       icon: <AlertTriangle />,
-      onClick: report.openDialog,
-    },
+      onClick: reportDialog.openDialog
+    }
   ];
 
   return (
@@ -103,20 +103,19 @@ export function ChatThreadContent({
         sendFailed={sendMessage.isError}
         onPickFile={(file) =>
           sendAttachment.mutate(file, {
-            onError: () =>
-              toast.error("파일 전송에 실패했어요. 잠시 후 다시 시도해 주세요."),
+            onError: () => toast.error("파일 전송에 실패했어요. 잠시 후 다시 시도해 주세요.")
           })
         }
         attachPending={sendAttachment.isPending}
       />
 
       <ReportChatDialog
-        open={report.open}
+        open={reportDialog.open}
         counterpartName={room.counterpart.name}
-        pending={report.pending}
-        errorMessage={report.errorMessage}
-        onSubmit={report.submit}
-        onClose={report.closeDialog}
+        pending={reportDialog.pending}
+        errorMessage={reportDialog.errorMessage}
+        onSubmit={reportDialog.submit}
+        onClose={reportDialog.closeDialog}
       />
     </div>
   );

--- a/apps/web/src/shared/ui/chat/ChatThreadContent.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadContent.tsx
@@ -8,8 +8,11 @@ import { useReadChat } from "@/shared/api/chat/use-read-chat";
 import { useRejectChat } from "@/shared/api/chat/use-reject-chat";
 import { useSendChatAttachment } from "@/shared/api/chat/use-send-chat-attachment";
 import { useSendChatMessage } from "@/shared/api/chat/use-send-chat-message";
+import { AlertTriangle } from "@/shared/ui/icons/AlertTriangle";
+import { FileText } from "@/shared/ui/icons/FileText";
+import { X } from "@/shared/ui/icons/X";
 import { toast } from "@/shared/ui/toast";
-import { ChatThreadHeader } from "./ChatThreadHeader";
+import { ChatThreadHeader, type ChatThreadHeaderMenuAction } from "./ChatThreadHeader";
 import { ChatThreadView } from "./ChatThreadView";
 import { MessageInputBar } from "./MessageInputBar";
 import { ReportChatDialog } from "./ReportChatDialog";
@@ -44,22 +47,46 @@ export function ChatThreadContent({
 
   const closed = room.roomStatus === "CLOSED";
 
+  const endChatConsultation = () =>
+    endChat.mutate(undefined, {
+      onError: () => toast.error("상담 종료에 실패했어요. 잠시 후 다시 시도해 주세요."),
+    });
+
+  const menuActions: ChatThreadHeaderMenuAction[] = [
+    {
+      key: "report",
+      label: "리포트 보기",
+      icon: <FileText />,
+      href: room.reportId ? `${reportBasePath}/${room.reportId}` : "#",
+    },
+    ...(room.roomStatus === "ACTIVE"
+      ? [
+          {
+            key: "close",
+            label: "상담 종료",
+            icon: <X />,
+            onClick: endChatConsultation,
+            tone: "danger" as const,
+            disabled: endChat.isPending,
+          },
+        ]
+      : []),
+    {
+      key: "report-chat",
+      label: "신고",
+      icon: <AlertTriangle />,
+      onClick: report.openDialog,
+    },
+  ];
+
   return (
     <div className="flex h-full flex-col">
       <ChatThreadHeader
         name={room.counterpart.name}
         caseNo={room.caseNo}
         roomStatus={room.roomStatus}
-        reportHref={room.reportId ? `${reportBasePath}/${room.reportId}` : "#"}
         onBack={() => router.push(chatBasePath)}
-        onClose={() =>
-          endChat.mutate(undefined, {
-            onError: () =>
-              toast.error("상담 종료에 실패했어요. 잠시 후 다시 시도해 주세요."),
-          })
-        }
-        closePending={endChat.isPending}
-        onReport={report.openDialog}
+        menuActions={menuActions}
       />
 
       <ChatThreadView

--- a/apps/web/src/shared/ui/chat/ChatThreadHeader.stories.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadHeader.stories.tsx
@@ -37,6 +37,22 @@ export const WithProfileLink: Story = {
 /** partner 하위호환 — onClose(상담 종료) 시그니처 그대로. */
 export const PartnerClose: Story = { args: { onClose: () => {} } };
 
+/** 신고 — 데스크톱 아웃라인 pill. roomStatus 무관 항상 노출(CLOSED 방 포함). */
+export const WithReport: Story = {
+  args: { onReport: () => {}, onClose: () => {} },
+};
+
+/** 신고(종료된 방) — CLOSED에서도 신고 버튼은 남고 상담 종료만 사라진다. */
+export const WithReportClosed: Story = {
+  args: { onReport: () => {}, onClose: () => {}, roomStatus: "CLOSED" },
+};
+
+/** 신고(모바일) — mobileActions 유무와 무관하게 아이콘 버튼(aria-label="신고하기")이 항상 보인다. */
+export const WithReportMobile: Story = {
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  args: { onBack: () => {}, onReport: () => {} },
+};
+
 /** customer 비교중 — 리포트 보기 + 매칭 거절(terra) + 매칭 완료(ink). */
 export const CustomerComparing: Story = {
   args: {

--- a/apps/web/src/shared/ui/chat/ChatThreadHeader.stories.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadHeader.stories.tsx
@@ -1,10 +1,26 @@
-import Link from "next/link";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { AlertTriangle } from "@/shared/ui/icons/AlertTriangle";
 import { ArrowRight } from "@/shared/ui/icons/ArrowRight";
 import { CheckCircle } from "@/shared/ui/icons/CheckCircle";
+import { FileText } from "@/shared/ui/icons/FileText";
 import { X } from "@/shared/ui/icons/X";
-import { ChatThreadHeader } from "./ChatThreadHeader";
+import { ChatThreadHeader, type ChatThreadHeaderMenuAction } from "./ChatThreadHeader";
 import { MatchStatusBadge } from "./MatchStatusBadge";
+
+const reportAction: ChatThreadHeaderMenuAction = {
+  key: "report",
+  label: "리포트 보기",
+  icon: <FileText />,
+  href: "#",
+};
+
+const reportChatAction: ChatThreadHeaderMenuAction = {
+  key: "report-chat",
+  label: "신고",
+  icon: <AlertTriangle />,
+  onClick: () => {},
+};
 
 const meta = {
   title: "UI/Chat/ChatThreadHeader",
@@ -14,13 +30,14 @@ const meta = {
     name: "김도현 손해사정사",
     caseNo: "#20260520-017",
     roomStatus: "ACTIVE",
-    reportHref: "#",
+    menuActions: [reportAction],
   },
 } satisfies Meta<typeof ChatThreadHeader>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+/** 액션 1개 — 더보기 안에 리포트 보기만. */
 export const Default: Story = {};
 
 export const WithBack: Story = { args: { onBack: () => {} } };
@@ -34,89 +51,68 @@ export const WithProfileLink: Story = {
   args: { profileHref: "/customer/adjusters/aaaaaaaa-1111-1111-1111-111111111111" },
 };
 
-/** partner 하위호환 — onClose(상담 종료) 시그니처 그대로. */
-export const PartnerClose: Story = { args: { onClose: () => {} } };
-
-/** 신고 — 데스크톱 아웃라인 pill. roomStatus 무관 항상 노출(CLOSED 방 포함). */
-export const WithReport: Story = {
-  args: { onReport: () => {}, onClose: () => {} },
+/** partner — 리포트 보기 + 상담 종료(danger) + 신고. */
+export const PartnerActions: Story = {
+  args: {
+    menuActions: [
+      reportAction,
+      {
+        key: "close",
+        label: "상담 종료",
+        icon: <X />,
+        onClick: () => {},
+        tone: "danger",
+      },
+      reportChatAction,
+    ],
+  },
 };
 
-/** 신고(종료된 방) — CLOSED에서도 신고 버튼은 남고 상담 종료만 사라진다. */
-export const WithReportClosed: Story = {
-  args: { onReport: () => {}, onClose: () => {}, roomStatus: "CLOSED" },
-};
-
-/** 신고(모바일) — mobileActions 유무와 무관하게 아이콘 버튼(aria-label="신고하기")이 항상 보인다. */
-export const WithReportMobile: Story = {
-  parameters: { viewport: { defaultViewport: "mobile1" } },
-  args: { onBack: () => {}, onReport: () => {} },
-};
-
-/** customer 비교중 — 리포트 보기 + 매칭 거절(terra) + 매칭 완료(ink). */
+/** 액션 4개(풀세트) — customer 비교 중: 리포트 보기 + 매칭 완료 + 매칭 거절(danger) + 신고. */
 export const CustomerComparing: Story = {
   args: {
     subtitle: "#20260520-017 · 상담 중 · 비교 중",
-    actions: (
-      <>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 rounded-full bg-terra px-3.5 py-1.5 text-[0.8125rem] font-semibold text-white transition hover:brightness-[.96]"
-        >
-          매칭 거절
-          <X className="text-[0.875rem]" />
-        </button>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 rounded-full bg-ink px-3.5 py-1.5 text-[0.8125rem] font-semibold text-white transition hover:brightness-[.96]"
-        >
-          매칭 완료
-          <CheckCircle className="text-[0.9375rem]" />
-        </button>
-      </>
-    ),
+    menuActions: [
+      reportAction,
+      { key: "accept", label: "매칭 완료", icon: <CheckCircle />, onClick: () => {} },
+      {
+        key: "reject",
+        label: "매칭 거절",
+        icon: <X />,
+        onClick: () => {},
+        tone: "danger",
+      },
+      reportChatAction,
+    ],
   },
 };
 
-/** customer 모바일 비교중 — 헤더 우측 컴팩트 매칭 버튼(거절=terra-soft·완료=navy). 모바일 폭에서 확인. */
-export const CustomerComparingMobile: Story = {
-  parameters: { viewport: { defaultViewport: "mobile1" } },
-  args: {
-    onBack: () => {},
-    subtitle: "#20260520-017 · 상담 중 · 비교 중",
-    mobileActions: (
-      <>
-        <button
-          type="button"
-          className="rounded-button bg-terra-soft px-2.5 py-2 text-[0.75rem] font-bold text-terra"
-        >
-          매칭 거절
-        </button>
-        <button
-          type="button"
-          className="flex items-center gap-1 rounded-button bg-navy px-2.5 py-2 text-[0.75rem] font-bold text-white"
-        >
-          <CheckCircle className="text-[0.9375rem]" />
-          매칭 완료
-        </button>
-      </>
-    ),
+/** 펼친 상태 — 더보기를 눌러 패널이 아코디언으로 열린 모습(대화를 아래로 민다). */
+export const MenuOpen: Story = {
+  args: CustomerComparing.args,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "더보기" }));
+    await expect(canvas.getByRole("menuitem", { name: "매칭 완료" })).toBeVisible();
   },
 };
 
-/** customer 매칭후 — 매칭 완료 배지 + 리포트 보기 + 사건 진행 보기(ink). */
+/** 매칭 후 — 배지 + 사건 진행 보기 링크 항목. */
 export const CustomerMatched: Story = {
   args: {
     subtitle: "#20260520-017 · 매칭 완료 · 진행 중",
     badge: <MatchStatusBadge group="matched" />,
-    actions: (
-      <Link
-        href="#"
-        className="flex items-center gap-1.5 rounded-full bg-ink px-3.5 py-1.5 text-[0.8125rem] font-semibold text-white transition hover:brightness-[.96]"
-      >
-        사건 진행 보기
-        <ArrowRight className="text-[0.9375rem]" />
-      </Link>
-    ),
+    menuActions: [
+      reportAction,
+      { key: "progress", label: "사건 진행 보기", icon: <ArrowRight />, href: "#" },
+      reportChatAction,
+    ],
   },
+};
+
+/** 모바일 — 데스크톱과 동일하게 더보기 하나로 통합(아이콘 버튼 없음). */
+export const MobileMenuOpen: Story = {
+  parameters: { viewport: { defaultViewport: "mobile1" } },
+  args: { ...CustomerComparing.args, onBack: () => {} },
+  play: MenuOpen.play,
 };

--- a/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import type { RoomStatus } from "@/shared/api/chat/chat.schema";
 import { cn } from "@/shared/lib/utils";
 import { Avatar } from "@/shared/ui/Avatar";
@@ -57,19 +57,25 @@ function ProfileLink({ href, children }: { href?: string; children: ReactNode })
 
 function MenuActionItem({
   action,
-  onSelect,
+  onSelect
 }: {
   action: ChatThreadHeaderMenuAction;
   onSelect: () => void;
 }) {
+  const danger = action.tone === "danger";
   const className = cn(
-    "flex w-full items-center gap-2.5 rounded-button px-3 py-2.5 text-left text-[0.8125rem] font-semibold transition hover:bg-paper-2",
-    action.tone === "danger" ? "text-terra" : "text-ink",
-    action.disabled && "pointer-events-none cursor-not-allowed opacity-[.42]",
+    "flex w-full items-center gap-3 px-3.5 py-3 text-left text-[0.8125rem] font-semibold transition",
+    danger ? "text-terra hover:bg-terra-soft/60" : "text-ink hover:bg-paper-2",
+    action.disabled && "pointer-events-none cursor-not-allowed opacity-[.42]"
   );
   const content = (
     <>
-      <span className="flex w-5 shrink-0 justify-center text-[0.9375rem]">
+      <span
+        className={cn(
+          "flex size-8 shrink-0 items-center justify-center rounded-full text-[0.9375rem]",
+          danger ? "bg-terra-soft text-terra" : "bg-paper-2 text-ink-2"
+        )}
+      >
         {action.icon}
       </span>
       {action.label}
@@ -114,92 +120,94 @@ export function ChatThreadHeader({
   badge,
   subtitle: subtitleOverride,
   profileHref,
-  menuActions,
+  menuActions
 }: ChatThreadHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
   const subtitle =
-    subtitleOverride ??
-    [caseNo, ROOM_STATUS_META[roomStatus].label].filter(Boolean).join(" · ");
+    subtitleOverride ?? [caseNo, ROOM_STATUS_META[roomStatus].label].filter(Boolean).join(" · ");
+
+  // 바깥 클릭·Esc로 닫기(진짜 오버레이 팝업이라 문서 흐름과 분리돼 있음).
+  useEffect(() => {
+    if (!menuOpen) return;
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!menuRef.current?.contains(event.target as Node)) setMenuOpen(false);
+    }
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setMenuOpen(false);
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [menuOpen]);
 
   return (
-    <>
-      <header className="flex items-center gap-2.5 border-b border-line-2 bg-paper px-4 py-3 md:bg-card md:px-5">
-        {onBack && (
-          <button
-            type="button"
-            onClick={onBack}
-            aria-label="목록으로"
-            className="-ml-1 flex size-8 items-center justify-center rounded-full text-[1.25rem] text-ink transition hover:bg-paper-2 md:hidden"
-          >
-            {/* Figma 663:3801 — 얇은 좌측 셰브런 */}
-            <ChevronRight className="rotate-180" />
-          </button>
-        )}
+    <header className="relative flex items-center gap-2.5 border-b border-line-2 bg-paper px-4 py-3 md:bg-card md:px-5">
+      {onBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          aria-label="목록으로"
+          className="-ml-1 flex size-8 items-center justify-center rounded-full text-[1.25rem] text-ink transition hover:bg-paper-2 md:hidden"
+        >
+          {/* Figma 663:3801 — 얇은 좌측 셰브런 */}
+          <ChevronRight className="rotate-180" />
+        </button>
+      )}
 
-        <ProfileLink href={profileHref}>
-          <Avatar name={name} size="sm" />
+      <ProfileLink href={profileHref}>
+        <Avatar name={name} size="sm" />
 
-          <div className="min-w-0 flex-1">
-            <p className="flex items-center gap-1.5 truncate text-[0.85rem] font-bold text-ink">
-              {name}
-              {/* Figma 95:4611 — 이름 옆 인증 마크 */}
-              <ShieldCheck className="shrink-0 text-[0.8125rem] text-ink-3" />
-              {badge}
-            </p>
-            {/* Figma 모바일(663:3796) 헤더는 이름만 — 사건번호·상태는 데스크톱(95:4571) 전용 */}
-            <p className="hidden truncate text-[0.6875rem] text-ink-3 md:block">
-              {subtitle}
-            </p>
-            <span className="sr-only md:hidden">{subtitle}</span>
-          </div>
-        </ProfileLink>
+        <div className="min-w-0 flex-1">
+          <p className="flex items-center gap-1.5 truncate text-[0.85rem] font-bold text-ink">
+            {name}
+            {/* Figma 95:4611 — 이름 옆 인증 마크 */}
+            <ShieldCheck className="shrink-0 text-[0.8125rem] text-ink-3" />
+            {badge}
+          </p>
+          {/* Figma 모바일(663:3796) 헤더는 이름만 — 사건번호·상태는 데스크톱(95:4571) 전용 */}
+          <p className="hidden truncate text-[0.6875rem] text-ink-3 md:block">{subtitle}</p>
+          <span className="sr-only md:hidden">{subtitle}</span>
+        </div>
+      </ProfileLink>
 
-        {menuActions.length > 0 && (
+      {menuActions.length > 0 && (
+        <div ref={menuRef} className="relative shrink-0">
           <button
             type="button"
             onClick={() => setMenuOpen((open) => !open)}
             aria-expanded={menuOpen}
             aria-controls={MENU_ID}
-            className="flex shrink-0 items-center gap-1.5 rounded-full border border-line bg-card px-3.5 py-1.5 text-[0.8125rem] font-semibold text-ink-2 transition hover:bg-paper-2"
+            className="flex items-center gap-1.5 rounded-full border border-line bg-card px-3.5 py-1.5 text-[0.8125rem] font-semibold text-ink-2 transition hover:bg-paper-2"
           >
             더보기
             <ChevronDown
-              className={cn(
-                "text-[0.9375rem] transition-transform",
-                menuOpen && "rotate-180",
-              )}
+              className={cn("text-[0.9375rem] transition-transform", menuOpen && "rotate-180")}
             />
           </button>
-        )}
-      </header>
 
-      {/* 오버레이가 아니라 문서 흐름에 끼워 넣어 대화를 아래로 민다(grid-rows 0fr↔1fr 확장) */}
-      <div
-        inert={!menuOpen}
-        className={cn(
-          "grid shrink-0",
-          menuOpen
-            ? "grid-rows-[1fr] transition-[grid-template-rows] duration-200"
-            : // 접힐 땐 높이 애니메이션이 끝난 뒤 visibility를 끈다(클릭·포커스 차단)
-              "invisible grid-rows-[0fr] [transition:grid-template-rows_200ms_ease,visibility_0s_200ms]",
-        )}
-      >
-        <div className="overflow-hidden">
-          <div
-            id={MENU_ID}
-            role="menu"
-            className="flex flex-col border-b border-line-2 bg-card p-2 md:px-3"
-          >
-            {menuActions.map((action) => (
-              <MenuActionItem
-                key={action.key}
-                action={action}
-                onSelect={() => setMenuOpen(false)}
-              />
-            ))}
-          </div>
+          {menuOpen && (
+            <div
+              id={MENU_ID}
+              role="menu"
+              className="absolute top-[calc(100%+0.5rem)] right-0 z-20 w-56 overflow-hidden rounded-card bg-card shadow-popover divide-y divide-line-2"
+            >
+              {menuActions.map((action) => (
+                <MenuActionItem
+                  key={action.key}
+                  action={action}
+                  onSelect={() => setMenuOpen(false)}
+                />
+              ))}
+            </div>
+          )}
         </div>
-      </div>
-    </>
+      )}
+    </header>
   );
 }

--- a/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
@@ -1,16 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import type { RoomStatus } from "@/shared/api/chat/chat.schema";
 import { cn } from "@/shared/lib/utils";
 import { Avatar } from "@/shared/ui/Avatar";
 import { ChevronDown } from "@/shared/ui/icons/ChevronDown";
 import { ChevronRight } from "@/shared/ui/icons/ChevronRight";
 import { ShieldCheck } from "@/shared/ui/icons/ShieldCheck";
+import { Popover } from "@/shared/ui/Popover";
 import { ROOM_STATUS_META } from "./room-status";
-
-const MENU_ID = "chat-header-menu";
 
 export interface ChatThreadHeaderMenuAction {
   key: string;
@@ -69,7 +68,7 @@ function MenuActionItem({
     "flex w-full items-center gap-3 px-3.5 py-3 text-left text-[0.8125rem] font-semibold transition",
     danger ? "text-terra hover:bg-terra-soft/60" : "text-ink hover:bg-paper-2",
     action.disabled && "pointer-events-none cursor-not-allowed opacity-[.42]",
-    action.mobileOnly && "md:hidden",
+    action.mobileOnly && "md:hidden"
   );
   const content = (
     <>
@@ -126,28 +125,9 @@ export function ChatThreadHeader({
   menuActions
 }: ChatThreadHeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
   const subtitle =
     subtitleOverride ?? [caseNo, ROOM_STATUS_META[roomStatus].label].filter(Boolean).join(" · ");
-
-  // 바깥 클릭·Esc로 닫기(진짜 오버레이 팝업이라 문서 흐름과 분리돼 있음).
-  useEffect(() => {
-    if (!menuOpen) return;
-
-    function handlePointerDown(event: PointerEvent) {
-      if (!menuRef.current?.contains(event.target as Node)) setMenuOpen(false);
-    }
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") setMenuOpen(false);
-    }
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [menuOpen]);
 
   return (
     <header className="relative flex items-center gap-2.5 border-b border-line-2 bg-paper px-4 py-3 md:bg-card md:px-5">
@@ -180,12 +160,13 @@ export function ChatThreadHeader({
       </ProfileLink>
 
       {menuActions.length > 0 && (
-        <div ref={menuRef} className="relative shrink-0">
+        <div className="relative shrink-0">
           <button
+            ref={triggerRef}
             type="button"
             onClick={() => setMenuOpen((open) => !open)}
+            aria-haspopup="menu"
             aria-expanded={menuOpen}
-            aria-controls={MENU_ID}
             className="flex items-center gap-1.5 rounded-full border border-line bg-card px-3.5 py-1.5 text-[0.8125rem] font-semibold text-ink-2 transition hover:bg-paper-2"
           >
             더보기
@@ -194,12 +175,14 @@ export function ChatThreadHeader({
             />
           </button>
 
-          {menuOpen && (
-            <div
-              id={MENU_ID}
-              role="menu"
-              className="absolute top-[calc(100%+0.5rem)] right-0 z-20 w-56 overflow-hidden rounded-card bg-card shadow-popover divide-y divide-line-2"
-            >
+          <Popover
+            open={menuOpen}
+            onClose={() => setMenuOpen(false)}
+            triggerRef={triggerRef}
+            label="더보기"
+            className="w-56 overflow-hidden rounded-card"
+          >
+            <div role="menu" className="flex flex-col divide-y divide-line-2">
               {menuActions.map((action) => (
                 <MenuActionItem
                   key={action.key}
@@ -208,7 +191,7 @@ export function ChatThreadHeader({
                 />
               ))}
             </div>
-          )}
+          </Popover>
         </div>
       )}
     </header>

--- a/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 import type { RoomStatus } from "@/shared/api/chat/chat.schema";
 import { Avatar } from "@/shared/ui/Avatar";
+import { AlertTriangle } from "@/shared/ui/icons/AlertTriangle";
 import { ChevronRight } from "@/shared/ui/icons/ChevronRight";
 import { FileText } from "@/shared/ui/icons/FileText";
 import { ShieldCheck } from "@/shared/ui/icons/ShieldCheck";
@@ -29,6 +30,8 @@ export interface ChatThreadHeaderProps {
   closePending?: boolean;
   /** 상대 프로필 링크(customer→사정사 프로필). 없으면(partner) 링크 없이 렌더 */
   profileHref?: string;
+  /** 신고 다이얼로그 열기. 전달 시 데스크톱 pill·모바일 아이콘 버튼 노출(roomStatus 무관 항상) */
+  onReport?: () => void;
 }
 
 /** href가 있으면 아바타·이름 묶음을 프로필 링크로, 없으면(partner) 헤더 flex에 그대로 편다. */
@@ -58,6 +61,7 @@ export function ChatThreadHeader({
   onClose,
   closePending,
   profileHref,
+  onReport,
 }: ChatThreadHeaderProps) {
   const subtitle =
     subtitleOverride ??
@@ -93,6 +97,18 @@ export function ChatThreadHeader({
         </div>
       </ProfileLink>
 
+      {/* 모바일 — 신고는 mobileActions 유무·roomStatus와 무관하게 항상 노출 */}
+      {onReport && (
+        <button
+          type="button"
+          onClick={onReport}
+          aria-label="신고하기"
+          className="flex size-9 shrink-0 items-center justify-center rounded-button text-[1.0625rem] text-ink-3 transition hover:bg-paper-2 md:hidden"
+        >
+          <AlertTriangle />
+        </button>
+      )}
+
       {/* 모바일 — 매칭 액션 주입 시(customer) 리포트 아이콘 대신 표시, 아니면(partner) 리포트 아이콘. Figma 1012:9931 */}
       {mobileActions ? (
         <div className="flex shrink-0 items-center gap-1.5 md:hidden">{mobileActions}</div>
@@ -100,7 +116,7 @@ export function ChatThreadHeader({
         <Link
           href={reportHref}
           aria-label="리포트 보기"
-          className="flex size-9 items-center justify-center rounded-button text-[1.1875rem] text-ink transition hover:bg-paper-2 md:hidden"
+          className="flex size-9 shrink-0 items-center justify-center rounded-button text-[1.1875rem] text-ink transition hover:bg-paper-2 md:hidden"
         >
           <FileText />
         </Link>
@@ -116,6 +132,16 @@ export function ChatThreadHeader({
           <FileText className="text-[0.9375rem]" />
         </Link>
         {actions}
+        {onReport && (
+          <button
+            type="button"
+            onClick={onReport}
+            className="flex items-center gap-1.5 rounded-full border border-line bg-card px-3.5 py-1.5 text-[0.8125rem] font-semibold text-ink-2 transition hover:bg-paper-2 hover:text-terra"
+          >
+            신고
+            <AlertTriangle className="text-[0.9375rem]" />
+          </button>
+        )}
         {onClose && roomStatus === "ACTIVE" && (
           <button
             type="button"

--- a/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
@@ -22,6 +22,8 @@ export interface ChatThreadHeaderMenuAction {
   disabled?: boolean;
   /** danger = 매칭 거절·상담 종료 */
   tone?: "default" | "danger";
+  /** 데스크톱에서 다른 곳에 전용 버튼으로 노출돼 더보기 목록에선 숨김(모바일만) */
+  mobileOnly?: boolean;
 }
 
 export interface ChatThreadHeaderProps {
@@ -66,7 +68,8 @@ function MenuActionItem({
   const className = cn(
     "flex w-full items-center gap-3 px-3.5 py-3 text-left text-[0.8125rem] font-semibold transition",
     danger ? "text-terra hover:bg-terra-soft/60" : "text-ink hover:bg-paper-2",
-    action.disabled && "pointer-events-none cursor-not-allowed opacity-[.42]"
+    action.disabled && "pointer-events-none cursor-not-allowed opacity-[.42]",
+    action.mobileOnly && "md:hidden",
   );
   const content = (
     <>

--- a/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
+++ b/apps/web/src/shared/ui/chat/ChatThreadHeader.tsx
@@ -1,37 +1,44 @@
+"use client";
+
 import Link from "next/link";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import type { RoomStatus } from "@/shared/api/chat/chat.schema";
+import { cn } from "@/shared/lib/utils";
 import { Avatar } from "@/shared/ui/Avatar";
-import { AlertTriangle } from "@/shared/ui/icons/AlertTriangle";
+import { ChevronDown } from "@/shared/ui/icons/ChevronDown";
 import { ChevronRight } from "@/shared/ui/icons/ChevronRight";
-import { FileText } from "@/shared/ui/icons/FileText";
 import { ShieldCheck } from "@/shared/ui/icons/ShieldCheck";
-import { X } from "@/shared/ui/icons/X";
 import { ROOM_STATUS_META } from "./room-status";
+
+const MENU_ID = "chat-header-menu";
+
+export interface ChatThreadHeaderMenuAction {
+  key: string;
+  label: string;
+  icon: ReactNode;
+  /** 있으면 링크, 없으면 버튼 */
+  href?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  /** danger = 매칭 거절·상담 종료 */
+  tone?: "default" | "danger";
+}
 
 export interface ChatThreadHeaderProps {
   name: string;
   /** 사건번호 — 사정사 검색 방(리포트 없음)은 null */
   caseNo: string | null;
   roomStatus: RoomStatus;
-  reportHref: string;
   /** 모바일 뒤로가기 — 없으면 버튼 미노출 */
   onBack?: () => void;
   /** 이름 옆 배지(매칭 완료 등). 없으면 미표시 */
   badge?: ReactNode;
   /** 서브타이틀 오버라이드. 없으면 기존 caseNo·roomStatus 라벨 */
   subtitle?: string;
-  /** 우측 액션 슬롯(데스크톱). 리포트 보기 다음에 붙는다(customer 매칭 버튼 등) */
-  actions?: ReactNode;
-  /** 모바일 우측 액션 슬롯. 전달 시 모바일 리포트 아이콘 대신 표시(customer 매칭 버튼). 미전달(partner)=현행 리포트 아이콘 */
-  mobileActions?: ReactNode;
-  /** 상담 종료(데스크톱 전용 버튼, partner 하위호환). ACTIVE 방에서만 노출 */
-  onClose?: () => void;
-  closePending?: boolean;
   /** 상대 프로필 링크(customer→사정사 프로필). 없으면(partner) 링크 없이 렌더 */
   profileHref?: string;
-  /** 신고 다이얼로그 열기. 전달 시 데스크톱 pill·모바일 아이콘 버튼 노출(roomStatus 무관 항상) */
-  onReport?: () => void;
+  /** 헤더 보조 액션 — 데스크톱·모바일 공통으로 "더보기" 패널에 세로 나열 */
+  menuActions: ChatThreadHeaderMenuAction[];
 }
 
 /** href가 있으면 아바타·이름 묶음을 프로필 링크로, 없으면(partner) 헤더 flex에 그대로 편다. */
@@ -48,112 +55,151 @@ function ProfileLink({ href, children }: { href?: string; children: ReactNode })
   );
 }
 
+function MenuActionItem({
+  action,
+  onSelect,
+}: {
+  action: ChatThreadHeaderMenuAction;
+  onSelect: () => void;
+}) {
+  const className = cn(
+    "flex w-full items-center gap-2.5 rounded-button px-3 py-2.5 text-left text-[0.8125rem] font-semibold transition hover:bg-paper-2",
+    action.tone === "danger" ? "text-terra" : "text-ink",
+    action.disabled && "pointer-events-none cursor-not-allowed opacity-[.42]",
+  );
+  const content = (
+    <>
+      <span className="flex w-5 shrink-0 justify-center text-[0.9375rem]">
+        {action.icon}
+      </span>
+      {action.label}
+    </>
+  );
+
+  if (action.href) {
+    return (
+      <Link
+        href={action.href}
+        role="menuitem"
+        aria-disabled={action.disabled}
+        className={className}
+        onClick={onSelect}
+      >
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={action.disabled}
+      className={className}
+      onClick={() => {
+        onSelect();
+        action.onClick?.();
+      }}
+    >
+      {content}
+    </button>
+  );
+}
+
 export function ChatThreadHeader({
   name,
   caseNo,
   roomStatus,
-  reportHref,
   onBack,
   badge,
   subtitle: subtitleOverride,
-  actions,
-  mobileActions,
-  onClose,
-  closePending,
   profileHref,
-  onReport,
+  menuActions,
 }: ChatThreadHeaderProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
   const subtitle =
     subtitleOverride ??
     [caseNo, ROOM_STATUS_META[roomStatus].label].filter(Boolean).join(" · ");
 
   return (
-    <header className="flex items-center gap-2.5 border-b border-line-2 bg-paper px-4 py-3 md:bg-card md:px-5">
-      {onBack && (
-        <button
-          type="button"
-          onClick={onBack}
-          aria-label="목록으로"
-          className="-ml-1 flex size-8 items-center justify-center rounded-full text-[1.25rem] text-ink transition hover:bg-paper-2 md:hidden"
-        >
-          {/* Figma 663:3801 — 얇은 좌측 셰브런 */}
-          <ChevronRight className="rotate-180" />
-        </button>
-      )}
+    <>
+      <header className="flex items-center gap-2.5 border-b border-line-2 bg-paper px-4 py-3 md:bg-card md:px-5">
+        {onBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            aria-label="목록으로"
+            className="-ml-1 flex size-8 items-center justify-center rounded-full text-[1.25rem] text-ink transition hover:bg-paper-2 md:hidden"
+          >
+            {/* Figma 663:3801 — 얇은 좌측 셰브런 */}
+            <ChevronRight className="rotate-180" />
+          </button>
+        )}
 
-      <ProfileLink href={profileHref}>
-        <Avatar name={name} size="sm" />
+        <ProfileLink href={profileHref}>
+          <Avatar name={name} size="sm" />
 
-        <div className="min-w-0 flex-1">
-          <p className="flex items-center gap-1.5 truncate text-[0.85rem] font-bold text-ink">
-            {name}
-            {/* Figma 95:4611 — 이름 옆 인증 마크 */}
-            <ShieldCheck className="shrink-0 text-[0.8125rem] text-ink-3" />
-            {badge}
-          </p>
-          {/* Figma 모바일(663:3796) 헤더는 이름만 — 사건번호·상태는 데스크톱(95:4571) 전용 */}
-          <p className="hidden truncate text-[0.6875rem] text-ink-3 md:block">{subtitle}</p>
-          <span className="sr-only md:hidden">{subtitle}</span>
+          <div className="min-w-0 flex-1">
+            <p className="flex items-center gap-1.5 truncate text-[0.85rem] font-bold text-ink">
+              {name}
+              {/* Figma 95:4611 — 이름 옆 인증 마크 */}
+              <ShieldCheck className="shrink-0 text-[0.8125rem] text-ink-3" />
+              {badge}
+            </p>
+            {/* Figma 모바일(663:3796) 헤더는 이름만 — 사건번호·상태는 데스크톱(95:4571) 전용 */}
+            <p className="hidden truncate text-[0.6875rem] text-ink-3 md:block">
+              {subtitle}
+            </p>
+            <span className="sr-only md:hidden">{subtitle}</span>
+          </div>
+        </ProfileLink>
+
+        {menuActions.length > 0 && (
+          <button
+            type="button"
+            onClick={() => setMenuOpen((open) => !open)}
+            aria-expanded={menuOpen}
+            aria-controls={MENU_ID}
+            className="flex shrink-0 items-center gap-1.5 rounded-full border border-line bg-card px-3.5 py-1.5 text-[0.8125rem] font-semibold text-ink-2 transition hover:bg-paper-2"
+          >
+            더보기
+            <ChevronDown
+              className={cn(
+                "text-[0.9375rem] transition-transform",
+                menuOpen && "rotate-180",
+              )}
+            />
+          </button>
+        )}
+      </header>
+
+      {/* 오버레이가 아니라 문서 흐름에 끼워 넣어 대화를 아래로 민다(grid-rows 0fr↔1fr 확장) */}
+      <div
+        inert={!menuOpen}
+        className={cn(
+          "grid shrink-0",
+          menuOpen
+            ? "grid-rows-[1fr] transition-[grid-template-rows] duration-200"
+            : // 접힐 땐 높이 애니메이션이 끝난 뒤 visibility를 끈다(클릭·포커스 차단)
+              "invisible grid-rows-[0fr] [transition:grid-template-rows_200ms_ease,visibility_0s_200ms]",
+        )}
+      >
+        <div className="overflow-hidden">
+          <div
+            id={MENU_ID}
+            role="menu"
+            className="flex flex-col border-b border-line-2 bg-card p-2 md:px-3"
+          >
+            {menuActions.map((action) => (
+              <MenuActionItem
+                key={action.key}
+                action={action}
+                onSelect={() => setMenuOpen(false)}
+              />
+            ))}
+          </div>
         </div>
-      </ProfileLink>
-
-      {/* 모바일 — 신고는 mobileActions 유무·roomStatus와 무관하게 항상 노출 */}
-      {onReport && (
-        <button
-          type="button"
-          onClick={onReport}
-          aria-label="신고하기"
-          className="flex size-9 shrink-0 items-center justify-center rounded-button text-[1.0625rem] text-ink-3 transition hover:bg-paper-2 md:hidden"
-        >
-          <AlertTriangle />
-        </button>
-      )}
-
-      {/* 모바일 — 매칭 액션 주입 시(customer) 리포트 아이콘 대신 표시, 아니면(partner) 리포트 아이콘. Figma 1012:9931 */}
-      {mobileActions ? (
-        <div className="flex shrink-0 items-center gap-1.5 md:hidden">{mobileActions}</div>
-      ) : (
-        <Link
-          href={reportHref}
-          aria-label="리포트 보기"
-          className="flex size-9 shrink-0 items-center justify-center rounded-button text-[1.1875rem] text-ink transition hover:bg-paper-2 md:hidden"
-        >
-          <FileText />
-        </Link>
-      )}
-
-      {/* 데스크톱 — 리포트 보기·상담 종료 버튼 */}
-      <div className="hidden items-center gap-2 md:flex">
-        <Link
-          href={reportHref}
-          className="flex items-center gap-1.5 rounded-full border border-line bg-card px-3.5 py-1.5 text-[0.8125rem] font-semibold text-ink transition hover:bg-paper-2"
-        >
-          리포트 보기
-          <FileText className="text-[0.9375rem]" />
-        </Link>
-        {actions}
-        {onReport && (
-          <button
-            type="button"
-            onClick={onReport}
-            className="flex items-center gap-1.5 rounded-full border border-line bg-card px-3.5 py-1.5 text-[0.8125rem] font-semibold text-ink-2 transition hover:bg-paper-2 hover:text-terra"
-          >
-            신고
-            <AlertTriangle className="text-[0.9375rem]" />
-          </button>
-        )}
-        {onClose && roomStatus === "ACTIVE" && (
-          <button
-            type="button"
-            onClick={onClose}
-            disabled={closePending}
-            className="flex items-center gap-1.5 rounded-full bg-terra px-3.5 py-1.5 text-[0.8125rem] font-semibold text-white transition hover:brightness-[.96] disabled:cursor-not-allowed disabled:opacity-[.42]"
-          >
-            상담 종료
-            <X className="text-[0.875rem]" />
-          </button>
-        )}
       </div>
-    </header>
+    </>
   );
 }

--- a/apps/web/src/shared/ui/chat/ReportChatDialog.stories.tsx
+++ b/apps/web/src/shared/ui/chat/ReportChatDialog.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { expect, userEvent, within } from "storybook/test";
+import { ReportChatDialog } from "./ReportChatDialog";
+
+const meta = {
+  title: "UI/Chat/ReportChatDialog",
+  component: ReportChatDialog,
+  parameters: { layout: "fullscreen" },
+  args: {
+    open: true,
+    counterpartName: "김도현 손해사정사",
+    onSubmit: () => {},
+    onClose: () => {},
+  },
+} satisfies Meta<typeof ReportChatDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** 기본 — 사유 미선택이라 제출 버튼 비활성. */
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole("button", { name: "신고하기" })).toBeDisabled();
+  },
+};
+
+/** 사유 선택됨 — 골드 선택 스타일 + 제출 버튼 활성. */
+export const ReasonSelected: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("radio", { name: "욕설·비방·괴롭힘" }));
+    await expect(canvas.getByRole("button", { name: "신고하기" })).toBeEnabled();
+  },
+};
+
+/** 기타 선택 — 상세 사유가 필수라 공백이면 제출 비활성. */
+export const OtherReasonRequiresDetail: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("radio", { name: "기타" }));
+    await expect(canvas.getByRole("button", { name: "신고하기" })).toBeDisabled();
+  },
+};
+
+/** 제출 중 — 라벨 `접수 중...`, 입력·닫기 차단. */
+export const Pending: Story = { args: { pending: true } };
+
+/** 실패 — 인라인 에러 유지 + 입력값 보존. */
+export const WithError: Story = {
+  args: { errorMessage: "신고 접수에 실패했어요. 잠시 후 다시 시도해 주세요." },
+};

--- a/apps/web/src/shared/ui/chat/ReportChatDialog.tsx
+++ b/apps/web/src/shared/ui/chat/ReportChatDialog.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  REPORT_DETAIL_MAX_LENGTH,
+  type ChatReportReason,
+  type ReportChatBody,
+} from "@/shared/api/chat/chat.schema";
+import { cn } from "@/shared/lib/utils";
+import { Modal } from "@/shared/ui/Modal";
+import { Textarea } from "@/shared/ui/Textarea";
+import { CHAT_REPORT_REASON_OPTIONS } from "./report-reason";
+
+export interface ReportChatDialogProps {
+  open: boolean;
+  /** 상대 이름 — 안내 문구용 */
+  counterpartName: string;
+  /** 제출 중 — 버튼 로딩·입력 비활성·dismiss 차단(이중 제출 방지) */
+  pending?: boolean;
+  /** 인라인 에러 문구(null이면 미표시) */
+  errorMessage?: string | null;
+  onSubmit: (body: ReportChatBody) => void;
+  onClose: () => void;
+}
+
+const DETAIL_FIELD_ID = "chat-report-detail";
+
+/** 채팅 상대 신고 다이얼로그(프레젠테이셔널). 서버 통신은 모르고 입력·제출 요청만 다룬다. */
+export function ReportChatDialog({
+  open,
+  counterpartName,
+  pending = false,
+  errorMessage = null,
+  onSubmit,
+  onClose,
+}: ReportChatDialogProps) {
+  const [reason, setReason] = useState<ChatReportReason | null>(null);
+  const [detail, setDetail] = useState("");
+
+  // 열릴 때만 초기화 — 실패 후에는 입력값을 보존해 재제출할 수 있게 둔다.
+  useEffect(() => {
+    if (!open) return;
+    setReason(null);
+    setDetail("");
+  }, [open]);
+
+  const detailRequired = reason === "OTHER";
+  const detailFilled = detail.trim().length > 0;
+  const submittable = reason !== null && (!detailRequired || detailFilled) && !pending;
+
+  const submit = () => {
+    if (reason === null || !submittable) return;
+    onSubmit({ reason, reasonDetail: detail.trim() || null });
+  };
+
+  return (
+    <Modal
+      open={open}
+      kicker="신고"
+      title="이 대화를 신고할까요?"
+      dismissible={!pending}
+      onClose={onClose}
+      className="max-w-[27.5rem]"
+    >
+      <p className="text-[0.8125rem] leading-relaxed text-ink-2">
+        신고 내용은 운영팀만 확인하며, 상대방에게는 알려지지 않아요.
+      </p>
+      <span className="sr-only">신고 대상: {counterpartName}</span>
+
+      <fieldset className="mt-5 flex flex-col gap-2" disabled={pending}>
+        <legend className="sr-only">신고 사유</legend>
+        {CHAT_REPORT_REASON_OPTIONS.map((option) => {
+          const selected = reason === option.value;
+
+          return (
+            <label
+              key={option.value}
+              className={cn(
+                "flex cursor-pointer items-center gap-2.5 rounded-card border px-4 py-3 text-[0.875rem] transition focus-within:ring-[3px] focus-within:ring-gold-soft",
+                selected
+                  ? "border-gold bg-gold-soft/40 font-semibold text-ink"
+                  : "border-line-2 bg-paper-2 text-ink-2 hover:border-gold-2 hover:bg-gold-soft/30",
+                pending && "cursor-not-allowed opacity-[.42]",
+              )}
+            >
+              <input
+                type="radio"
+                name="chat-report-reason"
+                value={option.value}
+                checked={selected}
+                onChange={() => setReason(option.value)}
+                disabled={pending}
+                className="sr-only"
+              />
+              <span
+                aria-hidden
+                className={cn(
+                  "flex size-4 shrink-0 items-center justify-center rounded-full border",
+                  selected ? "border-gold" : "border-line",
+                )}
+              >
+                {selected && <span className="size-2 rounded-full bg-gold" />}
+              </span>
+              {option.label}
+            </label>
+          );
+        })}
+      </fieldset>
+
+      <div className="mt-4">
+        <label htmlFor={DETAIL_FIELD_ID} className="text-[0.8125rem] font-semibold text-ink">
+          상세 사유
+          <span className="ml-1 text-[0.75rem] font-normal text-ink-3">
+            (기타 선택 시 필수)
+          </span>
+        </label>
+        <div className="mt-2">
+          <Textarea
+            id={DETAIL_FIELD_ID}
+            value={detail}
+            onChange={setDetail}
+            maxLength={REPORT_DETAIL_MAX_LENGTH}
+            rows={4}
+            counterPlacement="inside"
+            resizable={false}
+            placeholder="어떤 점이 문제였는지 알려주시면 확인에 도움이 돼요."
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {errorMessage && (
+        <p
+          role="alert"
+          className="mt-3 rounded-card bg-terra-soft px-3.5 py-2.5 text-[0.8125rem] text-terra"
+        >
+          {errorMessage}
+        </p>
+      )}
+
+      <div className="mt-6 flex gap-2.5">
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={pending}
+          className="flex-1 rounded-button bg-paper px-5 py-3 text-[0.875rem] font-bold text-ink transition hover:brightness-[.97] disabled:cursor-not-allowed disabled:opacity-[.42]"
+        >
+          취소
+        </button>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={!submittable}
+          className="flex-1 rounded-button bg-terra px-5 py-3 text-[0.875rem] font-bold text-white transition hover:brightness-[.96] disabled:cursor-not-allowed disabled:opacity-[.42]"
+        >
+          {pending ? "접수 중..." : "신고하기"}
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/src/shared/ui/chat/report-reason.ts
+++ b/apps/web/src/shared/ui/chat/report-reason.ts
@@ -1,0 +1,10 @@
+import type { ChatReportReason } from "@/shared/api/chat/chat.schema";
+
+/** 신고 사유 표시 라벨. 코드·네트워크는 영문 enum만 쓰고 한글은 화면 표시에만 쓴다. */
+export const CHAT_REPORT_REASON_OPTIONS: { value: ChatReportReason; label: string }[] = [
+  { value: "SPAM", label: "스팸·광고" },
+  { value: "ABUSE", label: "욕설·비방·괴롭힘" },
+  { value: "FRAUD", label: "사기 의심" },
+  { value: "PRIVACY_VIOLATION", label: "개인정보 침해" },
+  { value: "OTHER", label: "기타" },
+];

--- a/apps/web/src/shared/ui/chat/use-report-chat-dialog.ts
+++ b/apps/web/src/shared/ui/chat/use-report-chat-dialog.ts
@@ -23,7 +23,8 @@ export function useReportChatDialog(chatRoomId: string) {
 
   const closeDialog = () => setOpen(false);
 
-  const submit = (body: ReportChatBody) =>
+  const submit = (body: ReportChatBody) => {
+    setErrorMessage(null);
     mutate(body, {
       onSuccess: () => {
         setOpen(false);
@@ -32,6 +33,7 @@ export function useReportChatDialog(chatRoomId: string) {
       // 다이얼로그를 열어 둔 채 입력값을 보존해 재제출할 수 있게 한다.
       onError: () => setErrorMessage(REPORT_FAILED_MESSAGE),
     });
+  };
 
   return { open, openDialog, closeDialog, submit, pending: isPending, errorMessage };
 }

--- a/apps/web/src/shared/ui/chat/use-report-chat-dialog.ts
+++ b/apps/web/src/shared/ui/chat/use-report-chat-dialog.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState } from "react";
+import type { ReportChatBody } from "@/shared/api/chat/chat.schema";
+import { useReportChat } from "@/shared/api/chat/use-report-chat";
+import { toast } from "@/shared/ui/toast";
+
+const REPORT_FAILED_MESSAGE = "신고 접수에 실패했어요. 잠시 후 다시 시도해 주세요.";
+
+/**
+ * 신고 다이얼로그 상태 + 뮤테이션 배선. customer·partner 컨테이너가 같은 배선을 복붙하지 않도록 응집한다.
+ * 실패는 코드별 분기 없이 단일 경로(401은 fetch-json이 /login-required로 가로챈다).
+ */
+export function useReportChatDialog(chatRoomId: string) {
+  const [open, setOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { mutate, isPending } = useReportChat(chatRoomId);
+
+  const openDialog = () => {
+    setErrorMessage(null);
+    setOpen(true);
+  };
+
+  const closeDialog = () => setOpen(false);
+
+  const submit = (body: ReportChatBody) =>
+    mutate(body, {
+      onSuccess: () => {
+        setOpen(false);
+        toast.success("신고가 접수됐어요. 운영팀이 확인 후 안내드릴게요.");
+      },
+      // 다이얼로그를 열어 둔 채 입력값을 보존해 재제출할 수 있게 한다.
+      onError: () => setErrorMessage(REPORT_FAILED_MESSAGE),
+    });
+
+  return { open, openDialog, closeDialog, submit, pending: isPending, errorMessage };
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #244

## ✅ 작업 내용

### 채팅방 상대를 신고할 수 있는 다이얼로그를 추가했습니다

리포트 보기·매칭 완료·매칭 거절·신고까지 헤더 버튼이 한 번에 4개까지 늘어나 모바일에서 특히 답답해 보였습니다. 그래서 신고를 별도 버튼으로 얹는 대신, **헤더 보조 액션 전체를 "더보기" 버튼 하나로 묶고 아래로 펼치는 방식**으로 바꿨습니다(오버레이가 아니라 채팅 내용을 밀어내는 인라인 아코디언). 데스크톱·모바일 동일하게 동작합니다.

<img width="1000" alt="데스크톱 헤더 더보기 패널" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/dfcf0446c9353c67cde4e7d98dea0a2185170112/.pr-assets/issue-244/244-01-header-desktop.png" />

<br/>

### 1. 헤더 액션 더보기 메뉴 통합

`ChatThreadHeader`의 `reportHref`/`actions`/`mobileActions`/`onClose`/`onReport` 개별 prop을 `menuActions` 배열 하나로 교체했습니다. customer는 리포트 보기 + (비교 중이면) 매칭 완료·매칭 거절 + 신고, partner는 리포트 보기 + (진행 중이면) 상담 종료 + 신고를 각자 배열로 조립해 넘깁니다.

#### 세부 작업
* `ChatThreadHeader.tsx` → `menuActions` 단일 prop, 자체 상태로 펼침 관리, 데스크톱·모바일 이중 마크업 제거
* `ChatThreadContent.tsx`(partner) / `CustomerChatThreadContent.tsx`(customer) → 액션 배열 조립으로 교체
* Storybook 스토리 전면 재작성(액션 1개 / 풀세트 / 펼친 상태)

<br/>

### 2. 신고 사유 선택 다이얼로그

스팸·광고 / 욕설·비방·괴롭힘 / 사기 의심 / 개인정보 침해 / 기타 중 하나를 라디오로 고릅니다. 사유를 고르지 않으면 제출 버튼이 비활성화됩니다.

<img width="1000" alt="신고 사유 선택" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/dfcf0446c9353c67cde4e7d98dea0a2185170112/.pr-assets/issue-244/244-02-dialog-reason.png" />

#### 세부 작업
* `chat.schema.ts` → 신고 사유 enum, 요청·응답 zod 스키마 추가
* `report-chat.ts` / `use-report-chat.ts` → 신고 요청 fetch 함수·mutation 훅 추가
* `ReportChatDialog.tsx` → 사유 라디오 다이얼로그(+ Storybook 스토리)

<br/>

### 3. "기타" 선택 시 상세 사유 필수 입력

"기타"를 고르면 상세 사유(최대 500자)를 입력해야 제출할 수 있습니다.

<img width="1000" alt="기타 사유 상세 입력" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/dfcf0446c9353c67cde4e7d98dea0a2185170112/.pr-assets/issue-244/244-03-dialog-other.png" />

#### 세부 작업
* `ReportChatDialog.tsx` → "기타" 선택 시 상세 입력란 필수 검증, 500자 카운터
* `Textarea.tsx` → 제출 중 입력 차단용 `disabled` prop 추가

<br/>

### 4. 접수 성공·실패 처리, 모바일도 같은 더보기 메뉴로 접근

접수에 성공하면 다이얼로그가 닫히고 토스트로 안내합니다. 실패하면 다이얼로그를 유지하고 입력값을 보존한 채 인라인 에러를 보여줘 재제출할 수 있습니다. 중복 신고는 막지 않고 매번 접수됩니다.

<img width="360" alt="모바일 헤더 더보기 패널" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/dfcf0446c9353c67cde4e7d98dea0a2185170112/.pr-assets/issue-244/244-04-header-mobile.png" />

#### 세부 작업
* `use-report-chat-dialog.ts` → 다이얼로그 상태와 mutation 연결, 성공/실패 분기
* `handlers.ts` → MSW 핸들러(방 없음·사유 검증 실패·접수 성공), 테스트용 강제 실패 헤더 분기

## 📌 참고

`POST /chats/{chatRoomId}/report`는 Notion API 명세서 DB에 아직 등록돼 있지 않습니다. 이번 PR은 이슈 원문·팀 확정 사항(사유 enum 5종, 필드명 `reasonDetail`/`chatReportId`, **중복 신고 제한 없음**)을 기준으로 프론트 확정 계약을 구현했고, 백엔드 정식 명세 등록은 별도로 요청할 예정입니다.

## 🧪 테스트

Playwright + MSW **E2E**(`apps/web/e2e/chat-report.spec.ts` 신고 흐름 8개 + 헤더 더보기 메뉴로 바뀐 기존 `chat.spec.ts`·`shared-report.spec.ts` 회귀). 핵심 사용자 흐름을 행동 기준으로 검증했습니다.

| # | 테스트 | 검증 내용 |
|---|--------|-----------|
| 1 | 사유를 고르고 신고하면 다이얼로그가 닫히고 접수 안내가 보인다 | 성공 흐름 |
| 2 | 사유를 고르지 않으면 신고하기 버튼을 누를 수 없다 | 미선택 시 disabled |
| 3 | 기타를 고르면 상세 사유를 적어야 신고할 수 있다 | 기타 필수 입력 |
| 4 | 접수에 실패하면 입력값이 남은 채 안내가 뜨고 다시 보내면 접수된다 | 실패 후 입력 보존·재제출 |
| 5 | 같은 방을 연달아 두 번 신고해도 매번 접수된다 | 중복 제한 없음 |
| 6 | 상담이 종료된 방에서도 신고 버튼은 그대로 남는다 | roomStatus 무관 노출 |
| 7 | 파트너 방에서도 상대를 신고할 수 있다 | partner 측 배선 |
| 8 | 모바일에서는 더보기 메뉴로 신고 다이얼로그를 연다 | 모바일 접근성 |

`pnpm typecheck`·`pnpm lint` 통과, 신고·매칭·리포트 보기 관련 E2E 전부 chromium 프로젝트에서 통과했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 채팅방에서 상대방을 신고할 수 있는 기능을 추가했습니다.
  - 신고 사유 선택, 기타 사유 상세 입력, 글자 수 제한 및 제출 상태를 지원합니다.
  - 신고 성공·실패 시 안내 메시지를 제공하며, 실패 시 입력 내용이 유지됩니다.
  - 채팅 헤더의 추가 작업을 더보기 메뉴로 통합했습니다.

- **개선**
  - 모바일과 데스크톱에서 채팅 작업을 일관된 메뉴로 이용할 수 있습니다.
  - 입력 영역을 비활성화할 수 있도록 개선했습니다.

- **테스트**
  - 신고 및 채팅 헤더 메뉴의 주요 화면과 동작 검증을 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->