### PR TITLE
[Refactor] MSW 목 응답을 와이어 형식으로 통일

### DIFF
--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -1,8 +1,9 @@
-import { delay, http, HttpResponse } from "msw";
+import { delay, HttpResponse } from "msw";
 import { z } from "zod";
 import { camelToSnakeDeep, toSnakeKey } from "@/shared/api/case-convert";
 import { chatReportReasonSchema } from "@/shared/api/chat/chat.schema";
 import { API_BASE_URL } from "@/shared/api/config";
+import { wire } from "@/shared/mocks/wire-response";
 import {
   consumeReissue,
   isAccessTokenExpired,
@@ -1027,7 +1028,7 @@ export const handlers = [
   // 문의 폼 제출 (#220) — 백엔드 확정 전 임시 목(요청: Notion "POST /contact-inquiries").
   //   성공 200 + { received: true }. 이메일 형식 오류·문의 내용 길이 미달 등은 400 VALIDATION_ERROR.
   //   프론트 zod 스키마(contact-inquiry.schema.ts)와 동일 계약을 여기서 거울 검증한다.
-  http.post(`${API_BASE_URL}/contact-inquiries`, async ({ request }) => {
+  wire.post(`${API_BASE_URL}/contact-inquiries`, async ({ request }) => {
     await delay(500);
 
     const json: unknown = await request.json().catch(() => null);
@@ -1053,7 +1054,7 @@ export const handlers = [
   //   진행중/승인 상태에서 재-POST→409 DUPLICATE_RESOURCE, REJECTED에서 재-POST→201 재허용(재제출).
   //   x-mock-failure:apply→500 INTERNAL_SERVER_ERROR.
   //   x-mock-scenario:application-duplicate→409 강제(E2E "이미 신청" 재현용, 상태 무관).
-  http.post(`${API_BASE_URL}/users/adjuster-applications`, async ({ request }) => {
+  wire.post(`${API_BASE_URL}/users/adjuster-applications`, async ({ request }) => {
     await delay(600);
 
     if (request.headers.get("x-mock-failure") === "apply") {
@@ -1142,7 +1143,7 @@ export const handlers = [
   // 본인 자격 신청 상태 조회 (#44) — 미신청 404 POST_NOT_FOUND, 그 외 PENDING/APPROVED/REJECTED.
   //   시나리오 override: x-mock-scenario=application-(not-applied|pending|approved|rejected).
   //   x-mock-failure=application-unauthorized→401 LOGIN_REQUIRED / application-status→500.
-  http.get(`${API_BASE_URL}/users/adjuster-applications/me`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/users/adjuster-applications/me`, async ({ request }) => {
     await delay(400);
 
     const failure = request.headers.get("x-mock-failure");
@@ -1199,7 +1200,7 @@ export const handlers = [
   }),
 
   // 채팅방 목록 (이슈 #48) — 정확 경로. :param 라우트보다 먼저 등록.
-  http.get(`${API_BASE_URL}/chats`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/chats`, async ({ request }) => {
     await delay(400);
 
     if (request.headers.get("x-mock-failure") === "chat-list") {
@@ -1221,7 +1222,7 @@ export const handlers = [
   }),
 
   // 채팅방 단건 조회 (이슈 #161) — 딥링크 진입용. 목록 응답 없이도 방 헤더 렌더.
-  http.get(`${API_BASE_URL}/chats/:chatRoomId`, async ({ params }) => {
+  wire.get(`${API_BASE_URL}/chats/:chatRoomId`, async ({ params }) => {
     await delay(300);
 
     const room = chatRooms.find(
@@ -1243,7 +1244,7 @@ export const handlers = [
 
   // 메시지 히스토리 (이슈 #48) — 커서 페이지네이션(?cursor&size, 기본 30).
   // 페이지 내부는 최신순으로 반환, cursor는 "이 메시지보다 오래된 것" 기준. CLOSED 방도 조회 가능.
-  http.get(`${API_BASE_URL}/chats/:chatRoomId/messages`, async ({ request, params }) => {
+  wire.get(`${API_BASE_URL}/chats/:chatRoomId/messages`, async ({ request, params }) => {
     await delay(400);
 
     const chatRoomId = String(params.chatRoomId);
@@ -1276,7 +1277,7 @@ export const handlers = [
   }),
 
   // 메시지 전송 (이슈 #48) — CLOSED 방은 409, 그 외 상태 배열 append + 방 갱신.
-  http.post(`${API_BASE_URL}/chats/:chatRoomId/messages`, async ({ request, params }) => {
+  wire.post(`${API_BASE_URL}/chats/:chatRoomId/messages`, async ({ request, params }) => {
     await delay(300);
 
     const chatRoomId = String(params.chatRoomId);
@@ -1370,7 +1371,7 @@ export const handlers = [
   }),
 
   // 첨부 업로드 (POST /chats/{id}/attachments) — multipart file → key 메타 발급(private S3 가정).
-  http.post(`${API_BASE_URL}/chats/:chatRoomId/attachments`, async ({ request, params }) => {
+  wire.post(`${API_BASE_URL}/chats/:chatRoomId/attachments`, async ({ request, params }) => {
     await delay(500);
 
     const chatRoomId = String(params.chatRoomId);
@@ -1422,7 +1423,7 @@ export const handlers = [
   }),
 
   // 상담 수락 (PATCH /chats/{id}/accept) — 내 제안 ACCEPTED·방 CLOSED·형제 방 REJECTED+CLOSED·리포트 CLOSED.
-  http.patch(`${API_BASE_URL}/chats/:chatRoomId/accept`, async ({ params }) => {
+  wire.patch(`${API_BASE_URL}/chats/:chatRoomId/accept`, async ({ params }) => {
     await delay(300);
 
     const chatRoomId = String(params.chatRoomId);
@@ -1465,7 +1466,7 @@ export const handlers = [
   }),
 
   // 상담 거절 (PATCH /chats/{id}/reject) — 내 제안 REJECTED·방 CLOSED·리포트 AWAITING_ADOPTION. 형제 유지.
-  http.patch(`${API_BASE_URL}/chats/:chatRoomId/reject`, async ({ params }) => {
+  wire.patch(`${API_BASE_URL}/chats/:chatRoomId/reject`, async ({ params }) => {
     await delay(300);
 
     const chatRoomId = String(params.chatRoomId);
@@ -1500,7 +1501,7 @@ export const handlers = [
   }),
 
   // 읽음 처리 (POST /chats/{id}/read) — unread_count 0으로 리셋.
-  http.post(`${API_BASE_URL}/chats/:chatRoomId/read`, async ({ params }) => {
+  wire.post(`${API_BASE_URL}/chats/:chatRoomId/read`, async ({ params }) => {
     await delay(150);
 
     const chatRoomId = String(params.chatRoomId);
@@ -1523,7 +1524,7 @@ export const handlers = [
 
   // 채팅 상대 신고 (POST /chats/{id}/report, 이슈 #244) — 매 요청 새 접수(중복 제한 없음, 방 상태 불변).
   //  - x-mock-failure: chat-report → 500 INTERNAL_SERVER_ERROR(E2E 실패·재제출 시나리오)
-  http.post(`${API_BASE_URL}/chats/:chatRoomId/report`, async ({ params, request }) => {
+  wire.post(`${API_BASE_URL}/chats/:chatRoomId/report`, async ({ params, request }) => {
     await delay(300);
 
     if (request.headers.get("x-mock-failure") === "chat-report") {
@@ -1575,7 +1576,7 @@ export const handlers = [
   //  - x-mock-failure: shared-report-missing   → 404 REPORT_NOT_FOUND(검수 리포트 미등록)
   //  - x-mock-failure: shared-report-proposal  → 404 PROPOSAL_NOT_FOUND(제안 없는 사정사 검색 방)
   //  - 없는 방                                  → 404 CHAT_ROOM_NOT_FOUND
-  http.get(`${API_BASE_URL}/chats/:chatRoomId/shared-report`, async ({ request, params }) => {
+  wire.get(`${API_BASE_URL}/chats/:chatRoomId/shared-report`, async ({ request, params }) => {
     await delay(400);
 
     const chatRoomId = String(params.chatRoomId);
@@ -1692,7 +1693,7 @@ export const handlers = [
   //  - code=fail-external  → 500 EXTERNAL_API_ERROR   (브라우저 URL 주입 — E2E)
   //  - x-mock-failure 헤더 → invalid / unsupported / 그 외: 위와 동일(서버측 주입, 유지)
   //  콜백 페이지가 URL 쿼리 code를 그대로 전달하므로 E2E는 URL만으로 실패 결정 주입 가능.
-  http.get(`${API_BASE_URL}/auth/oauth2/:provider/callback`, async ({ request, params }) => {
+  wire.get(`${API_BASE_URL}/auth/oauth2/:provider/callback`, async ({ request, params }) => {
     await delay(600);
 
     const provider = String(params.provider);
@@ -1745,7 +1746,7 @@ export const handlers = [
   }),
 
   // 알림 모두 읽음 처리 (#49) — ⚠️ 명세없음-초안. 구체 경로를 목록 GET보다 먼저 등록.
-  http.patch(`${API_BASE_URL}/users/me/notifications/read-all`, async ({ request }) => {
+  wire.patch(`${API_BASE_URL}/users/me/notifications/read-all`, async ({ request }) => {
     await delay(400);
 
     if (request.headers.get("x-mock-failure") === "read-all") {
@@ -1765,7 +1766,7 @@ export const handlers = [
   }),
 
   // 알림 개별 읽음 처리 (#162, 스웨거 확정) — 대상 isRead 갱신, 없는 id는 404 봉투.
-  http.patch(
+  wire.patch(
     `${API_BASE_URL}/users/me/notifications/:notificationId/read`,
     async ({ request, params }) => {
       await delay(400);
@@ -1796,7 +1797,7 @@ export const handlers = [
   ),
 
   // 내 알림 목록 (#49, 명세 Done) — items+unread_count+페이지네이션. read-all 반영된 isRead 상태 그대로 반환.
-  http.get(`${API_BASE_URL}/users/me/notifications`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/users/me/notifications`, async ({ request }) => {
     await delay(400);
 
     if (request.headers.get("x-mock-failure") === "notifications") {
@@ -1828,7 +1829,7 @@ export const handlers = [
   //   provider/socialToken/userType 누락→400 MISSING_REQUIRED_FIELD,
   //   gender/birth_date/phone_number 누락→400 VALIDATION_ERROR("<필드>: must not be null"),
   //   x-mock-failure:social→500 EXTERNAL_API_ERROR.
-  http.post(`${API_BASE_URL}/auth/register`, async ({ request }) => {
+  wire.post(`${API_BASE_URL}/auth/register`, async ({ request }) => {
     await delay(600);
 
     const body = (await request.json().catch(() => ({}))) as {
@@ -1898,7 +1899,7 @@ export const handlers = [
   }),
 
   // 본인 프로필 조회 (이슈 #31 프로필 편집 + 대시보드 헤더 공용). :adjusterId 라우트보다 먼저 등록
-  http.get(`${API_BASE_URL}/adjusters/me/profile`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/adjusters/me/profile`, async ({ request }) => {
     await delay(500);
 
     if (request.headers.get("x-mock-failure") === "profile") {
@@ -1917,7 +1918,7 @@ export const handlers = [
 
   // 손해사정사 홈 대시보드 집계 (BFF, #30/#130) — GET /adjusters/me/home.
   // 기존 /dashboard·/in-progress·/profile-summary 3분할을 1콜로 통합. in_progress_limit(기본 5, 최대 20) 잘라 반환.
-  http.get(`${API_BASE_URL}/adjusters/me/home`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/adjusters/me/home`, async ({ request }) => {
     await delay(500);
 
     if (request.headers.get("x-mock-failure") === "home") {
@@ -1983,7 +1984,7 @@ export const handlers = [
   }),
 
   // 손해사정사 마이페이지 집계 (이슈 #46)
-  http.get(`${API_BASE_URL}/adjusters/me/mypage`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/adjusters/me/mypage`, async ({ request }) => {
     await delay(500);
 
     if (isLoggedOut()) {
@@ -2008,7 +2009,7 @@ export const handlers = [
   }),
 
   // 알림 설정 조회 (이슈 #46)
-  http.get(`${API_BASE_URL}/users/me/notification-settings`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/users/me/notification-settings`, async ({ request }) => {
     await delay(300);
 
     if (request.headers.get("x-mock-failure") === "notification-settings") {
@@ -2026,7 +2027,7 @@ export const handlers = [
   }),
 
   // 알림 설정 저장 (이슈 #46) — 수정한 항목만 머지, 전체 설정 반환
-  http.patch(`${API_BASE_URL}/users/me/notification-settings`, async ({ request }) => {
+  wire.patch(`${API_BASE_URL}/users/me/notification-settings`, async ({ request }) => {
     await delay(500);
 
     if (request.headers.get("x-mock-failure") === "notification-settings") {
@@ -2061,7 +2062,7 @@ export const handlers = [
   }),
 
   // 디바이스 토큰 등록 (이슈 #178)
-  http.post(`${API_BASE_URL}/users/me/device-tokens`, async ({ request }) => {
+  wire.post(`${API_BASE_URL}/users/me/device-tokens`, async ({ request }) => {
     await delay(300);
 
     if (request.headers.get("x-mock-failure") === "device-token") {
@@ -2101,7 +2102,7 @@ export const handlers = [
   }),
 
   // 디바이스 토큰 해제 (이슈 #178)
-  http.delete(`${API_BASE_URL}/users/me/device-tokens`, async ({ request }) => {
+  wire.delete(`${API_BASE_URL}/users/me/device-tokens`, async ({ request }) => {
     await delay(300);
 
     if (request.headers.get("x-mock-failure") === "device-token") {
@@ -2119,7 +2120,7 @@ export const handlers = [
   }),
 
   // 활동 카운트 (이슈 #105) — CONTRACT(명세없음-임시): GET /users/me/activity-summary
-  http.get(`${API_BASE_URL}/users/me/activity-summary`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/users/me/activity-summary`, async ({ request }) => {
     await delay(300);
 
     if (request.headers.get("x-mock-failure") === "activity-summary") {
@@ -2138,7 +2139,7 @@ export const handlers = [
 
   // 내 보험 목록 (이슈 #105) — GET /users/me/insurances (확정 스펙)
   // x-mock-scenario=insurances-empty → 0건 빈 상태 검증.
-  http.get(`${API_BASE_URL}/users/me/insurances`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/users/me/insurances`, async ({ request }) => {
     await delay(300);
 
     if (request.headers.get("x-mock-failure") === "insurances") {
@@ -2165,7 +2166,7 @@ export const handlers = [
   // 액세스 토큰 재발급 (#109) — refresh_token HttpOnly 쿠키만 사용(바디·Authorization 없음), data는 null.
   // E2E 주입: localStorage["mock:tokenExpired"]="once"(재발급 성공) | "refresh-expired"(재발급 실패).
   // 실제 호출 횟수는 localStorage["mock:reissueCount"]에 누적 — 동시 401 다발 시 단일-flight 검증용.
-  http.post(`${API_BASE_URL}/auth/reissue`, async () => {
+  wire.post(`${API_BASE_URL}/auth/reissue`, async () => {
     // 대시보드 동시 만료 E2E(#224): useMe·useReportList 둘 다 401을 받은 뒤에 재발급을 끝내
     // 늦게 나간 요청이 401 없이 200을 받는 타이밍 편차를 없앤다(상한 2초).
     await waitForExpiredResponses(2, 2000);
@@ -2197,7 +2198,7 @@ export const handlers = [
   // 로그아웃 (#155) — refresh_token HttpOnly 쿠키 무효화. 바디 없음, data는 null.
   // 성공 시 로그아웃 상태를 기록해 이후 보호 엔드포인트가 401 LOGIN_REQUIRED를 돌려준다.
   // E2E 실패 주입: x-mock-failure=logout → 500(서버 실패에도 클라이언트 정리·이동 검증용, 세션은 유지).
-  http.post(`${API_BASE_URL}/auth/logout`, async ({ request }) => {
+  wire.post(`${API_BASE_URL}/auth/logout`, async ({ request }) => {
     await delay(200);
 
     if (request.headers.get("x-mock-failure") === "logout") {
@@ -2217,7 +2218,7 @@ export const handlers = [
 
   // 본인 정보 조회 (고객 대시보드 인사말)
   // E2E 역할 게이팅 검증용: localStorage["mock:userType"]="adjuster"면 사정사로 응답(기본 insured_person).
-  http.get(`${API_BASE_URL}/users/me`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/users/me`, async ({ request }) => {
     await delay(300);
     // 비로그인 시나리오 주입 — E2E 랜딩(온보딩) 검증용. 기본은 로그인 유저(변경 없음).
     if (request.headers.get("x-mock-scenario") === "unauthenticated" || isLoggedOut()) {
@@ -2251,7 +2252,7 @@ export const handlers = [
 
   // 본인 정보 수정 — PATCH /users/me (확정 스펙 2026-07-14). body(하나 이상): phone_number·region[]·avatar_url.
   // 응답은 명세대로 me 전체 객체(snake). FE는 응답을 폐기하고 GET 재조회로 갱신한다.
-  http.patch(`${API_BASE_URL}/users/me`, async ({ request }) => {
+  wire.patch(`${API_BASE_URL}/users/me`, async ({ request }) => {
     await delay(500);
 
     if (request.headers.get("x-mock-failure") === "update-me") {
@@ -2286,7 +2287,7 @@ export const handlers = [
   // 회원 탈퇴 (#179) — DELETE /users/me. 요청 바디 없음, data는 null.
   // 성공 시 로그아웃 상태를 기록해 이후 보호 엔드포인트가 401 LOGIN_REQUIRED를 돌려준다.
   // E2E 실패 주입: x-mock-failure=withdraw → 500(정리·이동 없이 에러 안내·재시도 검증용, 세션 유지).
-  http.delete(`${API_BASE_URL}/users/me`, async ({ request }) => {
+  wire.delete(`${API_BASE_URL}/users/me`, async ({ request }) => {
     await delay(200);
 
     if (request.headers.get("x-mock-failure") === "withdraw") {
@@ -2309,7 +2310,7 @@ export const handlers = [
   //   x-mock-scenario=dashboard-onboarding → report_count 0(온보딩 분기), 나머지 null.
   //   x-mock-scenario=dashboard-inspecting → 검수 중(제안 0건): activeReport AWAITING_INSPECTION·firstReviewedAt null, proposalSummary null(제안 비교 숨김).
   //   x-mock-scenario=dashboard-closed → 전부 종료: activeReport·proposalSummary null(타임라인·제안 비교 숨김). reportCount>0라 온보딩 아님.
-  http.get(`${API_BASE_URL}/users/me/dashboard`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/users/me/dashboard`, async ({ request }) => {
     await delay(400);
 
     if (request.headers.get("x-mock-scenario") === "unauthenticated" || isLoggedOut()) {
@@ -2372,7 +2373,7 @@ export const handlers = [
 
   // 고객 리포트 목록 (대시보드 + 내 리포트 목록) — :reportId·pending-review와 충돌 없게 정확 경로.
   // §9 드리프트 필드 선반영(reportNo·claimedMin/Max·proposalCount·reviewedAt·adjusterNickname).
-  http.get(`${API_BASE_URL}/reports`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/reports`, async ({ request }) => {
     await delay(400);
 
     const url = new URL(request.url, "http://localhost");
@@ -2445,7 +2446,7 @@ export const handlers = [
   }),
 
   // 본인 프로필 수정 — 수정 가능 필드만 머지 후 전체 프로필 반환
-  http.patch(`${API_BASE_URL}/adjusters/me/profile`, async ({ request }) => {
+  wire.patch(`${API_BASE_URL}/adjusters/me/profile`, async ({ request }) => {
     await delay(700);
 
     let body: Record<string, unknown>;
@@ -2483,7 +2484,7 @@ export const handlers = [
 
   // 서버 프록시 업로드 — multipart(file·purpose) 수신 → { s3_url } 응답.
   // 기본 성공(결정적), x-mock-failure 헤더로 서버 오류 주입(재시도 검증용).
-  http.post(`${API_BASE_URL}/uploads`, async ({ request }) => {
+  wire.post(`${API_BASE_URL}/uploads`, async ({ request }) => {
     await delay(300);
 
     if (request.headers.get("x-mock-failure") === "upload") {
@@ -2549,7 +2550,7 @@ export const handlers = [
   }),
 
   // 분석 신청 생성 — 실손(medical_indemnity)만 허용, 그 외 UNSUPPORTED_OPERATION
-  http.post(`${API_BASE_URL}/reports`, async ({ request }) => {
+  wire.post(`${API_BASE_URL}/reports`, async ({ request }) => {
     await delay(600);
     // 요청 body는 client가 camel→snake 변환해 보냄 — 명세 필드명 그대로 읽는다.
     const body = (await request.json()) as {
@@ -2591,7 +2592,7 @@ export const handlers = [
   }),
 
   // 검수 대기 목록 (활성 손해사정사 전용) — :reportId 라우트보다 먼저 등록
-  http.get(`${API_BASE_URL}/reports/pending-review`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/reports/pending-review`, async ({ request }) => {
     await delay(400);
 
     const url = new URL(request.url, "http://localhost");
@@ -2627,7 +2628,7 @@ export const handlers = [
   }),
 
   // 검수 현황 요약 (하단 탭바 뱃지 + PC 요약 카드용)
-  http.get(`${API_BASE_URL}/reports/pending-review/summary`, async () => {
+  wire.get(`${API_BASE_URL}/reports/pending-review/summary`, async () => {
     await delay(300);
 
     const pendingCount = PENDING_REVIEWS.filter(
@@ -2642,7 +2643,7 @@ export const handlers = [
   }),
 
   // 검수 보류 (PC 프리뷰 패널) — POST + reason 필수(멱등). OTHER면 reason_detail 필수.
-  http.post(`${API_BASE_URL}/reports/:reportId/hold`, async ({ request, params }) => {
+  wire.post(`${API_BASE_URL}/reports/:reportId/hold`, async ({ request, params }) => {
     await delay(300);
 
     const reportId = typeof params.reportId === "string" ? params.reportId : "";
@@ -2693,7 +2694,7 @@ export const handlers = [
 
   // 사정사 검수 내역 조회 (이슈 #59) — 명세 봉투 거울. status 서버 필터 + page 페이지네이션.
   // 실패/빈 시나리오는 x-mock-* 헤더로 주입(E2E override용).
-  http.get(`${API_BASE_URL}/adjusters/me/reviewed-reports`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/adjusters/me/reviewed-reports`, async ({ request }) => {
     await delay(400);
 
     const failure = request.headers.get("x-mock-failure");
@@ -2754,7 +2755,7 @@ export const handlers = [
   //   같은 proposalId·status를 노출해 채팅↔proposals 정합 유지.
   //   그 외 리포트는 proposal_count와 맞춘 고정 제안 목(EXTRA_PROPOSALS)에서 반환 (이슈 #153).
   //   REJECTED 제안은 목록에서 제외(받은제안 카드 UX: 거절 시 제거. ⚠️ 노출 정책 백엔드 확인 중 — TEMP §5-3).
-  http.get(`${API_BASE_URL}/reports/:reportId/proposals`, async ({ params }) => {
+  wire.get(`${API_BASE_URL}/reports/:reportId/proposals`, async ({ params }) => {
     await delay(500);
 
     const reportId = typeof params.reportId === "string" ? params.reportId : "";
@@ -2806,7 +2807,7 @@ export const handlers = [
   //   ACCEPTED: 대상 방 매칭완료 + 형제(같은 reportId) 방 자동종료(REJECTED·CLOSED) 캐스케이드.
   //   REJECTED: 대상 방만 종료. 이미 확정된 방 재PATCH → 409.
   //   x-mock-failure:match-proposal → 500 INTERNAL_SERVER_ERROR (실패 토스트 E2E용).
-  http.patch(
+  wire.patch(
     `${API_BASE_URL}/reports/:reportId/proposals/:proposalId`,
     async ({ request, params }) => {
       await delay(400);
@@ -2966,7 +2967,7 @@ export const handlers = [
   // 손해사정사 목록 조회 (이슈 #47) — 반드시 :adjusterId 핸들러보다 앞에 등록
   //   x-mock-adjusters=empty → 0건 빈 상태 검증(이슈 #239). 대시보드 상태(x-mock-scenario)와
   //   조합해야 하므로 x-mock-failure처럼 별도 축 헤더로 둔다.
-  http.get(`${API_BASE_URL}/adjusters`, async ({ request }) => {
+  wire.get(`${API_BASE_URL}/adjusters`, async ({ request }) => {
     await delay(400);
 
     const url = new URL(request.url, "http://localhost");
@@ -3081,7 +3082,7 @@ export const handlers = [
 
   // 사정사 후기 등록 (이슈 #76) — 성공 201, 같은 adjusterId 재등록 시 409 DUPLICATE_RESOURCE.
   // 등록분은 buildAdjusterProfile.recentReviews에 합류(score→score, createdAt→reviewedAt) + 집계 재계산.
-  http.post(`${API_BASE_URL}/adjusters/:adjusterId/reviews`, async ({ request, params }) => {
+  wire.post(`${API_BASE_URL}/adjusters/:adjusterId/reviews`, async ({ request, params }) => {
     await delay(500);
 
     const rawAdjusterId = typeof params.adjusterId === "string" ? params.adjusterId : "";
@@ -3135,7 +3136,7 @@ export const handlers = [
   }),
 
   // 손해사정사 공개 프로필 조회 (이슈 #32)
-  http.get(`${API_BASE_URL}/adjusters/:adjusterId`, async ({ params }) => {
+  wire.get(`${API_BASE_URL}/adjusters/:adjusterId`, async ({ params }) => {
     await delay(500);
 
     const adjusterId =
@@ -3166,7 +3167,7 @@ export const handlers = [
   // 검수 화면 조회 (손해사정사) — GET /reports/{reportId}/review. :reportId GET보다 먼저 등록.
   // started=false면 adjuster_estimate·review·review_status는 null(작업본 미생성).
   // x-mock-scenario: review-started(작업본 있음) / review-not-found(404).
-  http.get(`${API_BASE_URL}/reports/:reportId/review`, async ({ request, params }) => {
+  wire.get(`${API_BASE_URL}/reports/:reportId/review`, async ({ request, params }) => {
     await delay(500);
 
     if (request.headers.get("x-mock-failure") === "review-detail") {
@@ -3333,7 +3334,7 @@ export const handlers = [
   }),
 
   // 리포트 상세 조회 (고객측 — issue: CONFIRMED/TRUSTED/INFO). 파트너 검수는 /review로 분리(#130).
-  http.get(`${API_BASE_URL}/reports/:reportId`, async ({ params }) => {
+  wire.get(`${API_BASE_URL}/reports/:reportId`, async ({ params }) => {
     await delay(500);
 
     const reportId =
@@ -3407,7 +3408,7 @@ export const handlers = [
   }),
 
   // 검수 반영 제출 (사정사) — body echo, 검수완료 시 AWAITING_ADOPTION
-  http.patch(`${API_BASE_URL}/reports/:reportId`, async ({ request, params }) => {
+  wire.patch(`${API_BASE_URL}/reports/:reportId`, async ({ request, params }) => {
     await delay(600);
 
     if (request.headers.get("x-mock-failure") === "submit-review") {

--- a/apps/web/src/shared/mocks/wire-response.ts
+++ b/apps/web/src/shared/mocks/wire-response.ts
@@ -25,9 +25,14 @@ function toWireResponse<Args extends unknown[]>(
     if (body === null || typeof body !== "object" || !("data" in body)) return result;
 
     const envelope = body as Record<string, unknown>;
+    // 원본 Content-Length는 변환 전 본문 기준이라 그대로 넘기면 새 본문과 어긋난다.
+    // HttpResponse.json은 넘겨받은 값이 있으면 다시 계산하지 않으므로 지워서 넘긴다.
+    const headers = new Headers(result.headers);
+    headers.delete("content-length");
+
     return HttpResponse.json(
       { ...envelope, data: camelToSnakeDeep(envelope.data) },
-      { status: result.status, headers: result.headers },
+      { status: result.status, headers },
     );
   };
 }

--- a/apps/web/src/shared/mocks/wire-response.ts
+++ b/apps/web/src/shared/mocks/wire-response.ts
@@ -1,0 +1,47 @@
+import { http, HttpResponse } from "msw";
+import { camelToSnakeDeep } from "@/shared/api/case-convert";
+
+/**
+ * 목 응답을 실제 와이어 모양(snake_case)으로 내보내는 경계.
+ *
+ * 목 데이터는 읽기 편하게 camelCase로 쓰고 나가는 지점에서만 바꾼다. 이 경계가 없으면
+ * 목이 서버와 다른 계약을 흉내내고, client의 snakeToCamelDeep이 camel 키를 그대로
+ * 통과시키는 탓에 E2E가 그 차이를 잡지 못한다(로컬은 통과, 실서버는 undefined).
+ *
+ * 응답 래퍼의 data만 바꾼다 — status·message·code는 서버도 그대로 내려준다.
+ */
+function toWireResponse<Args extends unknown[]>(
+  resolver: (...args: Args) => unknown,
+): (...args: Args) => Promise<unknown> {
+  return async (...args: Args) => {
+    const result = await resolver(...args);
+    if (!(result instanceof Response)) return result;
+    if (!result.headers.get("content-type")?.includes("application/json")) return result;
+
+    const body: unknown = await result
+      .clone()
+      .json()
+      .catch(() => null);
+    if (body === null || typeof body !== "object" || !("data" in body)) return result;
+
+    const envelope = body as Record<string, unknown>;
+    return HttpResponse.json(
+      { ...envelope, data: camelToSnakeDeep(envelope.data) },
+      { status: result.status, headers: result.headers },
+    );
+  };
+}
+
+function wrapMethod<Method extends typeof http.get>(method: Method): Method {
+  return ((path: never, resolver: never, options: never) =>
+    method(path, toWireResponse(resolver) as never, options)) as Method;
+}
+
+/** msw http 대체 — 핸들러가 돌려준 응답을 와이어 모양으로 바꿔 내보낸다. */
+export const wire = {
+  get: wrapMethod(http.get),
+  post: wrapMethod(http.post),
+  patch: wrapMethod(http.patch),
+  put: wrapMethod(http.put),
+  delete: wrapMethod(http.delete),
+};


### PR DESCRIPTION
## 🔗 관련 이슈

#283

## ✅ 작업 내용

### MSW 목이 실서버와 같은 필드명으로 응답하게 했습니다

목 페이로드 키 590개 중 582개가 camelCase입니다. 실제 와이어는 snake_case라 목이 서버와 다른 계약을 흉내내고 있었습니다.

그리고 이 차이는 테스트로 드러나지 않습니다. `client.ts`의 `snakeToCamelDeep`이 camel 키를 그대로 통과시키기 때문입니다. **로컬·CI가 모두 통과해도 실서버에서 필드가 `undefined`인 상황이 성립합니다.**

<br/>

### 1. 나가는 지점에 경계 하나

키 582개를 손대는 대신, 핸들러가 돌려준 응답의 `data`만 와이어 모양으로 바꾸는 경계를 뒀습니다.

```ts
// shared/mocks/wire-response.ts
export const wire = {
  get: wrapMethod(http.get),
  post: wrapMethod(http.post),
  ...
};
```

목 데이터는 지금처럼 camelCase로 쓰고 읽습니다. 바뀌는 건 나가는 순간뿐입니다.

#### 세부 작업
* 핸들러 49개를 `http.*` → `wire.*`로 전환
* 응답 래퍼의 `data`만 변환 — `status` · `message` · `code`는 서버도 그대로 내려줍니다
* 에러 응답은 `data`가 없어 대상이 아닙니다

## 💬 특이사항 / 결정 사항

### 수기 응답 스키마 31개는 그대로 둡니다

`responseValidator`는 `responseTransformer`보다 **먼저** 돕니다. 생성 zod는 변환 전 데이터(봉투 포함 snake)를, 수기 스키마는 변환 후 데이터(camel)를 봅니다. 두 층이 겹치지 않아 스키마를 snake로 재작성할 필요가 없습니다.

### 기존 `camelToSnakeDeep` 호출은 남겨뒀습니다

일부 핸들러가 이미 직접 변환하고 있었는데, snake 키에 다시 적용해도 바뀌지 않아 그대로 뒀습니다. 정리는 후속으로 미룹니다.
