### PR TITLE
[Refactor] 응답 상태 값 검증 완화 및 폴백 처리

### DIFF
--- a/apps/web/src/app/(auth)/signup/verification/_model/adjuster-application.schema.ts
+++ b/apps/web/src/app/(auth)/signup/verification/_model/adjuster-application.schema.ts
@@ -5,6 +5,7 @@ import type {
   CreateAdjusterApplicationResponse as GenCreateAdjusterApplicationResponse,
 } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 // 소속: 독립(개업) / 손해사정법인 소속
 export const affiliationSchema = z.enum(["INDEPENDENT", "FIRM"]);
@@ -23,7 +24,7 @@ export const submittedDocumentSchema = z.object({
 export type SubmittedDocument = z.infer<typeof submittedDocumentSchema>;
 
 // 신청/심사 상태 — 서버 enum(admin accept/reject와 동일)
-export const applicationStatusSchema = z.enum(["PENDING", "APPROVED", "REJECTED"]);
+export const applicationStatusSchema = enumWithFallback(["PENDING", "APPROVED", "REJECTED"]);
 
 // ── 신청 body ──
 // 생성 스키마 베이스 + 우리 제약(licenseImageUrl/registrationImageUrl url() 형식, affiliation enum,

--- a/apps/web/src/app/customer/_shared/model/report-list.schema.ts
+++ b/apps/web/src/app/customer/_shared/model/report-list.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ReportCardListResponse } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 /**
  * 고객 리포트 목록 정본 — 대시보드·받은 제안·검수 내역·내 리포트 목록 공유(이슈 #128 통합).
@@ -8,7 +9,7 @@ import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/dri
  * 이 단일본으로 통합. 응답 래퍼(status/message/code)는 client가 해제 — 여기선 data 페이로드만 모델링.
  */
 // 백엔드 ReportResponseSupport.customerStatus — CLOSED는 고객 노출 시 MATCHED로 매핑되어 CLOSED는 내려오지 않는다.
-export const reportListStatusSchema = z.enum([
+export const reportListStatusSchema = enumWithFallback([
   "AWAITING_INSPECTION",
   "AWAITING_ADOPTION",
   "COUNSELING",

--- a/apps/web/src/app/customer/_shared/model/report-status.ts
+++ b/apps/web/src/app/customer/_shared/model/report-status.ts
@@ -3,7 +3,8 @@ export type ReportListStatus =
   | "AWAITING_ADOPTION"
   | "COUNSELING"
   | "MATCHED"
-  | "NOT_SELECTED";
+  | "NOT_SELECTED"
+  | "UNKNOWN";
 
 export type ReportStatusTone = "gold" | "green" | "navy" | "neutral";
 
@@ -22,6 +23,8 @@ export const REPORT_STATUS_META: Record<
   COUNSELING: { label: "상담 중", tone: "navy", showCheck: false, muted: false },
   MATCHED: { label: "종결", tone: "neutral", showCheck: true, muted: true },
   NOT_SELECTED: { label: "선택 받지 못함", tone: "neutral", showCheck: false, muted: true },
+  // 명세에 없는 상태가 내려왔을 때의 폴백 — 단정하지 않고 진행 중으로 보여준다.
+  UNKNOWN: { label: "진행 중", tone: "neutral", showCheck: false, muted: false },
 };
 
 /** 상태 tone → 카드 좌측 스파인 배경 유틸. */

--- a/apps/web/src/app/customer/_shared/model/report-status.ts
+++ b/apps/web/src/app/customer/_shared/model/report-status.ts
@@ -23,8 +23,8 @@ export const REPORT_STATUS_META: Record<
   COUNSELING: { label: "상담 중", tone: "navy", showCheck: false, muted: false },
   MATCHED: { label: "종결", tone: "neutral", showCheck: true, muted: true },
   NOT_SELECTED: { label: "선택 받지 못함", tone: "neutral", showCheck: false, muted: true },
-  // 명세에 없는 상태가 내려왔을 때의 폴백 — 단정하지 않고 진행 중으로 보여준다.
-  UNKNOWN: { label: "진행 중", tone: "neutral", showCheck: false, muted: false },
+  // 명세에 없는 상태 — 어떤 단계인지 단정하지 않는 중립 라벨로 보여준다.
+  UNKNOWN: { label: "확인 필요", tone: "neutral", showCheck: false, muted: false },
 };
 
 /** 상태 tone → 카드 좌측 스파인 배경 유틸. */

--- a/apps/web/src/app/customer/chat/[chatRoomId]/shared-report/_components/SharedIssueCard.tsx
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/shared-report/_components/SharedIssueCard.tsx
@@ -14,6 +14,8 @@ const ISSUE_REVIEW_STATUS_META: Record<
   ACCEPTED: { label: "인정", tone: "green" },
   MODIFIED: { label: "수정", tone: "gold" },
   ADDED: { label: "사정사 추가", tone: "navy" },
+  // 명세에 없는 판정 — 단정하지 않고 중립 배지로 보여준다.
+  UNKNOWN: { label: "확인 필요", tone: "neutral" },
 };
 
 function formatImpact(won: number | null): string | null {

--- a/apps/web/src/app/customer/chat/[chatRoomId]/shared-report/_model/shared-report.schema.ts
+++ b/apps/web/src/app/customer/chat/[chatRoomId]/shared-report/_model/shared-report.schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { Estimate, Issue, SharedReportResponse } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 // 채팅방 공유 리포트 계약(응답 래퍼 내부 data만 — client가 래퍼 해제·snake→camel 변환).
 // 같은 리포트라도 방마다 사정사별 검수본이 달라 키·조회 단위는 chatRoomId.
@@ -8,7 +9,7 @@ import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/dri
 // 값 집합이 명세에 없어 잠그지 않는다(화면 분기에도 쓰지 않음).
 export const sharedReportStatusSchema = z.string();
 
-export const sharedReviewStatusSchema = z.enum([
+export const sharedReviewStatusSchema = enumWithFallback([
   "SENT",
   "COUNSELING",
   "REJECTED",
@@ -16,7 +17,7 @@ export const sharedReviewStatusSchema = z.enum([
 ]);
 
 // 쟁점 판정. EXCLUDED는 공유 리포트에서 제외돼 내려오지 않는다(명세 3값).
-export const sharedIssueReviewStatusSchema = z.enum([
+export const sharedIssueReviewStatusSchema = enumWithFallback([
   "ACCEPTED",
   "MODIFIED",
   "ADDED",

--- a/apps/web/src/app/customer/dashboard/_components/AnalysisTimelineCard.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/AnalysisTimelineCard.tsx
@@ -18,6 +18,8 @@ const STATUS_PILL_LABEL: Record<ReportStatus, string> = {
   COUNSELING: "매칭 완료",
   MATCHED: "매칭 완료",
   NOT_SELECTED: "제안 도착",
+  // 명세에 없는 상태 — 단정하지 않고 검수 중으로 보여준다.
+  UNKNOWN: "검수 중",
 };
 
 // 활성 리포트는 백엔드가 MATCHED(구 CLOSED)·NOT_SELECTED를 제외하고 내려주지만, 방어적으로 매칭(4단계)까지 다룬다.

--- a/apps/web/src/app/customer/dashboard/_components/AnalysisTimelineCard.tsx
+++ b/apps/web/src/app/customer/dashboard/_components/AnalysisTimelineCard.tsx
@@ -18,8 +18,8 @@ const STATUS_PILL_LABEL: Record<ReportStatus, string> = {
   COUNSELING: "매칭 완료",
   MATCHED: "매칭 완료",
   NOT_SELECTED: "제안 도착",
-  // 명세에 없는 상태 — 단정하지 않고 검수 중으로 보여준다.
-  UNKNOWN: "검수 중",
+  // 명세에 없는 상태 — 어떤 단계인지 단정하지 않는 중립 라벨로 보여준다.
+  UNKNOWN: "확인 필요",
 };
 
 // 활성 리포트는 백엔드가 MATCHED(구 CLOSED)·NOT_SELECTED를 제외하고 내려주지만, 방어적으로 매칭(4단계)까지 다룬다.

--- a/apps/web/src/app/customer/mypage/_model/analysis-step.ts
+++ b/apps/web/src/app/customer/mypage/_model/analysis-step.ts
@@ -19,6 +19,8 @@ const STATUS_TO_STEP: Record<ReportListItemStatus, AnalysisStep> = {
   COUNSELING: "EXPERT_REVIEW",
   MATCHED: "PROPOSAL_ARRIVED",
   NOT_SELECTED: "PROPOSAL_ARRIVED",
+  // 명세에 없는 상태 — 스테퍼를 앞당기지 않고 첫 단계로 둔다.
+  UNKNOWN: "INFO_INPUT",
 };
 
 export function toAnalysisStep(status: string): AnalysisStep {

--- a/apps/web/src/app/customer/report/[id]/_components/ReportDetailView.tsx
+++ b/apps/web/src/app/customer/report/[id]/_components/ReportDetailView.tsx
@@ -80,7 +80,9 @@ export function ReportDetailView({ reportId }: { reportId: string }) {
                 claimedMinAmount={data.claimedMinAmount}
                 claimedMaxAmount={data.claimedMaxAmount}
                 offeredAmount={data.offeredAmount}
-                confidenceLevel={data.confidenceLevel}
+                confidenceLevel={
+                  data.confidenceLevel === "UNKNOWN" ? null : data.confidenceLevel
+                }
               />
               <IssueReview issues={data.issues} />
               <div className="space-y-[1.125rem] md:grid md:grid-cols-2 md:gap-6 md:space-y-0 lg:block lg:space-y-6">

--- a/apps/web/src/app/customer/report/[id]/_model/report-detail.schema.ts
+++ b/apps/web/src/app/customer/report/[id]/_model/report-detail.schema.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 import type { CustomerReportDetailResponse, IssueItem } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 /**
  * 리포트 상세. 출처: API 명세 GET /reports/{reportId}(백엔드 CustomerReportDetailResponse).
  * 백엔드 필드 issue(단수)·reportNo는 기존 소비처(issues·caseNo) 무변경을 위해 파싱 시 별칭을 추가한다.
  */
 
-export const reportStatusSchema = z.enum([
+export const reportStatusSchema = enumWithFallback([
   "AWAITING_INSPECTION",
   "AWAITING_ADOPTION",
   "COUNSELING",
@@ -47,7 +48,7 @@ const rawReportDetailSchema = z.object({
   issue: z.array(issueItemSchema),
   question: z.string().nullable(),
   adjusterId: z.uuid().nullable(),
-  confidenceLevel: z.enum(["LOW", "MEDIUM", "HIGH"]).nullable(),
+  confidenceLevel: enumWithFallback(["LOW", "MEDIUM", "HIGH"]).nullable(),
   reportNo: z.string().nullable(),
   reviewComment: z.string().nullable(),
   reviewedAt: z.string().nullable(),

--- a/apps/web/src/app/customer/report/[id]/_model/report-status.ts
+++ b/apps/web/src/app/customer/report/[id]/_model/report-status.ts
@@ -13,4 +13,6 @@ export const REPORT_STATUS_META: Record<
   COUNSELING: { label: "상담 중", tone: "navy", nextStep: "상담 진행" },
   MATCHED: { label: "종결", tone: "green", nextStep: "후기 작성" },
   NOT_SELECTED: { label: "선택 받지 못함", tone: "neutral", nextStep: "다른 제안 검토" },
+  // 명세에 없는 상태가 내려왔을 때의 폴백 — 단정하지 않고 진행 중으로 보여준다.
+  UNKNOWN: { label: "진행 중", tone: "neutral", nextStep: "진행 상황 확인" },
 };

--- a/apps/web/src/app/customer/report/[id]/_model/report-status.ts
+++ b/apps/web/src/app/customer/report/[id]/_model/report-status.ts
@@ -13,6 +13,6 @@ export const REPORT_STATUS_META: Record<
   COUNSELING: { label: "상담 중", tone: "navy", nextStep: "상담 진행" },
   MATCHED: { label: "종결", tone: "green", nextStep: "후기 작성" },
   NOT_SELECTED: { label: "선택 받지 못함", tone: "neutral", nextStep: "다른 제안 검토" },
-  // 명세에 없는 상태가 내려왔을 때의 폴백 — 단정하지 않고 진행 중으로 보여준다.
-  UNKNOWN: { label: "진행 중", tone: "neutral", nextStep: "진행 상황 확인" },
+  // 명세에 없는 상태 — 어떤 단계인지 단정하지 않는 중립 라벨로 보여준다.
+  UNKNOWN: { label: "확인 필요", tone: "neutral", nextStep: "진행 상황 확인" },
 };

--- a/apps/web/src/app/partner/_shared/model/review-list.schema.ts
+++ b/apps/web/src/app/partner/_shared/model/review-list.schema.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import type { PendingReviewListResponse } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 /** 검수 대기 목록. 출처: API 명세 GET /reports/pending-review. 필드명 명세 그대로. */
 
-export const reviewStatusSchema = z.enum([
+export const reviewStatusSchema = enumWithFallback([
   "AWAITING_INSPECTION",
   "AWAITING_ADOPTION",
   "COUNSELING",

--- a/apps/web/src/app/partner/mypage/review-history/_model/review-status-meta.ts
+++ b/apps/web/src/app/partner/mypage/review-history/_model/review-status-meta.ts
@@ -15,6 +15,8 @@ const REVIEW_STATUS_META: Record<ReviewStatus, ReviewStatusMeta> = {
   COUNSELING: { label: "상담 전환", tone: "gold", hasCheck: false },
   REJECTED: { label: "반려", tone: "neutral", hasCheck: false },
   ACCEPTED: { label: "채택", tone: "green", hasCheck: true },
+  // 명세에 없는 상태 — 단정하지 않고 중립 배지로 보여준다.
+  UNKNOWN: { label: "확인 필요", tone: "neutral", hasCheck: false },
 };
 
 const FALLBACK_META: ReviewStatusMeta = { label: "", tone: "neutral", hasCheck: false };

--- a/apps/web/src/app/partner/mypage/review-history/_model/reviewed-reports.schema.ts
+++ b/apps/web/src/app/partner/mypage/review-history/_model/reviewed-reports.schema.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { accidentTypeSchema } from "@/shared/model/accident-type";
 import type { Stats } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 /**
  * 사정사 검수 내역. 출처: API 명세 GET /adjusters/me/reviewed-reports.
@@ -9,7 +10,7 @@ import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/dri
  */
 
 /** items[].status — 사정사 검수 상태(방향). 명세 Query status의 ALL(전체)은 제외. */
-export const reviewStatusSchema = z.enum([
+export const reviewStatusSchema = enumWithFallback([
   "SENT",
   "COUNSELING",
   "REJECTED",

--- a/apps/web/src/app/partner/review/[reportId]/_model/review-detail.schema.ts
+++ b/apps/web/src/app/partner/review/[reportId]/_model/review-detail.schema.ts
@@ -9,9 +9,10 @@ import type {
   ReviewWorkspaceResponse,
 } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 /** 리포트 생명주기 상태 (ERD REPORTS.status 5상태). */
-export const reviewReportStatusSchema = z.enum([
+export const reviewReportStatusSchema = enumWithFallback([
   "AWAITING_INSPECTION",
   "AWAITING_ADOPTION",
   "COUNSELING",
@@ -20,7 +21,7 @@ export const reviewReportStatusSchema = z.enum([
 ]);
 
 /** 검수 방향(작업본 상태). */
-export const reviewDirectionStatusSchema = z.enum([
+export const reviewDirectionStatusSchema = enumWithFallback([
   "SENT",
   "COUNSELING",
   "REJECTED",

--- a/apps/web/src/app/partner/review/[reportId]/_model/status-meta.ts
+++ b/apps/web/src/app/partner/review/[reportId]/_model/status-meta.ts
@@ -10,6 +10,8 @@ export const REPORT_STATUS_META: Record<ReviewReportStatus, { label: string; ton
   COUNSELING: { label: "상담 중", tone: "green" },
   CLOSED: { label: "종결", tone: "neutral" },
   NOT_SELECTED: { label: "선택 받지 못함", tone: "neutral" },
+  // 명세에 없는 상태 — 단정하지 않고 중립 배지로 보여준다.
+  UNKNOWN: { label: "확인 필요", tone: "neutral" },
 };
 
 /** 인정/수정/제외 토글 옵션 (ADDED는 신규추가 폼 전용, 미검수는 null). */

--- a/apps/web/src/shared/api/chat/chat.schema.ts
+++ b/apps/web/src/shared/api/chat/chat.schema.ts
@@ -9,11 +9,12 @@ import type {
   ReadResponse,
 } from "@/shared/api/generated/types.gen";
 import type { AssertFieldsExistInSpec, ExpectDriftCheck } from "@/shared/lib/drift-check";
+import { enumWithFallback } from "@/shared/lib/enum-with-fallback";
 
 // 채팅 도메인 계약(응답 래퍼 내부 data만 — client가 래퍼 해제·snake→camel 변환).
 // mine/theirs 판별은 서버 isMine(GET/POST messages)로 정합 — senderId 문자열 비교 제거.
 
-export const roomStatusSchema = z.enum(["ACTIVE", "CLOSED"]);
+export const roomStatusSchema = enumWithFallback(["ACTIVE", "CLOSED"]);
 
 // match_status — 파이프라인(사정사 검수) 방만. 사정사 검색으로 만든 방은 null.
 export const matchStatusSchema = z.enum([

--- a/apps/web/src/shared/lib/enum-with-fallback.ts
+++ b/apps/web/src/shared/lib/enum-with-fallback.ts
@@ -12,5 +12,11 @@ export const UNKNOWN_ENUM_VALUE = "UNKNOWN";
  * 요청 body·필터에는 쓰지 않는다 — 우리가 보내는 값은 오타가 컴파일에서 걸려야 한다.
  */
 export function enumWithFallback<const T extends readonly [string, ...string[]]>(values: T) {
-  return z.enum([...values, UNKNOWN_ENUM_VALUE] as unknown as [...T, "UNKNOWN"]).catch(UNKNOWN_ENUM_VALUE);
+  const known = new Set<string>(values);
+  // 모르는 "문자열"만 UNKNOWN으로 바꾼다. null·undefined·비문자열은 계속 실패해야
+  // 필수 필드 누락이나 타입 변경을 파싱 단계에서 잡을 수 있다(catch는 그것까지 삼킨다).
+  return z.preprocess(
+    (input) => (typeof input === "string" && !known.has(input) ? UNKNOWN_ENUM_VALUE : input),
+    z.enum([...values, UNKNOWN_ENUM_VALUE] as unknown as [...T, "UNKNOWN"]),
+  );
 }

--- a/apps/web/src/shared/lib/enum-with-fallback.ts
+++ b/apps/web/src/shared/lib/enum-with-fallback.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const UNKNOWN_ENUM_VALUE = "UNKNOWN";
+
+/**
+ * 응답 enum — 명세에 없는 값이 와도 파싱을 실패시키지 않고 UNKNOWN으로 받는다.
+ *
+ * 백엔드가 상태 값을 추가하면 엄격한 z.enum은 파싱 단계에서 던지고, suspense 쿼리는
+ * 콘솔 에러 없이 멈춘 것처럼 보인다(공유 엔드포인트에 CLOSED가 추가됐을 때 겪은 문제).
+ * 타입에 UNKNOWN이 남아 화면이 폴백 분기를 반드시 갖게 된다.
+ *
+ * 요청 body·필터에는 쓰지 않는다 — 우리가 보내는 값은 오타가 컴파일에서 걸려야 한다.
+ */
+export function enumWithFallback<const T extends readonly [string, ...string[]]>(values: T) {
+  return z.enum([...values, UNKNOWN_ENUM_VALUE] as unknown as [...T, "UNKNOWN"]).catch(UNKNOWN_ENUM_VALUE);
+}

--- a/apps/web/src/shared/ui/chat/room-status.ts
+++ b/apps/web/src/shared/ui/chat/room-status.ts
@@ -9,4 +9,6 @@ interface RoomStatusMeta {
 export const ROOM_STATUS_META: Record<RoomStatus, RoomStatusMeta> = {
   ACTIVE: { label: "상담 진행 중", tone: "green" },
   CLOSED: { label: "상담 종료", tone: "neutral" },
+  // 명세에 없는 상태 — 단정하지 않고 중립 배지로 보여준다.
+  UNKNOWN: { label: "확인 필요", tone: "neutral" },
 };


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #280

## ✅ 작업 내용

### 명세에 없는 상태 값이 응답으로 와도 화면이 멈추지 않게 했습니다

엄격한 `z.enum`은 모르는 값을 만나면 파싱 단계에서 던집니다. suspense 쿼리는 이때 콘솔 에러 없이 멈춘 것처럼 보입니다. 공유 엔드포인트에 `CLOSED`가 추가됐을 때 같은 방식으로 화면이 멈춘 적이 있고, `REPORT_STATUS_META` 주석은 `CLOSED`를 종료 상태로 설명하는데 정작 union에는 없어 같은 문제가 남아 있었습니다.

<br/>

### 1. 폴백 값을 갖는 응답 enum 헬퍼

```ts
// shared/lib/enum-with-fallback.ts
export function enumWithFallback<const T extends readonly [string, ...string[]]>(values: T) {
  return z.enum([...values, UNKNOWN_ENUM_VALUE] as unknown as [...T, "UNKNOWN"]).catch(UNKNOWN_ENUM_VALUE);
}
```

파싱은 실패하지 않고, 타입에는 `UNKNOWN`이 남습니다. 폴백을 빠뜨린 화면은 컴파일에서 걸립니다. 실제로 이번에 상태 메타 맵 6곳이 타입 에러로 드러났습니다.

<br/>

### 2. 응답 상태에 적용

리포트 목록·상세, 검수 대기 목록·검수 내역·검수 상세, 공유 리포트 판정, 채팅방 상태, 사정사 자격 신청 상태, AI 신뢰도 등급에 적용했습니다.

#### 세부 작업
* 상태 메타 맵 → `UNKNOWN` 항목 추가, 중립 톤에 "확인 필요" 또는 "진행 중" 라벨
* 분석 스테퍼 → 모르는 상태에서 단계를 앞당기지 않고 첫 단계로 폴백
* AI 신뢰도 → `UNKNOWN`이면 게이지를 그리지 않음

## 💬 특이사항 / 결정 사항

### 요청 enum과 액션 분기 enum은 엄격하게 남겼습니다

요청 body는 우리가 보내는 값이라 오타가 컴파일에서 걸려야 합니다. 매칭 상태(`matchStatus`)도 그대로 뒀습니다. 카드 CTA를 결정하는 값이라 폴백이 "종료"나 "상담 수락" 중 하나로 단정될 수밖에 없는데, 어느 쪽도 안전하지 않습니다. 표시가 아니라 동작을 좌우하는 값이므로 UI 설계 결정이 필요합니다.

같은 이유로 채팅 `messageType`도 제외했습니다. 모르는 타입의 말풍선을 어떻게 그릴지가 먼저입니다.

### 백엔드에 enum 선언을 요청하면 더 좋아집니다

현재 스펙은 상태 필드를 `type: string`으로만 내려보내 생성 zod가 값을 좁히지 못합니다. 선언이 채워지면 코드 생성이 이 부분을 대신할 수 있습니다.

## 🔜 후속 이슈

- `matchStatus` · `messageType` 폴백 UI 설계 후 적용
- 응답 스키마·목 데이터를 스펙 필드명으로 이관 (#283)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 정의되지 않은 상태값을 `UNKNOWN`으로 안전하게 처리합니다.
  * 상담방, 리포트, 검토 및 신청 상태를 중립적인 “확인 필요” 안내로 표시합니다.
  * 알 수 없는 상태에서도 분석 단계와 지급 신뢰도 정보를 안정적으로 표시합니다.

* **버그 수정**
  * 새로운 상태값이 추가되어도 목록 및 상세 화면이 중단되지 않습니다.
  * 상태값에 따라 배지, 진행 단계, 안내 문구가 일관되게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->