### PR TITLE
[Refactor] 서류제출·채팅·가입 화면 로직 훅 분리

### DIFF
--- a/.claude/skills/frontend-feature/references/naming-dictionary.md
+++ b/.claude/skills/frontend-feature/references/naming-dictionary.md
@@ -124,6 +124,7 @@ items[]{ `paymentId` · `amount`(int) · `type`(`SUBSCRIPTION`) · `status`(`PAI
 
 - **조회 훅:** `use<Entity><List|Detail>` — `useReportList` · `useReportDetail` · `useMe` · `useChatList` · `usePaymentHistory` · `useProfile`(사정사 본인 프로필=`GET /adjusters/me/profile`)
 - **뮤테이션 훅:** `use<Verb><Entity>` — `useCreateReport`(신청) · `useReviewReport`(검수=PATCH) · `useCreateMatch`(상담신청) · `useCreateSubscription` · `useApplyAdjuster`(자격신청) · `useUpdateMe` · `useDeleteMe`(탈퇴) · `useRegister` · `useLogout` · `useUpdateProfile`(사정사 프로필 수정=PATCH) · `useUploadAvatar`(`POST /uploads`)
+- **화면 오케스트레이션 훅:** `use<Screen>` — 세그먼트 `_hooks/`에 두고 `{ state, derived, actions }` 반환(선례 `useReviewDraft`). 뷰는 파생값을 재계산하지 않는다 — `useDocumentUpload`(서류 제출 스텝 업로드) · `useCustomerChatThread`(고객 채팅 스레드) · `useSignupForm`(가입 동의·본인확인 폼)
 - **API 함수:** `<verb><Entity>` — `getReport` · `getReportList` · `createReport` · `reviewReport` · `createMatch` · `getMe` · `getProfile` · `updateProfile` · `uploadAvatar` …
 - **쿼리키 factory**(`@lukemorales/query-key-factory`): 도메인별 `createQueryKeys('<domain>', …)` → `report.list(params)` · `report.detail(reportId)` · `user.me` · `chat.list` · `payment.history` · `adjuster.meProfile()`(사정사 본인 프로필)
 

--- a/apps/web/src/app/(auth)/signup/_components/SignupFunnel.tsx
+++ b/apps/web/src/app/(auth)/signup/_components/SignupFunnel.tsx
@@ -1,124 +1,20 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import type { UserType } from "@/shared/model/user";
 import { ChevronRight } from "@/shared/ui/icons/ChevronRight";
 import { AuthHeader } from "../../_shared/ui/AuthHeader";
-import { getRegisterErrorCode, useRegister } from "../_api/use-register";
+import { useSignupForm } from "../_hooks/use-signup-form";
 import { AdjusterNotice } from "./AdjusterNotice";
 import { CompleteStep } from "./CompleteStep";
 import { ConsentStep } from "./ConsentStep";
 import { IdentityStep } from "./IdentityStep";
 import { RoleSelectStep } from "./RoleSelectStep";
 import { SignupProgress } from "./SignupProgress";
-import { useSignupFunnel, type SignupStep } from "../_hooks/use-signup-funnel";
-import { useSignupSocial } from "../_hooks/use-signup-social";
-import { isRequiredConsentMet, type ConsentState } from "../_model/consent-config";
-import { toRegisterBody, type RegisterResponse } from "../_model/register.schema";
-import { clearSignupTicket } from "../../_shared/lib/signup-ticket";
-import {
-  clearSignupDraft,
-  loadSignupDraft,
-  saveSignupDraft,
-  type IdentityDraft,
-} from "../_model/signup-draft";
-import type { TermsType } from "@/shared/model/terms-content";
-
-const CUSTOMER_DASHBOARD_PATH = "/customer/dashboard";
-const ADJUSTER_CERTIFY_PATH = "/signup/verification";
-
-/** 뒤로가기 대상 단계. 첫 단계·완료는 없음. */
-const BACK_TARGET: Partial<Record<SignupStep, SignupStep>> = {
-  terms: "role",
-  identity: "terms",
-};
 
 export function SignupFunnel() {
-  const router = useRouter();
-  const funnel = useSignupFunnel();
-  const social = useSignupSocial();
-  const register = useRegister();
+  const { state, derived, actions } = useSignupForm();
 
-  const [selectedUserType, setSelectedUserType] = useState<UserType | null>(
-    () => loadSignupDraft().userType,
-  );
-  const [consent, setConsent] = useState<ConsentState>(() => loadSignupDraft().consent);
-  const [identity, setIdentity] = useState<IdentityDraft>(() => loadSignupDraft().identity);
-  const [showAdjusterNotice, setShowAdjusterNotice] = useState(false);
-  const [result, setResult] = useState<RegisterResponse | null>(null);
-
-  // 약관 상세 페이지 왕복 시 선택 역할·동의·본인 확인 입력 유지(전체 페이지 이동 대비).
-  useEffect(() => {
-    saveSignupDraft({ userType: selectedUserType, consent, identity });
-  }, [selectedUserType, consent, identity]);
-
-  // 소셜 인증 컨텍스트(티켓·쿼리) 없이 직접 진입하면 로그인으로 되돌림.
-  useEffect(() => {
-    if (!social) router.replace("/login");
-  }, [social, router]);
-
-  // 직접 URL 진입 가드: 선행 단계 미완이면 첫 단계로 되돌림.
-  useEffect(() => {
-    if (funnel.step === "terms" && selectedUserType !== "insured_person") {
-      funnel.goTo("role", { replace: true });
-    }
-    if (
-      funnel.step === "identity" &&
-      (selectedUserType !== "insured_person" || !isRequiredConsentMet(consent))
-    ) {
-      funnel.goTo("role", { replace: true });
-    }
-    if (funnel.step === "done" && !result) {
-      funnel.goTo("role", { replace: true });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [funnel.step]);
-
-  const handleStart = () => {
-    if (selectedUserType === "insured_person") {
-      funnel.goTo("terms");
-      return;
-    }
-    if (selectedUserType === "adjuster") setShowAdjusterNotice(true);
-  };
-
-  const handleToggle = (type: TermsType, checked: boolean) => {
-    setConsent((prev) => ({ ...prev, [type]: checked }));
-  };
-
-  const handleToggleAll = (checked: boolean) => {
-    setConsent({ service: checked, privacy: checked, marketing: checked });
-  };
-
-  const handleSubmit = () => {
-    if (selectedUserType !== "insured_person" || !social || !identity.gender) return;
-
-    const body = toRegisterBody({
-      provider: social.provider,
-      socialToken: social.socialToken,
-      userType: selectedUserType,
-      nickname: social.nickname,
-      gender: identity.gender,
-      birthDate: identity.birthDate,
-      phoneNumber: identity.phoneNumber,
-    });
-
-    register.mutate(body, {
-      onSuccess: (data) => {
-        clearSignupDraft();
-        clearSignupTicket();
-        setResult(data);
-        funnel.goTo("done", { replace: true });
-      },
-    });
-  };
-
-  if (!social) return null;
-
-  const backTarget = BACK_TARGET[funnel.step];
-  const goBack = backTarget ? () => funnel.goTo(backTarget) : undefined;
+  if (!derived.ready) return null;
 
   return (
     <div className="flex min-h-dvh w-full flex-col">
@@ -138,18 +34,18 @@ export function SignupFunnel() {
       />
 
       <div className="mx-auto flex w-full flex-1 flex-col pb-8 pt-6 sm:pt-10 md:max-w-[35rem] md:px-5 md:pb-16 md:pt-12">
-      {funnel.step !== "done" && (
+      {derived.showProgress && (
         <div className="md:hidden">
-          <SignupProgress current={funnel.stepNumber} total={funnel.total} onBack={goBack} />
+          <SignupProgress current={derived.stepNumber} total={derived.total} onBack={actions.goBack} />
         </div>
       )}
 
       <div className="mt-6 flex flex-1 flex-col justify-center md:mt-0">
         <div className="rounded-card-lg border border-line bg-card p-6 sm:p-8 md:p-9 md:shadow-modal">
-        {goBack && (
+        {derived.canGoBack && (
           <button
             type="button"
-            onClick={goBack}
+            onClick={actions.goBack}
             aria-label="이전 단계로"
             className="-ml-2 mb-4 hidden size-9 items-center justify-center rounded-chip text-ink transition hover:bg-paper md:flex"
           >
@@ -157,48 +53,48 @@ export function SignupFunnel() {
           </button>
         )}
 
-        {funnel.step === "role" && (
+        {derived.step === "role" && (
           <RoleSelectStep
-            selected={selectedUserType}
-            onSelect={setSelectedUserType}
-            onStart={handleStart}
+            selected={state.selectedUserType}
+            onSelect={actions.selectUserType}
+            onStart={actions.start}
           />
         )}
 
-        {funnel.step === "terms" && (
+        {derived.step === "terms" && (
           <ConsentStep
-            consent={consent}
-            onToggle={handleToggle}
-            onToggleAll={handleToggleAll}
-            onNext={() => funnel.goTo("identity")}
+            consent={state.consent}
+            onToggle={actions.toggleConsent}
+            onToggleAll={actions.toggleAllConsent}
+            onNext={actions.goToIdentity}
           />
         )}
 
-        {funnel.step === "identity" && (
+        {derived.step === "identity" && (
           <IdentityStep
-            identity={identity}
-            onChange={setIdentity}
-            onSubmit={handleSubmit}
-            loading={register.isPending}
-            errorCode={getRegisterErrorCode(register.error)}
+            identity={state.identity}
+            onChange={actions.changeIdentity}
+            onSubmit={actions.submit}
+            loading={derived.registerPending}
+            errorCode={derived.registerErrorCode}
           />
         )}
 
-        {funnel.step === "done" && result && (
+        {derived.step === "done" && state.result && (
           <CompleteStep
-            nickname={result.nickname}
-            email={social.email}
-            onStartAnalysis={() => router.push(CUSTOMER_DASHBOARD_PATH)}
+            nickname={state.result.nickname}
+            email={derived.email}
+            onStartAnalysis={actions.startAnalysis}
           />
         )}
         </div>
       </div>
       </div>
 
-      {showAdjusterNotice && (
+      {state.showAdjusterNotice && (
         <AdjusterNotice
-          onClose={() => setShowAdjusterNotice(false)}
-          onProceed={() => router.push(ADJUSTER_CERTIFY_PATH)}
+          onClose={actions.closeAdjusterNotice}
+          onProceed={actions.proceedAdjusterNotice}
         />
       )}
     </div>

--- a/apps/web/src/app/(auth)/signup/_hooks/use-signup-form.ts
+++ b/apps/web/src/app/(auth)/signup/_hooks/use-signup-form.ts
@@ -1,0 +1,148 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { TermsType } from "@/shared/model/terms-content";
+import type { UserType } from "@/shared/model/user";
+import { clearSignupTicket } from "../../_shared/lib/signup-ticket";
+import { getRegisterErrorCode, useRegister } from "../_api/use-register";
+import { isRequiredConsentMet, type ConsentState } from "../_model/consent-config";
+import { toRegisterBody, type RegisterResponse } from "../_model/register.schema";
+import {
+  clearSignupDraft,
+  loadSignupDraft,
+  saveSignupDraft,
+  type IdentityDraft,
+} from "../_model/signup-draft";
+import { useSignupFunnel, type SignupStep } from "./use-signup-funnel";
+import { useSignupSocial } from "./use-signup-social";
+
+const CUSTOMER_DASHBOARD_PATH = "/customer/dashboard";
+const ADJUSTER_CERTIFY_PATH = "/signup/verification";
+
+/** 뒤로가기 대상 단계. 첫 단계·완료는 없음. */
+const BACK_TARGET: Partial<Record<SignupStep, SignupStep>> = {
+  terms: "role",
+  identity: "terms",
+};
+
+export function useSignupForm() {
+  const router = useRouter();
+  const funnel = useSignupFunnel();
+  const social = useSignupSocial();
+  const register = useRegister();
+
+  const [draft] = useState(loadSignupDraft);
+  const [selectedUserType, setSelectedUserType] = useState<UserType | null>(draft.userType);
+  const [consent, setConsent] = useState<ConsentState>(draft.consent);
+  const [identity, setIdentity] = useState<IdentityDraft>(draft.identity);
+  const [showAdjusterNotice, setShowAdjusterNotice] = useState(false);
+  const [result, setResult] = useState<RegisterResponse | null>(null);
+
+  // 약관 상세 페이지 왕복 시 선택 역할·동의·본인 확인 입력 유지(전체 페이지 이동 대비).
+  useEffect(() => {
+    saveSignupDraft({ userType: selectedUserType, consent, identity });
+  }, [selectedUserType, consent, identity]);
+
+  // 소셜 인증 컨텍스트(티켓·쿼리) 없이 직접 진입하면 로그인으로 되돌림.
+  useEffect(() => {
+    if (!social) router.replace("/login");
+  }, [social, router]);
+
+  // 직접 URL 진입 가드: 선행 단계 미완이면 첫 단계로 되돌림.
+  useEffect(() => {
+    if (funnel.step === "terms" && selectedUserType !== "insured_person") {
+      funnel.goTo("role", { replace: true });
+    }
+    if (
+      funnel.step === "identity" &&
+      (selectedUserType !== "insured_person" || !isRequiredConsentMet(consent))
+    ) {
+      funnel.goTo("role", { replace: true });
+    }
+    if (funnel.step === "done" && !result) {
+      funnel.goTo("role", { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [funnel.step]);
+
+  const start = useCallback(() => {
+    if (selectedUserType === "insured_person") {
+      funnel.goTo("terms");
+      return;
+    }
+    if (selectedUserType === "adjuster") setShowAdjusterNotice(true);
+  }, [selectedUserType, funnel]);
+
+  const toggleConsent = useCallback((type: TermsType, checked: boolean) => {
+    setConsent((prev) => ({ ...prev, [type]: checked }));
+  }, []);
+
+  const toggleAllConsent = useCallback((checked: boolean) => {
+    setConsent({ service: checked, privacy: checked, marketing: checked });
+  }, []);
+
+  const { mutate: submitRegister } = register;
+  const submit = useCallback(() => {
+    if (selectedUserType !== "insured_person" || !social || !identity.gender) return;
+
+    const body = toRegisterBody({
+      provider: social.provider,
+      socialToken: social.socialToken,
+      userType: selectedUserType,
+      nickname: social.nickname,
+      gender: identity.gender,
+      birthDate: identity.birthDate,
+      phoneNumber: identity.phoneNumber,
+    });
+
+    submitRegister(body, {
+      onSuccess: (data) => {
+        clearSignupDraft();
+        clearSignupTicket();
+        setResult(data);
+        funnel.goTo("done", { replace: true });
+      },
+    });
+  }, [selectedUserType, social, identity, submitRegister, funnel]);
+
+  const backTarget = BACK_TARGET[funnel.step];
+
+  const derived = useMemo(
+    () => ({
+      ready: social !== null,
+      step: funnel.step,
+      stepNumber: funnel.stepNumber,
+      total: funnel.total,
+      showProgress: funnel.step !== "done",
+      canGoBack: backTarget !== undefined,
+      registerPending: register.isPending,
+      registerErrorCode: getRegisterErrorCode(register.error),
+      email: social?.email,
+    }),
+    [social, funnel.step, funnel.stepNumber, funnel.total, backTarget, register.isPending, register.error],
+  );
+
+  const actions = useMemo(
+    () => ({
+      selectUserType: setSelectedUserType,
+      start,
+      toggleConsent,
+      toggleAllConsent,
+      goToIdentity: () => funnel.goTo("identity"),
+      changeIdentity: setIdentity,
+      submit,
+      goBack: backTarget ? () => funnel.goTo(backTarget) : undefined,
+      closeAdjusterNotice: () => setShowAdjusterNotice(false),
+      proceedAdjusterNotice: () => router.push(ADJUSTER_CERTIFY_PATH),
+      startAnalysis: () => router.push(CUSTOMER_DASHBOARD_PATH),
+    }),
+    [start, toggleConsent, toggleAllConsent, submit, backTarget, funnel, router],
+  );
+
+  return {
+    state: { selectedUserType, consent, identity, showAdjusterNotice, result },
+    derived,
+    actions,
+  };
+}

--- a/apps/web/src/app/customer/adjust-request/_components/Step6Documents.tsx
+++ b/apps/web/src/app/customer/adjust-request/_components/Step6Documents.tsx
@@ -1,157 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useFormContext } from "react-hook-form";
-import { uploadErrorMessage } from "@/shared/api/upload-file";
-import { accidentTypeLabel } from "@/shared/model/accident-type";
-import { validateUploadFile } from "@/shared/model/upload.schema";
 import { AlertTriangle } from "@/shared/ui/icons/AlertTriangle";
 import { ShieldCheck } from "@/shared/ui/icons/ShieldCheck";
-import { useUploadDocument } from "../_api/use-upload-document";
-import {
-  DOCUMENT_SLOTS,
-  type DocumentSlotKey,
-  type DocumentSlots,
-  REQUIRED_DOCUMENT_SLOTS,
-} from "../_model/document-slots";
-import type { AdjustRequestDraft } from "../_model/types";
-import { DocumentSlot, type SlotStatus } from "./DocumentSlot";
-import { UploadFileItem, type UploadStatus } from "./UploadFileItem";
-
-const ACCEPT = ".pdf,.jpg,.jpeg,.png";
-
-interface SlotEntry {
-  status: SlotStatus;
-  url?: string;
-  fileName?: string;
-  error?: string;
-  file?: File;
-}
-type SlotMap = Partial<Record<DocumentSlotKey, SlotEntry>>;
-
-/** 기타 서류 항목 — 슬롯에 없는 documentUrls 복원용(신규 추가 경로 없음). */
-interface ExtraItem {
-  id: string;
-  status: UploadStatus;
-  name: string;
-  size: number;
-  url?: string;
-  error?: string;
-  previewUrl?: string;
-  file?: File;
-}
-
-function fileNameFromUrl(url: string): string {
-  try {
-    const base = new URL(url).pathname.split("/").filter(Boolean).pop();
-    return base ? decodeURIComponent(base) : "첨부 파일";
-  } catch {
-    return "첨부 파일";
-  }
-}
+import { useDocumentUpload } from "../_hooks/use-document-upload";
+import { DocumentSlot } from "./DocumentSlot";
+import { UploadFileItem } from "./UploadFileItem";
 
 export function Step6Documents() {
-  const { getValues, setValue, watch } = useFormContext<AdjustRequestDraft>();
-  const upload = useUploadDocument();
-
-  const [slots, setSlots] = useState<SlotMap>({});
-  const [extras, setExtras] = useState<ExtraItem[]>([]);
-  const [hydrated, setHydrated] = useState(false);
-
-  // 복원: documentSlots → 슬롯, 슬롯에 없는 documentUrls → 기타 서류.
-  // (File은 복원 불가 → url·파일명만. SSR 불일치 방지로 마운트 후 1회.)
-  useEffect(() => {
-    if (hydrated) return;
-    const draftSlots = getValues("documentSlots");
-    const draftUrls = getValues("documentUrls") ?? [];
-
-    const nextSlots: SlotMap = {};
-    const slotUrls = new Set<string>();
-    for (const def of DOCUMENT_SLOTS) {
-      const v = draftSlots?.[def.key];
-      if (v?.url) {
-        nextSlots[def.key] = { status: "done", url: v.url, fileName: v.fileName };
-        slotUrls.add(v.url);
-      }
-    }
-    const restoredExtras: ExtraItem[] = draftUrls
-      .filter((u) => !slotUrls.has(u))
-      .map((u) => ({ id: crypto.randomUUID(), status: "done", name: fileNameFromUrl(u), size: 0, url: u }));
-
-    setSlots(nextSlots);
-    setExtras(restoredExtras);
-    setHydrated(true);
-  }, [getValues, hydrated]);
-
-  // canonical documentSlots + 파생 documentUrls(슬롯 순서 + 기타) 폼 반영.
-  useEffect(() => {
-    if (!hydrated) return;
-    const canonical: DocumentSlots = {};
-    const urls: string[] = [];
-    for (const def of DOCUMENT_SLOTS) {
-      const s = slots[def.key];
-      if (s?.status === "done" && s.url) {
-        canonical[def.key] = { url: s.url, fileName: s.fileName ?? "" };
-        urls.push(s.url);
-      }
-    }
-    for (const e of extras) {
-      if (e.status === "done" && e.url) urls.push(e.url);
-    }
-    setValue("documentSlots", Object.keys(canonical).length ? canonical : undefined);
-    setValue("documentUrls", urls.length ? urls : null);
-  }, [slots, extras, hydrated, setValue]);
-
-  const startSlotUpload = (key: DocumentSlotKey, file: File) => {
-    setSlots((prev) => ({ ...prev, [key]: { status: "uploading", fileName: file.name, file } }));
-    upload.mutate(file, {
-      onSuccess: (data) =>
-        setSlots((prev) => ({ ...prev, [key]: { status: "done", url: data.url, fileName: file.name } })),
-      onError: (e) =>
-        setSlots((prev) => ({ ...prev, [key]: { status: "error", error: uploadErrorMessage(e), fileName: file.name, file } })),
-    });
-  };
-
-  const pickSlotFile = (key: DocumentSlotKey, file: File) => {
-    const invalid = validateUploadFile(file, "report_document");
-    if (invalid) {
-      setSlots((prev) => ({ ...prev, [key]: { status: "error", error: invalid, fileName: file.name } }));
-      return;
-    }
-    startSlotUpload(key, file);
-  };
-
-  const removeSlot = (key: DocumentSlotKey) =>
-    setSlots((prev) => {
-      const next = { ...prev };
-      delete next[key];
-      return next;
-    });
-
-  const startExtraUpload = (item: ExtraItem) => {
-    if (!item.file) return;
-    const file = item.file;
-    setExtras((prev) => prev.map((i) => (i.id === item.id ? { ...i, status: "uploading", error: undefined } : i)));
-    upload.mutate(file, {
-      onSuccess: (data) =>
-        setExtras((prev) => prev.map((i) => (i.id === item.id ? { ...i, status: "done", url: data.url } : i))),
-      onError: (e) =>
-        setExtras((prev) => prev.map((i) => (i.id === item.id ? { ...i, status: "error", error: uploadErrorMessage(e) } : i))),
-    });
-  };
-
-  const removeExtra = (id: string) =>
-    setExtras((prev) => {
-      const target = prev.find((i) => i.id === id);
-      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
-      return prev.filter((i) => i.id !== id);
-    });
-
-  // accidentType은 localStorage draft에서 옴 → SSR/첫 렌더엔 없음.
-  // 하이드레이션 불일치 방지로 마운트 후(hydrated)에만 라벨 노출.
-  const accidentType = watch("accidentType");
-  const caseLabel = hydrated && accidentType ? accidentTypeLabel(accidentType) : "";
-  const missingRequired = REQUIRED_DOCUMENT_SLOTS.filter((d) => slots[d.key]?.status !== "done");
+  const { state, derived, actions } = useDocumentUpload();
 
   return (
     <section className="flex flex-col gap-5">
@@ -160,41 +16,37 @@ export function Step6Documents() {
           관련 서류를 올려주세요
         </h2>
         <p className="mt-1.5 text-[0.84375rem] text-ink-3">
-          {caseLabel ? `${caseLabel} ` : ""}케이스에 필요한 서류예요. 각 칸에 맞는 파일을 올려주세요 (PDF 또는 이미지,
-          최대 20MB).
+          {derived.caseLabel ? `${derived.caseLabel} ` : ""}케이스에 필요한 서류예요. 각 칸에 맞는 파일을 올려주세요
+          (PDF 또는 이미지, 최대 20MB).
         </p>
       </div>
 
       <div className="flex flex-col gap-2.5">
-        {DOCUMENT_SLOTS.map((def) => {
-          const s = slots[def.key];
-          const status = s?.status ?? "idle";
-          return (
-            <DocumentSlot
-              key={def.key}
-              def={def}
-              status={status}
-              fileName={s?.fileName}
-              errorMessage={s?.error}
-              accept={ACCEPT}
-              onPickFile={(file) => pickSlotFile(def.key, file)}
-              onRetry={s?.file ? () => startSlotUpload(def.key, s.file as File) : undefined}
-              onRemove={status === "done" ? () => removeSlot(def.key) : undefined}
-            />
-          );
-        })}
+        {derived.slotViews.map((slot) => (
+          <DocumentSlot
+            key={slot.def.key}
+            def={slot.def}
+            status={slot.status}
+            fileName={slot.fileName}
+            errorMessage={slot.error}
+            accept={derived.accept}
+            onPickFile={(file) => actions.pickSlotFile(slot.def.key, file)}
+            onRetry={slot.canRetry ? () => actions.retrySlot(slot.def.key) : undefined}
+            onRemove={slot.status === "done" ? () => actions.removeSlot(slot.def.key) : undefined}
+          />
+        ))}
       </div>
 
-      {missingRequired.length > 0 && (
+      {derived.missingRequired.length > 0 && (
         <p className="flex items-center gap-1.5 text-[0.75rem] text-ink-3">
           <AlertTriangle className="shrink-0 text-[0.875rem] text-gold-ink" />
-          정확한 분석을 위해 {missingRequired.map((d) => d.label).join("·")} 첨부를 권장해요.
+          정확한 분석을 위해 {derived.missingRequired.map((d) => d.label).join("·")} 첨부를 권장해요.
         </p>
       )}
 
-      {extras.length > 0 && (
+      {state.extras.length > 0 && (
         <div className="flex flex-col gap-2">
-          {extras.map((item) => (
+          {state.extras.map((item) => (
             <UploadFileItem
               key={item.id}
               name={item.name}
@@ -202,8 +54,8 @@ export function Step6Documents() {
               status={item.status}
               previewUrl={item.previewUrl}
               errorMessage={item.error}
-              onRetry={() => startExtraUpload(item)}
-              onRemove={() => removeExtra(item.id)}
+              onRetry={() => actions.retryExtra(item)}
+              onRemove={() => actions.removeExtra(item.id)}
             />
           ))}
         </div>

--- a/apps/web/src/app/customer/adjust-request/_components/Step6Documents.tsx
+++ b/apps/web/src/app/customer/adjust-request/_components/Step6Documents.tsx
@@ -38,7 +38,7 @@ export function Step6Documents() {
       </div>
 
       {derived.missingRequired.length > 0 && (
-        <p className="flex items-center gap-1.5 text-[0.75rem] text-ink-3">
+        <p role="status" className="flex items-center gap-1.5 text-[0.75rem] text-ink-3">
           <AlertTriangle className="shrink-0 text-[0.875rem] text-gold-ink" />
           정확한 분석을 위해 {derived.missingRequired.map((d) => d.label).join("·")} 첨부를 권장해요.
         </p>

--- a/apps/web/src/app/customer/adjust-request/_hooks/use-document-upload.ts
+++ b/apps/web/src/app/customer/adjust-request/_hooks/use-document-upload.ts
@@ -82,9 +82,10 @@ export function useDocumentUpload() {
         slotUrls.add(v.url);
       }
     }
-    const restoredExtras: ExtraItem[] = draftUrls
+    // url이 곧 고유 식별자 — crypto.randomUUID는 비보안 컨텍스트(http LAN 접속 등)에서 없을 수 있다.
+    const restoredExtras: ExtraItem[] = [...new Set(draftUrls)]
       .filter((u) => !slotUrls.has(u))
-      .map((u) => ({ id: crypto.randomUUID(), status: "done", name: fileNameFromUrl(u), size: 0, url: u }));
+      .map((u) => ({ id: u, status: "done", name: fileNameFromUrl(u), size: 0, url: u }));
 
     setSlots(nextSlots);
     setExtras(restoredExtras);

--- a/apps/web/src/app/customer/adjust-request/_hooks/use-document-upload.ts
+++ b/apps/web/src/app/customer/adjust-request/_hooks/use-document-upload.ts
@@ -1,0 +1,215 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { uploadErrorMessage } from "@/shared/api/upload-file";
+import { accidentTypeLabel } from "@/shared/model/accident-type";
+import { validateUploadFile } from "@/shared/model/upload.schema";
+import { useUploadDocument } from "../_api/use-upload-document";
+import type { SlotStatus } from "../_components/DocumentSlot";
+import type { UploadStatus } from "../_components/UploadFileItem";
+import {
+  DOCUMENT_SLOTS,
+  type DocumentSlotDef,
+  type DocumentSlotKey,
+  type DocumentSlots,
+  REQUIRED_DOCUMENT_SLOTS,
+} from "../_model/document-slots";
+import type { AdjustRequestDraft } from "../_model/types";
+
+const ACCEPT = ".pdf,.jpg,.jpeg,.png";
+
+interface SlotEntry {
+  status: SlotStatus;
+  url?: string;
+  fileName?: string;
+  error?: string;
+  file?: File;
+}
+type SlotMap = Partial<Record<DocumentSlotKey, SlotEntry>>;
+
+/** 기타 서류 항목 — 슬롯에 없는 documentUrls 복원용(신규 추가 경로 없음). */
+export interface ExtraItem {
+  id: string;
+  status: UploadStatus;
+  name: string;
+  size: number;
+  url?: string;
+  error?: string;
+  previewUrl?: string;
+  file?: File;
+}
+
+/** 슬롯 카드 1장에 필요한 표시값 묶음. 뷰는 이 값을 그대로 내려보내기만 한다. */
+export interface SlotView {
+  def: DocumentSlotDef;
+  status: SlotStatus;
+  fileName?: string;
+  error?: string;
+  canRetry: boolean;
+}
+
+function fileNameFromUrl(url: string): string {
+  try {
+    const base = new URL(url).pathname.split("/").filter(Boolean).pop();
+    return base ? decodeURIComponent(base) : "첨부 파일";
+  } catch {
+    return "첨부 파일";
+  }
+}
+
+export function useDocumentUpload() {
+  const { getValues, setValue, watch } = useFormContext<AdjustRequestDraft>();
+  const { mutate: uploadFile } = useUploadDocument();
+
+  const [slots, setSlots] = useState<SlotMap>({});
+  const [extras, setExtras] = useState<ExtraItem[]>([]);
+  const [hydrated, setHydrated] = useState(false);
+
+  // 복원: documentSlots → 슬롯, 슬롯에 없는 documentUrls → 기타 서류.
+  // (File은 복원 불가 → url·파일명만. SSR 불일치 방지로 마운트 후 1회.)
+  useEffect(() => {
+    if (hydrated) return;
+    const draftSlots = getValues("documentSlots");
+    const draftUrls = getValues("documentUrls") ?? [];
+
+    const nextSlots: SlotMap = {};
+    const slotUrls = new Set<string>();
+    for (const def of DOCUMENT_SLOTS) {
+      const v = draftSlots?.[def.key];
+      if (v?.url) {
+        nextSlots[def.key] = { status: "done", url: v.url, fileName: v.fileName };
+        slotUrls.add(v.url);
+      }
+    }
+    const restoredExtras: ExtraItem[] = draftUrls
+      .filter((u) => !slotUrls.has(u))
+      .map((u) => ({ id: crypto.randomUUID(), status: "done", name: fileNameFromUrl(u), size: 0, url: u }));
+
+    setSlots(nextSlots);
+    setExtras(restoredExtras);
+    setHydrated(true);
+  }, [getValues, hydrated]);
+
+  // canonical documentSlots + 파생 documentUrls(슬롯 순서 + 기타) 폼 반영.
+  useEffect(() => {
+    if (!hydrated) return;
+    const canonical: DocumentSlots = {};
+    const urls: string[] = [];
+    for (const def of DOCUMENT_SLOTS) {
+      const s = slots[def.key];
+      if (s?.status === "done" && s.url) {
+        canonical[def.key] = { url: s.url, fileName: s.fileName ?? "" };
+        urls.push(s.url);
+      }
+    }
+    for (const e of extras) {
+      if (e.status === "done" && e.url) urls.push(e.url);
+    }
+    setValue("documentSlots", Object.keys(canonical).length ? canonical : undefined);
+    setValue("documentUrls", urls.length ? urls : null);
+  }, [slots, extras, hydrated, setValue]);
+
+  const startSlotUpload = useCallback(
+    (key: DocumentSlotKey, file: File) => {
+      setSlots((prev) => ({ ...prev, [key]: { status: "uploading", fileName: file.name, file } }));
+      uploadFile(file, {
+        onSuccess: (data) =>
+          setSlots((prev) => ({ ...prev, [key]: { status: "done", url: data.url, fileName: file.name } })),
+        onError: (e) =>
+          setSlots((prev) => ({
+            ...prev,
+            [key]: { status: "error", error: uploadErrorMessage(e), fileName: file.name, file },
+          })),
+      });
+    },
+    [uploadFile],
+  );
+
+  const pickSlotFile = useCallback(
+    (key: DocumentSlotKey, file: File) => {
+      const invalid = validateUploadFile(file, "report_document");
+      if (invalid) {
+        setSlots((prev) => ({ ...prev, [key]: { status: "error", error: invalid, fileName: file.name } }));
+        return;
+      }
+      startSlotUpload(key, file);
+    },
+    [startSlotUpload],
+  );
+
+  const retrySlot = useCallback(
+    (key: DocumentSlotKey) => {
+      const file = slots[key]?.file;
+      if (file) startSlotUpload(key, file);
+    },
+    [slots, startSlotUpload],
+  );
+
+  const removeSlot = useCallback(
+    (key: DocumentSlotKey) =>
+      setSlots((prev) => {
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      }),
+    [],
+  );
+
+  const retryExtra = useCallback(
+    (item: ExtraItem) => {
+      if (!item.file) return;
+      const file = item.file;
+      setExtras((prev) => prev.map((i) => (i.id === item.id ? { ...i, status: "uploading", error: undefined } : i)));
+      uploadFile(file, {
+        onSuccess: (data) =>
+          setExtras((prev) => prev.map((i) => (i.id === item.id ? { ...i, status: "done", url: data.url } : i))),
+        onError: (e) =>
+          setExtras((prev) =>
+            prev.map((i) => (i.id === item.id ? { ...i, status: "error", error: uploadErrorMessage(e) } : i)),
+          ),
+      });
+    },
+    [uploadFile],
+  );
+
+  const removeExtra = useCallback(
+    (id: string) =>
+      setExtras((prev) => {
+        const target = prev.find((i) => i.id === id);
+        if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
+        return prev.filter((i) => i.id !== id);
+      }),
+    [],
+  );
+
+  // accidentType은 localStorage draft에서 옴 → SSR/첫 렌더엔 없음.
+  // 하이드레이션 불일치 방지로 마운트 후(hydrated)에만 라벨 노출.
+  const accidentType = watch("accidentType");
+
+  const derived = useMemo(() => {
+    const slotViews: SlotView[] = DOCUMENT_SLOTS.map((def) => {
+      const s = slots[def.key];
+      return {
+        def,
+        status: s?.status ?? "idle",
+        fileName: s?.fileName,
+        error: s?.error,
+        canRetry: s?.file !== undefined,
+      };
+    });
+    return {
+      accept: ACCEPT,
+      caseLabel: hydrated && accidentType ? accidentTypeLabel(accidentType) : "",
+      missingRequired: REQUIRED_DOCUMENT_SLOTS.filter((d) => slots[d.key]?.status !== "done"),
+      slotViews,
+    };
+  }, [slots, hydrated, accidentType]);
+
+  const actions = useMemo(
+    () => ({ pickSlotFile, retrySlot, removeSlot, retryExtra, removeExtra }),
+    [pickSlotFile, retrySlot, removeSlot, retryExtra, removeExtra],
+  );
+
+  return { state: { extras }, derived, actions };
+}

--- a/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/_components/CustomerChatThreadContent.tsx
@@ -1,17 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
-import { useChatList } from "@/shared/api/chat/use-chat-list";
-import { useChatMessages } from "@/shared/api/chat/use-chat-messages";
-import { useChatRoom } from "@/shared/api/chat/use-chat-room";
-import { toMatchGroup } from "@/shared/api/chat/match-status";
 import { accidentTypeLabel } from "@/shared/model/accident-type";
-import { useAcceptChat } from "@/shared/api/chat/use-accept-chat";
-import { useReadChat } from "@/shared/api/chat/use-read-chat";
-import { useRejectChat } from "@/shared/api/chat/use-reject-chat";
-import { useSendChatAttachment } from "@/shared/api/chat/use-send-chat-attachment";
-import { useSendChatMessage } from "@/shared/api/chat/use-send-chat-message";
 import { AlertTriangle } from "@/shared/ui/icons/AlertTriangle";
 import { ArrowRight } from "@/shared/ui/icons/ArrowRight";
 import { CheckCircle } from "@/shared/ui/icons/CheckCircle";
@@ -29,8 +18,7 @@ import { MatchStatusBadge } from "@/shared/ui/chat/MatchStatusBadge";
 import { MessageInputBar } from "@/shared/ui/chat/MessageInputBar";
 import { ReportChatDialog } from "@/shared/ui/chat/ReportChatDialog";
 import { useReportChatDialog } from "@/shared/ui/chat/use-report-chat-dialog";
-import { ROOM_STATUS_META } from "@/shared/ui/chat/room-status";
-import { toast } from "@/shared/ui/toast";
+import { useCustomerChatThread } from "../_hooks/use-customer-chat-thread";
 
 export interface CustomerChatThreadContentProps {
   chatRoomId: string;
@@ -46,71 +34,19 @@ export function CustomerChatThreadContent({
   chatRoomId,
   chatBasePath
 }: CustomerChatThreadContentProps) {
-  const router = useRouter();
-  const { data: room } = useChatRoom(chatRoomId);
-  // 형제 방 비교(comparingCount·종료 예고)만 목록 유지 — 방 자체는 단건 조회
-  const { data: rooms } = useChatList();
-  const { messages, hasOlder, loadOlder, loadingOlder } = useChatMessages(chatRoomId);
-  const sendMessage = useSendChatMessage(chatRoomId);
-  const sendAttachment = useSendChatAttachment(chatRoomId);
-  const accept = useAcceptChat(chatRoomId);
-  const reject = useRejectChat(chatRoomId);
-  const { mutate: markRead } = useReadChat(chatRoomId);
+  const { state, derived, actions } = useCustomerChatThread({ chatRoomId, chatBasePath });
+  const { room } = state;
   const reportDialog = useReportChatDialog(chatRoomId);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [rejectOpen, setRejectOpen] = useState(false);
-
-  useEffect(() => {
-    markRead();
-  }, [markRead, chatRoomId]);
-
-  const group = toMatchGroup(room.matchStatus, room.roomStatus);
-  // 원본 리포트가 아니라 사정사 검수 결과(공유 리포트)로 이동. 사정사 검색 방은 공유 리포트가 없어 비활성.
-  const sharedReportHref = room.reportId ? `${chatBasePath}/${chatRoomId}/shared-report` : "#";
-  const matchPending = accept.isPending || reject.isPending;
-
-  // 목록 응답에 현재 방이 아직 없어도(딥링크 직진입) 비교 수에 자신은 포함
-  const listSiblings = room.reportId ? rooms.filter((item) => item.reportId === room.reportId) : [];
-  const siblings = listSiblings.some((item) => item.chatRoomId === room.chatRoomId)
-    ? listSiblings
-    : [room, ...listSiblings];
-  const comparingCount = siblings.filter(
-    (item) => toMatchGroup(item.matchStatus, item.roomStatus) === "comparing"
-  ).length;
-  const endingConsultations = siblings
-    .filter(
-      (item) =>
-        item.chatRoomId !== room.chatRoomId &&
-        toMatchGroup(item.matchStatus, item.roomStatus) === "comparing"
-    )
-    .map((item) => ({ name: item.counterpart.name }));
-
-  const subtitle = [room.caseNo, SUBTITLE_SUFFIX[group] ?? ROOM_STATUS_META[room.roomStatus].label]
-    .filter(Boolean)
-    .join(" · ");
-
-  // 거절도 비가역이라 완료와 대칭으로 확인 모달을 거친다
-  const rejectMatch = () => setRejectOpen(true);
-  const confirmReject = () =>
-    reject.mutate(undefined, {
-      onSuccess: () => setRejectOpen(false),
-      onError: () => toast.error("매칭 거절에 실패했어요. 잠시 후 다시 시도해 주세요.")
-    });
-  const confirmMatch = () =>
-    accept.mutate(undefined, {
-      onSuccess: () => setConfirmOpen(false),
-      onError: () => toast.error("매칭 완료에 실패했어요. 잠시 후 다시 시도해 주세요.")
-    });
 
   const matchActions: ChatThreadHeaderMenuAction[] =
-    group === "comparing"
+    derived.group === "comparing"
       ? [
           {
             key: "accept",
             label: "매칭 완료",
             icon: <CheckCircle />,
-            onClick: () => setConfirmOpen(true),
-            disabled: matchPending,
+            onClick: actions.openConfirm,
+            disabled: derived.matchPending,
             // 데스크톱은 비교 배너에 전용 버튼이 있어 더보기에선 모바일에만 노출
             mobileOnly: true
           },
@@ -118,26 +54,26 @@ export function CustomerChatThreadContent({
             key: "reject",
             label: "매칭 거절",
             icon: <X />,
-            onClick: rejectMatch,
+            onClick: actions.openReject,
             tone: "danger",
-            disabled: matchPending,
+            disabled: derived.matchPending,
             // 데스크톱에선 접근 경로 없음(모바일 더보기 전용) — 팀 결정
             mobileOnly: true
           }
         ]
-      : group === "matched"
+      : derived.group === "matched"
         ? [
             {
               key: "progress",
               label: "사건 진행 보기",
               icon: <ArrowRight />,
-              href: sharedReportHref
+              href: derived.sharedReportHref
             }
           ]
         : [];
 
   const menuActions: ChatThreadHeaderMenuAction[] = [
-    { key: "report", label: "리포트 보기", icon: <FileText />, href: sharedReportHref },
+    { key: "report", label: "리포트 보기", icon: <FileText />, href: derived.sharedReportHref },
     ...matchActions,
     { key: "report-chat", label: "신고", icon: <AlertTriangle />, onClick: reportDialog.openDialog }
   ];
@@ -150,69 +86,65 @@ export function CustomerChatThreadContent({
         roomStatus={room.roomStatus}
         // customer 방의 상대는 항상 사정사 — counterpart.userId가 곧 adjusterId
         profileHref={`/customer/adjusters/${room.counterpart.userId}`}
-        subtitle={subtitle}
-        badge={group === "matched" ? <MatchStatusBadge group={group} /> : undefined}
+        subtitle={derived.subtitle}
+        badge={derived.group === "matched" ? <MatchStatusBadge group={derived.group} /> : undefined}
         menuActions={menuActions}
-        onBack={() => router.push(chatBasePath)}
+        onBack={actions.goBack}
       />
 
       {/* Figma 1012:9931 — 모바일 스레드엔 배너 없음(목록 배너·헤더 버튼이 대체). 데스크톱만 노출 */}
-      {group === "comparing" && room.reportTypeLabel != null && (
+      {derived.group === "comparing" && room.reportTypeLabel != null && (
         <div className="hidden md:block">
           <ChatComparisonBanner
             variant="comparing"
             reportTypeLabel={accidentTypeLabel(room.reportTypeLabel)}
-            comparingCount={comparingCount}
-            onMatchComplete={() => setConfirmOpen(true)}
-            matchCompletePending={matchPending}
+            comparingCount={derived.comparingCount}
+            onMatchComplete={actions.openConfirm}
+            matchCompletePending={derived.matchPending}
           />
         </div>
       )}
-      {group === "matched" && room.reportTypeLabel != null && (
+      {derived.group === "matched" && room.reportTypeLabel != null && (
         <div className="hidden md:block">
           <ChatComparisonBanner
             variant="matched"
             reportTypeLabel={accidentTypeLabel(room.reportTypeLabel)}
-            progressHref={sharedReportHref}
+            progressHref={derived.sharedReportHref}
           />
         </div>
       )}
 
       <ChatThreadView
-        messages={messages}
-        hasOlder={hasOlder}
-        onLoadOlder={loadOlder}
-        loadingOlder={loadingOlder}
+        messages={state.messages}
+        hasOlder={state.hasOlder}
+        onLoadOlder={actions.loadOlder}
+        loadingOlder={state.loadingOlder}
       />
 
       <MessageInputBar
-        onSend={(content) => sendMessage.mutate({ content })}
-        disabled={sendMessage.isPending}
-        closed={room.roomStatus === "CLOSED"}
-        sendFailed={sendMessage.isError}
-        onPickFile={(file) =>
-          sendAttachment.mutate(file, {
-            onError: () => toast.error("파일 전송에 실패했어요. 잠시 후 다시 시도해 주세요.")
-          })
-        }
-        attachPending={sendAttachment.isPending}
+        onSend={actions.send}
+        disabled={derived.sendPending}
+        closed={derived.closed}
+        sendFailed={derived.sendFailed}
+        onPickFile={actions.sendFile}
+        attachPending={derived.attachPending}
       />
 
       <MatchConfirmModal
-        open={confirmOpen}
+        open={state.confirmOpen}
         adjusterName={room.counterpart.name}
-        endingConsultations={endingConsultations}
-        pending={matchPending}
-        onConfirm={confirmMatch}
-        onCancel={() => setConfirmOpen(false)}
+        endingConsultations={derived.endingConsultations}
+        pending={derived.matchPending}
+        onConfirm={actions.confirmMatch}
+        onCancel={actions.closeConfirm}
       />
 
       <MatchRejectConfirmModal
-        open={rejectOpen}
+        open={state.rejectOpen}
         adjusterName={room.counterpart.name}
-        pending={matchPending}
-        onConfirm={confirmReject}
-        onCancel={() => setRejectOpen(false)}
+        pending={derived.matchPending}
+        onConfirm={actions.confirmReject}
+        onCancel={actions.closeReject}
       />
 
       <ReportChatDialog
@@ -226,8 +158,3 @@ export function CustomerChatThreadContent({
     </div>
   );
 }
-
-const SUBTITLE_SUFFIX: Partial<Record<ReturnType<typeof toMatchGroup>, string>> = {
-  comparing: "상담 중 · 비교 중",
-  matched: "매칭 완료 · 진행 중"
-};

--- a/apps/web/src/app/customer/chat/[chatRoomId]/_hooks/use-customer-chat-thread.ts
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/_hooks/use-customer-chat-thread.ts
@@ -1,0 +1,138 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toMatchGroup } from "@/shared/api/chat/match-status";
+import { useAcceptChat } from "@/shared/api/chat/use-accept-chat";
+import { useChatList } from "@/shared/api/chat/use-chat-list";
+import { useChatMessages } from "@/shared/api/chat/use-chat-messages";
+import { useChatRoom } from "@/shared/api/chat/use-chat-room";
+import { useReadChat } from "@/shared/api/chat/use-read-chat";
+import { useRejectChat } from "@/shared/api/chat/use-reject-chat";
+import { useSendChatAttachment } from "@/shared/api/chat/use-send-chat-attachment";
+import { useSendChatMessage } from "@/shared/api/chat/use-send-chat-message";
+import { ROOM_STATUS_META } from "@/shared/ui/chat/room-status";
+import { toast } from "@/shared/ui/toast";
+
+const SUBTITLE_SUFFIX: Partial<Record<ReturnType<typeof toMatchGroup>, string>> = {
+  comparing: "상담 중 · 비교 중",
+  matched: "매칭 완료 · 진행 중",
+};
+
+interface UseCustomerChatThreadParams {
+  chatRoomId: string;
+  /** 방 목록·뒤로가기 베이스(예 "/customer/chat") */
+  chatBasePath: string;
+}
+
+export function useCustomerChatThread({ chatRoomId, chatBasePath }: UseCustomerChatThreadParams) {
+  const router = useRouter();
+  const { data: room } = useChatRoom(chatRoomId);
+  // 형제 방 비교(comparingCount·종료 예고)만 목록 유지 — 방 자체는 단건 조회
+  const { data: rooms } = useChatList();
+  const { messages, hasOlder, loadOlder, loadingOlder } = useChatMessages(chatRoomId);
+  const sendMessage = useSendChatMessage(chatRoomId);
+  const sendAttachment = useSendChatAttachment(chatRoomId);
+  const accept = useAcceptChat(chatRoomId);
+  const reject = useRejectChat(chatRoomId);
+  const { mutate: markRead } = useReadChat(chatRoomId);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [rejectOpen, setRejectOpen] = useState(false);
+
+  useEffect(() => {
+    markRead();
+  }, [markRead, chatRoomId]);
+
+  const derived = useMemo(() => {
+    const group = toMatchGroup(room.matchStatus, room.roomStatus);
+
+    // 목록 응답에 현재 방이 아직 없어도(딥링크 직진입) 비교 수에 자신은 포함
+    const listSiblings = room.reportId ? rooms.filter((item) => item.reportId === room.reportId) : [];
+    const siblings = listSiblings.some((item) => item.chatRoomId === room.chatRoomId)
+      ? listSiblings
+      : [room, ...listSiblings];
+
+    return {
+      group,
+      // 원본 리포트가 아니라 사정사 검수 결과(공유 리포트)로 이동. 사정사 검색 방은 공유 리포트가 없어 비활성.
+      sharedReportHref: room.reportId ? `${chatBasePath}/${chatRoomId}/shared-report` : "#",
+      subtitle: [room.caseNo, SUBTITLE_SUFFIX[group] ?? ROOM_STATUS_META[room.roomStatus].label]
+        .filter(Boolean)
+        .join(" · "),
+      comparingCount: siblings.filter(
+        (item) => toMatchGroup(item.matchStatus, item.roomStatus) === "comparing",
+      ).length,
+      endingConsultations: siblings
+        .filter(
+          (item) =>
+            item.chatRoomId !== room.chatRoomId &&
+            toMatchGroup(item.matchStatus, item.roomStatus) === "comparing",
+        )
+        .map((item) => ({ name: item.counterpart.name })),
+      matchPending: accept.isPending || reject.isPending,
+      sendPending: sendMessage.isPending,
+      sendFailed: sendMessage.isError,
+      attachPending: sendAttachment.isPending,
+      closed: room.roomStatus === "CLOSED",
+    };
+  }, [
+    room,
+    rooms,
+    chatRoomId,
+    chatBasePath,
+    accept.isPending,
+    reject.isPending,
+    sendMessage.isPending,
+    sendMessage.isError,
+    sendAttachment.isPending,
+  ]);
+
+  const { mutate: acceptMatch } = accept;
+  const { mutate: rejectMatch } = reject;
+  const { mutate: send } = sendMessage;
+  const { mutate: sendFile } = sendAttachment;
+
+  const confirmMatch = useCallback(
+    () =>
+      acceptMatch(undefined, {
+        onSuccess: () => setConfirmOpen(false),
+        onError: () => toast.error("매칭 완료에 실패했어요. 잠시 후 다시 시도해 주세요."),
+      }),
+    [acceptMatch],
+  );
+
+  // 거절도 비가역이라 완료와 대칭으로 확인 모달을 거친다
+  const confirmReject = useCallback(
+    () =>
+      rejectMatch(undefined, {
+        onSuccess: () => setRejectOpen(false),
+        onError: () => toast.error("매칭 거절에 실패했어요. 잠시 후 다시 시도해 주세요."),
+      }),
+    [rejectMatch],
+  );
+
+  const actions = useMemo(
+    () => ({
+      openConfirm: () => setConfirmOpen(true),
+      closeConfirm: () => setConfirmOpen(false),
+      openReject: () => setRejectOpen(true),
+      closeReject: () => setRejectOpen(false),
+      confirmMatch,
+      confirmReject,
+      send: (content: string) => send({ content }),
+      sendFile: (file: File) =>
+        sendFile(file, {
+          onError: () => toast.error("파일 전송에 실패했어요. 잠시 후 다시 시도해 주세요."),
+        }),
+      loadOlder,
+      goBack: () => router.push(chatBasePath),
+    }),
+    [confirmMatch, confirmReject, send, sendFile, loadOlder, router, chatBasePath],
+  );
+
+  return {
+    state: { room, messages, hasOlder, loadingOlder, confirmOpen, rejectOpen },
+    derived,
+    actions,
+  };
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #251

## ✅ 작업 내용

### 서류 제출 화면 상태 관리 훅 구현

서류 제출 화면의 상태 관리와 업로드 로직을 `useDocumentUpload`로 분리했습니다.

#### 적용 내용

- 업로드 슬롯 상태 관리
- 임시 저장 복원 및 폼 동기화
- 업로드 성공·실패 처리
- 슬롯 표시값과 재시도 로직을 파생값·액션으로 분리

<br/>

### 고객 채팅 화면 상태 관리 훅 구현

채팅 화면에서 사용하던 상태와 비즈니스 로직을 `useCustomerChatThread`로 통합했습니다.

#### 적용 내용

- 채팅방 조회 및 메시지 관리
- 매칭·거절·첨부·읽음 처리
- 비교 중인 상담방 계산
- 전송 상태와 화면 표시값을 파생값으로 분리

<br/>

### 회원가입 화면 상태 관리 훅 구현

회원가입 화면의 상태와 퍼널 제어 로직을 `useSignupForm`으로 분리했습니다.

#### 적용 내용

- 역할, 약관 동의, 본인 인증 상태 관리
- 드래프트 저장 및 복원
- 단계 이동과 제출 처리
- 소셜 로그인 컨텍스트 검증

<br/>

### 화면 상태 관리 구조 리팩터링

세 화면 모두 화면 상태와 비즈니스 로직을 `_hooks`로 이동하고, 컴포넌트는 훅 호출과 UI 렌더링만 담당하도록 정리했습니다.

기존 `useReviewDraft`와 동일한 `{ state, derived, actions }` 구조를 적용해 화면 상태 관리 방식을 통일했습니다.

## 🧪 테스트

Playwright + MSW E2E **148개** 전체 통과

### 분석 신청

- 전체 퍼널 제출
- 서류 업로드
- 임시 저장 복원

### 고객 채팅

- 매칭 및 거절
- 비교 배너 표시
- 딥링크 진입

### 회원가입

- 가입 완료
- 단계 진입 가드
- 드래프트 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 단계별 입력, 약관 동의, 본인정보 관리와 제출 흐름을 안정적으로 지원합니다.
  * 신청 서류를 복원하고, 업로드·재시도·삭제 및 필수 서류 누락 여부를 확인할 수 있습니다.
  * 고객 채팅에서 메시지·첨부파일 전송, 이전 메시지 확인, 매칭 수락·거절과 관련 상태를 이용할 수 있습니다.

* **개선 사항**
  * 회원가입, 서류 제출, 채팅 화면의 진행 상태와 오류 안내가 더욱 일관되게 표시됩니다.
  * 단계별 뒤로가기와 완료 후 화면 이동 흐름이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->