### PR TITLE
[Infra] release 브랜치 배포 자동화 워크플로 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,65 @@
+name: CD
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [release]
+
+concurrency:
+  group: cd-release
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  INSTANCE_ID: i-0c05f056a90e222b9
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: AWS 자격 증명 (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::938500344078:role/GitHubActions-CIRole
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: SSM으로 배포 스크립트 실행
+        id: send-command
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids "$INSTANCE_ID" \
+            --document-name "AWS-RunShellScript" \
+            --comment "release 배포 (${{ github.sha }})" \
+            --parameters commands='[
+              "set -e",
+              "sudo -u ubuntu -i bash -lc '\''cd ~/Frontend && git fetch origin && git checkout release && git reset --hard origin/release && pnpm install --frozen-lockfile && NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter @insurance/web build && pm2 restart web'\''"
+            ]' \
+            --query "Command.CommandId" --output text)
+          echo "command_id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
+          echo "SSM CommandId: $COMMAND_ID"
+
+      - name: 배포 완료 대기
+        run: |
+          aws ssm wait command-executed \
+            --command-id "${{ steps.send-command.outputs.command_id }}" \
+            --instance-id "$INSTANCE_ID" || true
+
+      - name: 배포 결과 확인
+        run: |
+          aws ssm get-command-invocation \
+            --command-id "${{ steps.send-command.outputs.command_id }}" \
+            --instance-id "$INSTANCE_ID" \
+            --output json > invocation.json
+          cat invocation.json | python3 -c "import json,sys; d=json.load(sys.stdin); print('--- stdout ---'); print(d.get('StandardOutputContent','')); print('--- stderr ---'); print(d.get('StandardErrorContent','')); print('Status:', d.get('Status'))"
+          STATUS=$(python3 -c "import json; print(json.load(open('invocation.json'))['Status'])")
+          if [ "$STATUS" != "Success" ]; then
+            echo "::error::배포 실패 (SSM Status=$STATUS)"
+            exit 1
+          fi


### PR DESCRIPTION
## 설명

`release` 브랜치에 push되면 EC2에 자동 배포되는 CD 워크플로를 추가한다. 지금까지 배포는 SSM 콘솔에서 수동으로 실행해 왔다.

## 동작

1. `release` 브랜치 push → 기존 CI 실행
2. CI가 성공하면(`workflow_run: completed` + `conclusion == success`) CD 실행
3. OIDC로 `GitHubActions-CIRole` 자격 증명 획득
4. SSM `send-command`로 EC2(`i-0c05f056a90e222b9`)에서 배포 스크립트 실행
   - `git reset --hard origin/release` → `pnpm install --frozen-lockfile` → `pnpm --filter @insurance/web build` → `pm2 restart web`
5. 실행 완료 대기 후 stdout/stderr 출력, Status가 `Success`가 아니면 워크플로 실패

## 사전 조건 확인 결과

- [x] `GitHubActions-CIRole` 인라인 정책에 `ssm:SendCommand` · `ssm:GetCommandInvocation` · `ssm:ListCommandInvocations` 있음
- [x] OIDC trust policy가 `repo:SM17-YoonDongJu/*:*` 허용
- [x] 대상 인스턴스 SSM 관리 상태 Online (Ubuntu, agent 3.3.4793.0)
- [ ] 머지 후 `release`에 테스트 push해 실제 배포 성공 확인

## 완료 조건

- [ ] `release` push 시 CI 통과 후 CD가 자동 실행된다
- [ ] 배포 실패 시 워크플로가 실패로 표시되고 SSM 로그가 Actions에 남는다

