### PR TITLE
[Fix] 마이페이지 헤딩 셀렉터 중복 매칭으로 E2E 불안정 수정

### DIFF
--- a/apps/web/e2e/account-withdraw.spec.ts
+++ b/apps/web/e2e/account-withdraw.spec.ts
@@ -94,7 +94,7 @@ test.describe("모바일", () => {
   test("설정 목록의 회원 탈퇴를 누르면 탈퇴 안내가 보인다", async ({ page }) => {
     await page.goto(CUSTOMER_MYPAGE_PATH);
     await expect(
-      page.getByRole("heading", { name: "내 정보" }).filter({ visible: true }),
+      page.getByRole("heading", { level: 1, name: "내 정보" }).filter({ visible: true }),
     ).toBeVisible({ timeout: 15000 });
 
     await clickWithdrawEntry(page);

--- a/apps/web/e2e/customer-logout.spec.ts
+++ b/apps/web/e2e/customer-logout.spec.ts
@@ -65,7 +65,7 @@ test.describe("모바일", () => {
   test("하단 로그아웃을 누르면 로그인 화면으로 이동한다", async ({ page }) => {
     await page.goto(MYPAGE_PATH);
     await expect(
-      page.getByRole("heading", { name: "내 정보" }).filter({ visible: true }),
+      page.getByRole("heading", { level: 1, name: "내 정보" }).filter({ visible: true }),
     ).toBeVisible();
 
     await clickLogout(page);
@@ -81,7 +81,7 @@ test.describe("모바일", () => {
 
     await page.goto(MYPAGE_PATH);
     await expect(
-      page.getByRole("heading", { name: "내 정보" }).filter({ visible: true }),
+      page.getByRole("heading", { level: 1, name: "내 정보" }).filter({ visible: true }),
     ).toBeVisible();
 
     await clickLogout(page);

--- a/apps/web/e2e/user-mypage.spec.ts
+++ b/apps/web/e2e/user-mypage.spec.ts
@@ -149,7 +149,7 @@ test.describe("모바일 내 정보 허브", () => {
     await page.goto(PATH);
 
     await expect(
-      page.getByRole("heading", { name: "내 정보" }).filter({ visible: true }),
+      page.getByRole("heading", { level: 1, name: "내 정보" }).filter({ visible: true }),
     ).toBeVisible();
     await expect(
       page.getByText("일반 회원").filter({ visible: true }),
@@ -189,7 +189,7 @@ test.describe("모바일 파트너 전환 role 조건부", () => {
 
     // 허브가 렌더된 뒤(설정 리스트 노출) 파트너 전환 부재를 단언
     await expect(
-      page.getByRole("heading", { name: "내 정보" }).filter({ visible: true }),
+      page.getByRole("heading", { level: 1, name: "내 정보" }).filter({ visible: true }),
     ).toBeVisible();
     await expect(page.getByText("파트너 모드로 전환")).toHaveCount(0);
   });


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #284

## ✅ 작업 내용

### 마이페이지 헤딩을 잡는 셀렉터가 두 요소를 함께 매칭하던 것을 좁혔습니다

`getByRole("heading", { name: "내 정보" })`는 기본이 부분 일치라 마이페이지의 헤딩 두 개를 함께 잡습니다.

```
strict mode violation: resolved to 2 elements
  1) <h1 class="mt-1 font-serif ...">내 정보</h1>          모바일 헤더
  2) <h2 class="text-[0.8125rem] ...">내 정보 · 설정</h2>   설정 섹션
```

두 헤딩의 가시성이 레이아웃 시점에 따라 갈리면서 CI에서 간헐적으로 실패했습니다(#276 실행에서 flaky로 검출). 재시도에서 통과해 묻히기 쉬운 형태입니다.

`level: 1`로 좁혔습니다. 같은 화면을 보는 `adjuster-mypage.spec.ts`·`account-withdraw.spec.ts`가 이미 쓰던 방식이라 규칙을 맞춘 것에 가깝습니다.

#### 세부 작업
* `customer-logout.spec.ts` 2곳 · `user-mypage.spec.ts` 2곳 · `account-withdraw.spec.ts` 1곳
* 마이페이지 헤딩을 부분 일치로 잡는 셀렉터는 이제 남아 있지 않습니다

## 💬 특이사항

이슈에는 2개 파일로 적었는데 실제로 훑어보니 `user-mypage.spec.ts`에도 같은 패턴이 2곳 더 있었습니다. 함께 고쳤습니다.
