### PR TITLE
[Docs] issue-craft 스킬 라벨 규칙 수정

### DIFF
--- a/.claude/skills/issue-craft/SKILL.md
+++ b/.claude/skills/issue-craft/SKILL.md
@@ -106,8 +106,11 @@ gh issue view <NN> --json title,labels,assignees,body -q '.body'
 | `[Refactor]` | `FE,Refactor` |
 | `[Design]` | `FE,Design` |
 | `[Docs]` | `FE,Docs` |
+| 릴리즈·배포 | `Release` |
 
-> 존재하는 라벨: `Epic · FE · Feature · Fix · Settings · Story · Design · Docs · Refactor · Infra`. 없는 라벨을 지어내지 말 것. 확신 없으면 `gh label list`로 확인.
+릴리즈는 `FE`를 붙이지 않는다 — 앱 전체 배포라 프론트 한정이 아니다. 제목도 대괄호 태그가 아니라 `release (1.0.0) 배포` 형식이고 base가 `release` 브랜치다(#269).
+
+> 존재하는 라벨: `Epic · FE · Feature · Fix · Settings · Story · Design · Docs · Refactor · Infra · Release`. 없는 라벨을 지어내지 말 것. 확신 없으면 `gh label list --limit 50`으로 확인(기본 출력이 잘려 라벨을 놓칠 수 있다).
 
 ## 4. 본문 작성 규칙
 

--- a/.claude/skills/issue-craft/SKILL.md
+++ b/.claude/skills/issue-craft/SKILL.md
@@ -102,12 +102,12 @@ gh issue view <NN> --json title,labels,assignees,body -q '.body'
 | Tag | 라벨 |
 |-----|------|
 | `[Feature]` | `FE,Feature` |
-| `[Infra]` | `FE,Feature` (Infra 라벨 없음 → Feature) |
+| `[Infra]` / `[Settings]` | `FE,Infra` / `FE,Settings` |
 | `[Refactor]` | `FE,Refactor` |
 | `[Design]` | `FE,Design` |
 | `[Docs]` | `FE,Docs` |
 
-> 존재하는 라벨: `Epic · FE · Feature · Fix · Settings · Story · Design · Docs · Refactor`. 없는 라벨을 지어내지 말 것. 확신 없으면 `gh label list`로 확인.
+> 존재하는 라벨: `Epic · FE · Feature · Fix · Settings · Story · Design · Docs · Refactor · Infra`. 없는 라벨을 지어내지 말 것. 확신 없으면 `gh label list`로 확인.
 
 ## 4. 본문 작성 규칙
 
@@ -178,7 +178,7 @@ gh issue create \
 - 모바일 RN 웹뷰 기준 레이아웃이 깨지지 않는다
 ```
 
-### B. 인프라 (#58 트림) — 라벨 `FE,Feature` · 제목 `[Infra] …`(접미사 없음)
+### B. 인프라 (#58 트림) — 라벨 `FE,Infra` · 제목 `[Infra] …`(접미사 없음)
 ```markdown
 ## 배경
 ## 작업 항목


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #278

## ✅ 작업 내용

### issue-craft 스킬의 라벨 안내를 실제 레포 라벨에 맞췄습니다

스킬 문서가 실제 레포 라벨과 어긋나 있어, 그대로 따르면 잘못된 라벨이 붙었습니다.

<br/>

### 1. Infra 라벨 매핑 수정

`[Infra]` 이슈에 `FE,Feature`를 붙이라고 안내하면서 사유를 "Infra 라벨 없음"으로 적어두었는데, 레포에는 `Infra` 라벨이 존재합니다. 최근 인프라 이슈(#247 · #277)도 `FE,Infra`를 쓰고 있어 문서만 뒤처져 있었습니다.

#### 세부 작업
* §3 라벨 표 → `[Infra]` / `[Settings]`를 `FE,Infra` / `FE,Settings`로 분리
* §7 인프라 예시 → 라벨 표기를 `FE,Infra`로 정정

<br/>

### 2. Release 라벨 규칙 추가

릴리즈·배포에 쓰는 `Release` 라벨도 문서에 없었습니다. 표에 추가하면서 두 가지를 함께 적었습니다.

* `FE`를 붙이지 않습니다 — 앱 전체 배포라 프론트 한정이 아닙니다
* 제목이 대괄호 태그가 아니라 `release (1.0.0) 배포` 형식이고 base가 `release` 브랜치입니다(#269)

#### 세부 작업
* 존재하는 라벨 목록 → `Infra` · `Release` 반영
* 확인 명령 → `gh label list --limit 50`으로 수정

<br/>

### 3. 라벨 설명 정리

레포 라벨 9개의 설명을 실제 용도로 채웠습니다. `Epic` · `FE` · `Settings` · `Story`는 GitHub 기본 라벨을 이름만 바꿔 쓰면서 설명이 잔재로 남아 있었고(`good first issue` · `documentation` · `duplicate` · `help wanted`), `Design` · `Docs` · `Refactor` · `Infra` · `Release`는 비어 있었습니다.

라벨 설정 변경이라 이 PR에는 코드 diff가 없습니다.

## 💬 특이사항

라벨 목록을 처음 확인할 때 `gh label list`의 기본 출력이 잘려 `Release`를 놓쳤습니다. 같은 실수가 반복되지 않도록 문서의 확인 명령에 `--limit`을 박아뒀습니다.
