### PR TITLE
[Infra] E2E 테스트 샤딩으로 CI 시간 단축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,15 @@ jobs:
       - name: 생성물이 스냅샷과 일치하는지 확인
         run: git diff --exit-code -- apps/web/src/shared/api/generated
 
+  # 807개 테스트를 6샤드로 분할 — 샤드당 고정비(설치·빌드) 약 1분 20초는 병렬로 겹친다.
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 20
+    strategy:
+      # 한 샤드가 깨져도 나머지 결과를 끝까지 받는다.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -107,10 +113,42 @@ jobs:
             playwright-browsers-${{ runner.os }}-
       - name: Playwright 브라우저 설치 (chromium, webkit)
         run: pnpm --filter @insurance/web exec playwright install --with-deps chromium webkit
-      - name: E2E 테스트
-        run: pnpm --filter @insurance/web test:e2e
+      - name: E2E 테스트 (샤드 ${{ matrix.shard }}/6)
+        run: pnpm --filter @insurance/web exec playwright test --shard=${{ matrix.shard }}/6
+      - name: blob 리포트 업로드
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: blob-report-${{ matrix.shard }}
+          path: apps/web/blob-report/
+          retention-days: 1
+
+  # 샤드가 하나라도 실패했을 때만 blob을 합쳐 HTML 리포트를 만든다.
+  # 성공 경로에는 붙지 않아 그린 PR의 소요 시간에 영향이 없다.
+  e2e-report:
+    needs: e2e
+    if: ${{ !cancelled() && needs.e2e.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: 샤드별 blob 리포트 내려받기
+        uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-*
+          merge-multiple: true
+          path: apps/web/all-blob-reports
+      - name: HTML 리포트 병합
+        run: pnpm --filter @insurance/web exec playwright merge-reports --reporter html all-blob-reports
       - name: 실패 리포트 업로드
-        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ storybook-static
 test-results/
 playwright-report/
 playwright/.cache/
+blob-report/
+all-blob-reports/
 
 # figma 변환 검증 스크린샷(일회용 — 찍고 대조 후 삭제, 커밋 금지)
 *.figma-shot.png

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: IS_CI,
   retries: IS_CI ? 2 : 0,
-  reporter: IS_CI ? [["list"], ["html", { open: "never" }]] : "list",
+  // CI는 샤드별 blob 리포트만 남기고, 실패 시 e2e-report 잡이 HTML로 병합한다.
+  reporter: IS_CI ? [["list"], ["blob"]] : "list",
   use: {
     baseURL: BASE_URL,
     trace: "on-first-retry",


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #303

## ✅ 변경 사항

CI 전체가 16분인데 e2e 잡 하나가 16분 10초로 사실상 전부였습니다. 나머지는 typecheck 38초, lint 24초, build 59초, api-codegen 27초로 1분을 넘지 않습니다.

e2e 잡 내부를 재보니 설치·브라우저 48초, 빌드·기동 33초, 테스트 실행 14분 46초입니다. 실행이 96%를 차지합니다.

원인은 테스트 개수가 아니라 병렬도입니다. 로그 첫 줄이 `Running 807 tests using 2 workers`입니다. 4코어 러너에서 Playwright 기본값이 `cpus/2`라 워커를 2개만 잡습니다.

<br/>

### 1. e2e 잡을 6샤드로 분할

`strategy.matrix`로 여섯 갈래로 나누고 샤드마다 자기 몫만 실행합니다.

```yaml
# .github/workflows/ci.yml
strategy:
  fail-fast: false
  matrix:
    shard: [1, 2, 3, 4, 5, 6]
steps:
  - name: E2E 테스트 (샤드 ${{ matrix.shard }}/6)
    run: pnpm --filter @insurance/web exec playwright test --shard=${{ matrix.shard }}/6
```

#### 세부 작업
* `fail-fast: false` → 한 샤드가 깨져도 나머지 결과를 끝까지 받음
* `timeout-minutes` 45 → 20으로 조정
* 샤드마다 `blob-report`를 아티팩트로 업로드

<br/>

### 2. 실패 시에만 리포트 병합

샤드를 나누면 HTML 리포트가 여섯 조각으로 흩어집니다. CI 리포터를 `blob`으로 바꿔 병합 가능한 형식으로 남기고, 샤드가 실패했을 때만 도는 잡에서 하나로 합칩니다.

```ts
// apps/web/playwright.config.ts
reporter: IS_CI ? [["list"], ["blob"]] : "list",
```

#### 세부 작업
* `e2e-report` 잡 → `needs.e2e.result == 'failure'` 조건이라 성공 경로에는 붙지 않음
* `playwright merge-reports --reporter html`로 단일 리포트 생성
* `blob-report/` · `all-blob-reports/` gitignore 추가

## 🧪 검증

E2E 스펙은 건드리지 않았습니다. 807개가 그대로 돌고 분배만 바뀝니다.

샤드 배정을 실제로 확인했습니다. 직전 CI 런의 테스트별 소요시간을 샤드 배정에 매핑한 값입니다.

| 샤드 | 테스트 | 테스트시간 합 | 평균 대비 |
|---|---|---|---|
| 1 | 135 | 3m 35s | −12.6% |
| 2 | 135 | 3m 36s | −11.9% |
| 3 | 135 | 3m 22s | −17.7% |
| 4 | 134 | 3m 24s | −16.9% |
| 5 | 134 | 5m 36s | +36.6% |
| 6 | 134 | 5m 01s | +22.5% |

Playwright가 개수 기준으로 쪼개서 시간은 최대 1.37배 벌어집니다. 가장 느린 샤드 5를 기준으로 잡으면 `5m 36s ÷ 2워커 × 1.20(관측 오버헤드) + 1m 21s(고정비) = 4m 43s`입니다. **16분 10초에서 약 4분 40초로 줄어듭니다.**

이 PR의 CI 런이 실측값입니다.

## 💬 결정 사항

### 스모크 분리 대신 샤딩

처음에는 PR에서 스모크만 돌리는 안을 검토했습니다. 이 레포는 PR에서 dev로 바로 머지하는 흐름이라, 스모크에서 빠진 700여 개는 dev에 들어간 뒤에야 실행됩니다. 깨진 것을 dev에서 발견하게 됩니다. 커버리지를 버려 시간을 사는 거래라 택하지 않았습니다.

샤딩은 807개를 그대로 두고 나누기만 해서 커버리지 손실이 없습니다.

### 샤드 수를 6으로

샤드마다 설치·빌드 고정비 1분 21초가 반복됩니다. 4샤드는 5분 40초, 8샤드는 3분 40초입니다. 8샤드는 6샤드보다 40초 빠른데 그 절반이 셋업 대기입니다. 6에서 끊었습니다.

공개 레포라 표준 러너는 분 과금이 없어 샤드를 늘려도 비용이 들지 않습니다. 대신 조직 플랜이 free라 동시 실행이 20잡으로 제한됩니다. 6샤드면 CI 한 건이 10잡이라 PR 두 건까지 여유롭습니다.

### 필수 상태 체크 확인

매트릭스를 붙이면 체크 이름이 `e2e`에서 `e2e (1)`~`e2e (6)`으로 바뀝니다. `e2e`가 required로 걸려 있었다면 그 이름의 체크가 올라오지 않아 PR이 머지 불가로 묶입니다. `dev`·`main` 모두 브랜치 보호가 없고 ruleset도 비활성이라 해당하지 않는 것을 확인했습니다.

나중에 브랜치 보호를 켜면 샤드 여섯 개를 전부 등록하거나, 샤드 전체를 기다리는 게이트 잡 하나를 두고 그것만 required로 거는 편이 낫습니다.
