### PR TITLE
chore : 배포 빌드 전 프로젝트 소유권 정리 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,7 @@ jobs:
             --comment "release 배포 (${{ github.sha }})" \
             --parameters commands='[
               "set -e",
+              "chown -R ubuntu:ubuntu /home/ubuntu/Frontend",
               "sudo -u ubuntu -i bash -lc '\''cd ~/Frontend && git fetch origin && git checkout release && git reset --hard origin/release && pnpm install --frozen-lockfile && NODE_OPTIONS=--max-old-space-size=3072 pnpm --filter @insurance/web build && pm2 restart web'\''"
             ]' \
             --query "Command.CommandId" --output text)


### PR DESCRIPTION
## 개요

release 배포 CD가 EC2 빌드 단계에서 실패하는 문제 수정.

```
Error: EACCES: permission denied, unlink '/home/ubuntu/Frontend/apps/web/.next/build/031494c8e9dcd9cd.js'
```

## 원인

이전 수동 배포 시 SSM 기본 실행 계정(root)으로 빌드가 돌아 `.next`에 root 소유 파일이 남음. CD 스크립트는 `ubuntu` 유저로 빌드하므로 해당 파일을 삭제하지 못해 `next build`가 EACCES로 실패.

## 조치

SSM 배포 명령 첫 단계에 `chown -R ubuntu:ubuntu /home/ubuntu/Frontend` 추가 — 빌드 전 소유권을 항상 정리해 root 잔여물로 인한 재발 차단.

머지 후 release의 CI 런을 재실행하면 CD가 dev의 갱신된 워크플로로 다시 배포합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **배포**
  * 배포 과정에서 프런트엔드 디렉터리와 하위 항목의 소유권이 올바르게 설정됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->