### PR TITLE
[Feature] 계정 삭제 안내 공개 페이지 추가(web)

### DIFF
--- a/apps/web/e2e/_capture-249.spec.ts
+++ b/apps/web/e2e/_capture-249.spec.ts
@@ -1,0 +1,43 @@
+import { test } from "@playwright/test";
+import { hideQueryDevtools } from "./_region-helpers";
+
+/** PR 스크린샷 캡처 헬퍼(#249). 테스트 아님 — CI 제외(testIgnore). */
+
+const DIR = "../../.pr-assets/issue-249";
+
+const DESKTOP = { width: 1280, height: 900 };
+const MOBILE = { width: 390, height: 844 };
+
+test.beforeEach(async ({ page }) => {
+  await hideQueryDevtools(page);
+  await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
+});
+
+test("01 계정 삭제 안내 데스크톱", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto("/account-deletion");
+  await page.getByRole("heading", { name: "계정 삭제 안내" }).waitFor({ timeout: 15000 });
+  await page.screenshot({ path: `${DIR}/01-account-deletion-desktop.png`, fullPage: true });
+});
+
+test("02 계정 삭제 안내 모바일", async ({ page }) => {
+  await page.setViewportSize(MOBILE);
+  await page.goto("/account-deletion");
+  await page.getByRole("heading", { name: "계정 삭제 안내" }).waitFor({ timeout: 15000 });
+  await page.screenshot({ path: `${DIR}/02-account-deletion-mobile.png`, fullPage: true });
+});
+
+test("03 랜딩 푸터 계정 삭제 링크", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto("/");
+  const footer = page.getByRole("contentinfo");
+  await footer.getByRole("link", { name: "계정 삭제" }).waitFor({ timeout: 15000 });
+  await footer.screenshot({ path: `${DIR}/03-landing-footer.png` });
+});
+
+test("04 문의하기 계정 삭제 안내 링크", async ({ page }) => {
+  await page.setViewportSize(DESKTOP);
+  await page.goto("/contact");
+  await page.getByRole("link", { name: "계정 삭제 안내" }).waitFor({ timeout: 15000 });
+  await page.screenshot({ path: `${DIR}/04-contact-link-desktop.png`, fullPage: true });
+});

--- a/apps/web/e2e/public-pages.spec.ts
+++ b/apps/web/e2e/public-pages.spec.ts
@@ -2,7 +2,8 @@ import { expect, test } from "@playwright/test";
 import { setAuthCookie } from "./_auth-cookie-helpers";
 
 /**
- * 공개 마케팅 페이지 E2E — 서비스 소개(/about)·이용 방법(/guide)·문의하기(/contact) (공개 페이지 슬라이스).
+ * 공개 마케팅 페이지 E2E — 서비스 소개(/about)·이용 방법(/guide)·문의하기(/contact)·계정 삭제
+ *   안내(/account-deletion) (공개 페이지 슬라이스).
  *
  * 원칙(fe-e2e-strategy): 핵심 사용자 흐름(CUJ) happy-path만 — 랜딩 헤더에서 두 페이지로
  *   진입 → 콘텐츠 노출 → FAQ 디스클로저 동작 → CTA로 로그인 진입 → 로그인 전후 푸터에서 문의하기 진입.
@@ -14,6 +15,7 @@ const LANDING = "/";
 const ABOUT = "/about";
 const GUIDE = "/guide";
 const CONTACT = "/contact";
+const ACCOUNT_DELETION = "/account-deletion";
 
 test.describe("공개 페이지 진입 흐름", () => {
   test.use({ viewport: { width: 1280, height: 900 } });
@@ -115,6 +117,47 @@ test.describe("문의하기 진입 흐름", () => {
     await expect(async () => {
       await page.getByRole("contentinfo").getByRole("link", { name: "문의하기" }).click();
       await expect(page).toHaveURL(/\/contact$/);
+    }).toPass({ timeout: 10000 });
+  });
+});
+
+test.describe("계정 삭제 안내 페이지", () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  // 스토어 심사자가 로그인 없이 여는 URL — 로그인 가드에 걸리면 제출 자체가 반려된다.
+  test("비로그인 상태로 /account-deletion에 접근하면 리다이렉트 없이 안내가 보인다", async ({
+    page
+  }) => {
+    await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
+    await page.goto(ACCOUNT_DELETION);
+
+    await expect(page).toHaveURL(/\/account-deletion$/);
+    await expect(page.getByRole("heading", { name: "계정 삭제 안내" })).toBeVisible();
+    await expect(page.getByText("앱 이름: 바른보상")).toBeVisible();
+    await expect(page.getByText("개발자: 바른보상 팀")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "계정 삭제 요청 방법" })).toBeVisible();
+    await expect(page.getByText("주고받은 채팅 대화")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "보관되는 데이터와 보관 기간" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "teambrbosang@gmail.com" })).toBeVisible();
+  });
+
+  test("랜딩 푸터의 계정 삭제를 누르면 /account-deletion으로 이동한다", async ({ page }) => {
+    await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
+    await page.goto(LANDING);
+
+    await expect(async () => {
+      await page.getByRole("contentinfo").getByRole("link", { name: "계정 삭제" }).click();
+      await expect(page).toHaveURL(/\/account-deletion$/);
+    }).toPass({ timeout: 10000 });
+  });
+
+  test("문의하기의 계정 삭제 안내를 누르면 /account-deletion으로 이동한다", async ({ page }) => {
+    await page.setExtraHTTPHeaders({ "x-mock-scenario": "unauthenticated" });
+    await page.goto(CONTACT);
+
+    await expect(async () => {
+      await page.getByRole("link", { name: "계정 삭제 안내" }).click();
+      await expect(page).toHaveURL(/\/account-deletion$/);
     }).toPass({ timeout: 10000 });
   });
 });

--- a/apps/web/src/app/(public)/_components/LandingFooter.tsx
+++ b/apps/web/src/app/(public)/_components/LandingFooter.tsx
@@ -6,7 +6,8 @@ const FOOTER_LINKS = [
   { label: "이용 방법", href: "/guide" },
   { label: "문의하기", href: "/contact" },
   { label: "이용약관", href: "/terms" },
-  { label: "개인정보처리방침", href: "/privacy" }
+  { label: "개인정보처리방침", href: "/privacy" },
+  { label: "계정 삭제", href: "/account-deletion" }
 ] as const;
 
 const LEGAL_NOTICE =

--- a/apps/web/src/app/(public)/account-deletion/_model/content.ts
+++ b/apps/web/src/app/(public)/account-deletion/_model/content.ts
@@ -1,0 +1,50 @@
+export const APP_NAME = "바른보상";
+export const DEVELOPER_NAME = "바른보상 팀";
+export const DELETION_REQUEST_EMAIL = "teambrbosang@gmail.com";
+
+export interface AccountDeletionSection {
+  heading: string;
+  body?: string;
+  items?: readonly string[];
+  ordered?: boolean;
+}
+
+export const ACCOUNT_DELETION_SECTIONS: readonly AccountDeletionSection[] = [
+  {
+    heading: "서비스 정보",
+    items: [
+      `앱 이름: ${APP_NAME}`,
+      `개발자: ${DEVELOPER_NAME}`,
+      `문의 이메일: ${DELETION_REQUEST_EMAIL}`
+    ]
+  },
+  {
+    heading: "계정 삭제 요청 방법",
+    ordered: true,
+    items: [
+      `${APP_NAME} 앱 또는 웹에서 로그인합니다.`,
+      "마이페이지로 이동합니다.",
+      "회원 탈퇴를 선택한 뒤 안내에 따라 탈퇴를 완료합니다."
+    ],
+    body: "탈퇴가 완료되면 계정과 관련 데이터가 삭제됩니다."
+  },
+  {
+    heading: "삭제되는 데이터",
+    items: [
+      "계정 정보(소셜 로그인 식별자, 닉네임, 성별, 생년월일, 휴대전화번호, 프로필 이미지, 활동 지역)",
+      "받은 제안과 상담 내역",
+      "주고받은 채팅 대화",
+      "요청한 검토 리포트 이력",
+      "신청 과정에서 업로드한 첨부 파일",
+      "알림 발송에 사용한 기기 푸시 토큰"
+    ]
+  },
+  {
+    heading: "보관되는 데이터와 보관 기간",
+    body: "회원 탈퇴 시 위 데이터를 지체 없이 파기하며 별도로 보관하지 않습니다. 다만 손해사정사 회원이 제출한 자격증 사본 등 자격 검증 정보는 분쟁 대응을 위해 탈퇴 후 1년간 별도 보관한 뒤 파기하고, 관계 법령에 따라 보존이 필요한 항목이 있는 경우 해당 법령이 정한 기간 동안 보관합니다."
+  },
+  {
+    heading: "삭제 후 복구",
+    body: "삭제된 정보는 복구할 수 없으며, 같은 계정으로 다시 가입해도 이전 내역은 되살아나지 않습니다."
+  }
+];

--- a/apps/web/src/app/(public)/account-deletion/page.tsx
+++ b/apps/web/src/app/(public)/account-deletion/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ACCOUNT_DELETION_SECTIONS,
+  APP_NAME,
+  DELETION_REQUEST_EMAIL
+} from "./_model/content";
+
+export const metadata: Metadata = {
+  title: "계정 삭제 안내",
+  description: `${APP_NAME} 계정과 관련 데이터를 삭제하는 방법, 삭제되는 데이터 항목과 보관 기간을 안내합니다.`
+};
+
+export default function AccountDeletionPage() {
+  return (
+    <div className="mx-auto w-full max-w-[48rem] px-6 py-10 sm:py-14">
+      <h1 className="font-serif text-xl font-bold text-ink">계정 삭제 안내</h1>
+
+      <div className="mt-6 rounded-card-lg border border-line bg-card p-6 sm:p-8">
+        <div className="flex flex-col gap-6">
+          {ACCOUNT_DELETION_SECTIONS.map((section) => (
+            <section key={section.heading}>
+              <h2 className="text-[0.9375rem] font-bold text-ink">{section.heading}</h2>
+
+              {section.items ? (
+                section.ordered ? (
+                  <ol className="mt-2 flex list-decimal flex-col gap-1.5 pl-[1.125rem] text-[0.8125rem] leading-relaxed text-ink-2">
+                    {section.items.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ol>
+                ) : (
+                  <ul className="mt-2 flex list-disc flex-col gap-1.5 pl-[1.125rem] text-[0.8125rem] leading-relaxed text-ink-2">
+                    {section.items.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )
+              ) : null}
+
+              {section.body ? (
+                <p className="mt-2 text-[0.8125rem] leading-relaxed text-ink-2">{section.body}</p>
+              ) : null}
+            </section>
+          ))}
+
+          <section>
+            <h2 className="text-[0.9375rem] font-bold text-ink">메일로 삭제 요청하기</h2>
+            <p className="mt-2 text-[0.8125rem] leading-relaxed text-ink-2">
+              앱이나 웹에 접속하기 어려운 경우{" "}
+              <a
+                href={`mailto:${DELETION_REQUEST_EMAIL}`}
+                className="text-ink underline underline-offset-2"
+              >
+                {DELETION_REQUEST_EMAIL}
+              </a>
+              로 가입하신 계정 정보와 함께 삭제를 요청해 주세요. 본인 확인 후 처리해 드립니다.
+              개인정보 처리에 대한 자세한 내용은{" "}
+              <Link href="/privacy" className="text-ink underline underline-offset-2">
+                개인정보 처리방침
+              </Link>
+              에서 확인하실 수 있습니다.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(public)/contact/page.tsx
+++ b/apps/web/src/app/(public)/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { ContactForm } from "./_components/ContactForm";
 
 const CONTACT_EMAIL = "teambrbosang@gmail.com";
@@ -35,6 +36,20 @@ export default function ContactPage() {
                 {CONTACT_EMAIL}
               </a>
               로 보내주세요.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-[0.9375rem] font-bold text-ink">계정 삭제 문의</h2>
+            <p className="mt-2 text-[0.8125rem] leading-relaxed text-ink-2">
+              계정과 관련 데이터 삭제를 원하시면{" "}
+              <Link
+                href="/account-deletion"
+                className="text-ink underline underline-offset-2"
+              >
+                계정 삭제 안내
+              </Link>
+              에서 삭제 절차와 삭제되는 데이터를 확인하실 수 있습니다.
             </p>
           </section>
         </div>

--- a/apps/web/src/shared/ui/Footer.tsx
+++ b/apps/web/src/shared/ui/Footer.tsx
@@ -19,7 +19,8 @@ const FOOTER_COLUMNS = [
     heading: "정책",
     links: [
       { label: "이용약관", href: "/terms" },
-      { label: "개인정보처리방침", href: "/privacy" }
+      { label: "개인정보처리방침", href: "/privacy" },
+      { label: "계정 삭제", href: "/account-deletion" }
     ]
   }
 ] as const;


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #249

## ✅ 작업 내용

### Google Play 데이터 안전 제출용 계정 삭제 안내 페이지를 추가했습니다

<img width="1000" alt="계정 삭제 안내 데스크톱" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/141dc1f4f4516f8dc9124f80b9f24f5cd99c8dee/.pr-assets/issue-249/01-account-deletion-desktop.png" />

스토어 등록정보에 넣을 "계정 및 관련 데이터 삭제 요청 URL"입니다. 기존 `/withdraw`는 `proxy.ts` matcher에 걸려 비로그인 접근이 `/login-required`로 튕기므로, 심사자가 로그인 없이 열 수 있는 공개 페이지를 따로 만들었습니다. 제출 URL은 `https://www.brbosang.com/account-deletion`입니다.

<br/>

### 1. 공개 페이지 추가

`(public)` 라우트 그룹에 서버 컴포넌트로 넣었습니다. `proxy.ts` matcher는 `/customer`·`/partner`·`/notifications`·`/withdraw`뿐이라 미들웨어 수정 없이 비로그인 접근이 통과합니다. 마크업은 `/terms`·`/privacy`·`/contact`와 같은 셸을 그대로 써서 신규 컴포넌트 없이 구성했고, 문구는 `_model/content.ts`에 모아 페이지는 렌더만 합니다.

구글이 요구하는 3요소를 각각 섹션으로 담았습니다.

| 요구 사항 | 페이지 섹션 |
|---|---|
| 앱 이름·개발자 이름 | 서비스 정보 |
| 삭제 요청 절차 | 계정 삭제 요청 방법, 메일로 삭제 요청하기 |
| 삭제 데이터·보관 데이터·보관 기간 | 삭제되는 데이터, 보관되는 데이터와 보관 기간, 삭제 후 복구 |

#### 세부 작업
* `account-deletion/page.tsx` → 페이지 및 `metadata` 지정
* `account-deletion/_model/content.ts` → 안내 문구

<br/>

### 2. 진입 링크 추가

<img width="1000" alt="랜딩 푸터 계정 삭제 링크" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/141dc1f4f4516f8dc9124f80b9f24f5cd99c8dee/.pr-assets/issue-249/03-landing-footer.png" />

랜딩 푸터와 문의하기 페이지에 링크를 넣었습니다. 이슈 범위 밖이지만 로그인 이후 셸이 쓰는 `shared/ui/Footer.tsx`에도 함께 넣었습니다. 여기가 빠지면 앱에 로그인한 상태에서는 페이지에 닿을 방법이 없습니다.

#### 세부 작업
* `LandingFooter.tsx` → 푸터 메뉴에 "계정 삭제" 추가
* `shared/ui/Footer.tsx` → 정책 항목에 "계정 삭제" 추가
* `contact/page.tsx` → 계정 삭제 문의 섹션 추가

<br/>

### 3. 탈퇴 화면 안내 항목 보강

<img width="1000" alt="탈퇴 화면 삭제 안내" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/fc50d75a7d7cc774633453f009e49a08aa233ab6/.pr-assets/issue-249/05-withdraw-notice-desktop.png" />

`WithdrawNotice`의 `DELETED_ITEMS`는 제안·상담, 채팅, 리포트 이력 3개뿐이라 안내 페이지보다 좁았습니다. 탈퇴 직전 화면이 실제 삭제 범위보다 적게 안내하는 상태여서 계정 정보·첨부 파일·기기 푸시 토큰을 더해 두 화면을 맞췄습니다.

#### 세부 작업
* `WithdrawNotice.tsx` → 삭제 항목 3개 → 6개

<br/>

### 4. 모바일 웹뷰 레이아웃

<img width="380" alt="계정 삭제 안내 모바일" src="https://raw.githubusercontent.com/SM17-YoonDongJu/Frontend/141dc1f4f4516f8dc9124f80b9f24f5cd99c8dee/.pr-assets/issue-249/02-account-deletion-mobile.png" />

기존 공개 페이지와 같은 `max-w-[48rem]` 셸을 쓰므로 390px 폭에서도 문서 카드가 그대로 줄어듭니다.

## 🧪 테스트

Playwright + MSW **E2E 3개**(`apps/web/e2e/public-pages.spec.ts`).

| # | 테스트 | 검증 내용 |
|---|--------|-----------|
| 1 | 비로그인 상태로 /account-deletion에 접근하면 리다이렉트 없이 안내가 보인다 | URL 유지, 앱·개발자명, 삭제 절차, 삭제 데이터, 보관 기간, 문의 메일 노출 |
| 2 | 랜딩 푸터의 계정 삭제를 누르면 /account-deletion으로 이동한다 | 비로그인 푸터 진입 |
| 3 | 문의하기의 계정 삭제 안내를 누르면 /account-deletion으로 이동한다 | 문의하기 진입 |

탈퇴 화면 문구는 기존 `account-withdraw.spec.ts`가 이미 검증합니다. chromium 전체 스펙 280개 통과했습니다.

## 📌 참고

보관 기간 문구는 이슈 본문의 "별도 보관하지 않음" 대신 개인정보 처리방침 제7조를 그대로 따랐습니다. 방침에는 손해사정사 회원의 자격 검증 정보를 탈퇴 후 1년간 보관한다고 적혀 있어서, 안내 페이지에서 "보관하지 않음"이라고만 쓰면 두 문서가 어긋납니다.

## 🔜 후속 제안

백엔드 탈퇴 처리가 실제로 하드 삭제인지 확인이 필요합니다. soft delete라면 보관 기간 문구와 개인정보 처리방침 제7조를 함께 고쳐야 합니다.
