### PR TITLE
[Fix] 소셜 로그인 콜백 code 중복 요청으로 간헐적 에러 수정(web)

### DIFF
--- a/apps/web/e2e/app-oauth-callback.spec.ts
+++ b/apps/web/e2e/app-oauth-callback.spec.ts
@@ -40,6 +40,32 @@ test.describe("외부 브라우저 복귀", () => {
   });
 });
 
+test.describe("콜백 code 중복 요청 방지 (#306)", () => {
+  const CALL_COUNT_KEY = "mock:oauthCallbackCallCount:kakao:valid";
+
+  test("성공 후 콜백 페이지가 같은 code로 리마운트돼도 API가 한 번만 호출된다", async ({
+    page,
+  }) => {
+    // 테스트마다 새 브라우저 컨텍스트라 localStorage는 비어 있음(addInitScript는 매 네비게이션마다
+    // 재실행돼 첫 호출 카운트까지 지워버리므로 별도 초기화 불필요).
+    // 콜백 응답만으론 미들웨어 보호 라우트 진입이 안 되므로(SW는 실제 쿠키를 못 심음) 직접 주입.
+    await setAuthCookie(page, "USER");
+
+    await page.goto("/login/oauth2/code/kakao?code=valid&state=s1");
+    await expect(page).toHaveURL(/\/customer\/dashboard/, { timeout: 15000 });
+
+    // gcTime 만료 후 리마운트를 흉내: 같은 code로 콜백 페이지를 다시 연다.
+    await page.goto("/login/oauth2/code/kakao?code=valid&state=s1");
+    await page.waitForTimeout(1000);
+
+    const callCount = await page.evaluate(
+      (key) => window.localStorage.getItem(key),
+      CALL_COUNT_KEY,
+    );
+    expect(callCount).toBe("1");
+  });
+});
+
 test.describe("앱 웹뷰 내 콜백", () => {
   // 앱 웹뷰 판별은 UA 토큰(BareunApp) 기준 — 웹뷰 안에서는 접두어가 있어도 정상 교환.
   test.use({

--- a/apps/web/e2e/app-oauth-callback.spec.ts
+++ b/apps/web/e2e/app-oauth-callback.spec.ts
@@ -64,6 +64,26 @@ test.describe("콜백 code 중복 요청 방지 (#306)", () => {
     );
     expect(callCount).toBe("1");
   });
+
+  test("다른 code로 로그인한 뒤에도 앞선 code의 소모 기록이 유지된다", async ({ page }) => {
+    await setAuthCookie(page, "USER");
+
+    await page.goto("/login/oauth2/code/kakao?code=valid&state=s1");
+    await expect(page).toHaveURL(/\/customer\/dashboard/, { timeout: 15000 });
+
+    // 같은 세션에서 두 번째 로그인 — 소모 기록이 code별로 분리돼 있어야 한다.
+    await page.goto("/login/oauth2/code/kakao?code=valid-2&state=s2");
+    await expect(page).toHaveURL(/\/customer\/dashboard/, { timeout: 15000 });
+
+    await page.goto("/login/oauth2/code/kakao?code=valid&state=s1");
+    await page.waitForTimeout(1000);
+
+    const callCount = await page.evaluate(
+      (key) => window.localStorage.getItem(key),
+      CALL_COUNT_KEY,
+    );
+    expect(callCount).toBe("1");
+  });
 });
 
 test.describe("앱 웹뷰 내 콜백", () => {

--- a/apps/web/src/app/(auth)/login/oauth2/code/[provider]/_api/consumed-code.ts
+++ b/apps/web/src/app/(auth)/login/oauth2/code/[provider]/_api/consumed-code.ts
@@ -1,0 +1,25 @@
+const CONSUMED_CODE_KEY = "bb.oauthConsumedCode";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+/**
+ * 카카오/네이버 인가코드는 1회용 — 콜백 페이지가 리마운트돼도(gcTime 만료 후 재요청 등)
+ * 이미 성공 처리한 code로는 다시 호출하지 않도록 세션 단위로 기억한다.
+ */
+export function isCodeConsumed(provider: string, code: string): boolean {
+  if (!isBrowser()) return false;
+  try {
+    return window.sessionStorage.getItem(CONSUMED_CODE_KEY) === `${provider}:${code}`;
+  } catch {
+    return false;
+  }
+}
+
+export function markCodeConsumed(provider: string, code: string): void {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.setItem(CONSUMED_CODE_KEY, `${provider}:${code}`);
+  } catch {}
+}

--- a/apps/web/src/app/(auth)/login/oauth2/code/[provider]/_api/consumed-code.ts
+++ b/apps/web/src/app/(auth)/login/oauth2/code/[provider]/_api/consumed-code.ts
@@ -1,7 +1,11 @@
-const CONSUMED_CODE_KEY = "bb.oauthConsumedCode";
+const CONSUMED_CODE_KEY_PREFIX = "bb.oauthConsumedCode";
 
 function isBrowser(): boolean {
   return typeof window !== "undefined";
+}
+
+function consumedCodeKey(provider: string, code: string): string {
+  return `${CONSUMED_CODE_KEY_PREFIX}:${provider}:${code}`;
 }
 
 /**
@@ -11,7 +15,7 @@ function isBrowser(): boolean {
 export function isCodeConsumed(provider: string, code: string): boolean {
   if (!isBrowser()) return false;
   try {
-    return window.sessionStorage.getItem(CONSUMED_CODE_KEY) === `${provider}:${code}`;
+    return window.sessionStorage.getItem(consumedCodeKey(provider, code)) !== null;
   } catch {
     return false;
   }
@@ -20,6 +24,6 @@ export function isCodeConsumed(provider: string, code: string): boolean {
 export function markCodeConsumed(provider: string, code: string): void {
   if (!isBrowser()) return;
   try {
-    window.sessionStorage.setItem(CONSUMED_CODE_KEY, `${provider}:${code}`);
+    window.sessionStorage.setItem(consumedCodeKey(provider, code), "1");
   } catch {}
 }

--- a/apps/web/src/app/(auth)/login/oauth2/code/[provider]/_api/use-oauth-callback.ts
+++ b/apps/web/src/app/(auth)/login/oauth2/code/[provider]/_api/use-oauth-callback.ts
@@ -3,6 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { authKeys } from "@/shared/api/query-keys";
 import { getOauthCallback } from "./get-oauth-callback";
+import { isCodeConsumed, markCodeConsumed } from "./consumed-code";
 import {
   oauthProviderSchema,
   type OauthProvider,
@@ -15,28 +16,35 @@ interface UseOauthCallbackParams {
 }
 
 /**
- * OAuth 콜백 1회성 인증 교환. 캐싱 부적합(staleTime 0·gcTime 0)이라 매 진입 재요청,
- * 실패 시 refetch()로 재시도. provider/code가 유효할 때만 enabled.
+ * OAuth 콜백 1회성 인증 교환, 실패 시 refetch()로 재시도.
+ * 카카오/네이버 인가코드는 1회용이라 성공한 code는 sessionStorage에 기록해 재요청을 막는다
+ * (콜백 페이지가 리마운트돼도 이미 소모된 code로 다시 호출하지 않음).
  */
 export function useOauthCallback({ provider, code, state }: UseOauthCallbackParams) {
   const parsedProvider = oauthProviderSchema.safeParse(provider);
   const validProvider: OauthProvider | null = parsedProvider.success
     ? parsedProvider.data
     : null;
-  const enabled = validProvider !== null && code !== null && code !== "";
+  const enabled =
+    validProvider !== null &&
+    code !== null &&
+    code !== "" &&
+    !isCodeConsumed(validProvider, code);
 
   return useQuery({
     queryKey: authKeys.oauthCallback(validProvider ?? provider, code ?? "").queryKey,
-    queryFn: () => {
+    queryFn: async () => {
       if (validProvider === null || !code) {
         throw new Error("유효하지 않은 로그인 요청입니다.");
       }
-      return getOauthCallback(validProvider, code, state ?? undefined);
+      const result = await getOauthCallback(validProvider, code, state ?? undefined);
+      markCodeConsumed(validProvider, code);
+      return result;
     },
     enabled,
     retry: false,
     staleTime: 0,
-    gcTime: 0,
+    gcTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
   });
 }

--- a/apps/web/src/shared/mocks/handlers.ts
+++ b/apps/web/src/shared/mocks/handlers.ts
@@ -1733,6 +1733,13 @@ export const handlers = [
     const code = url.searchParams.get("code");
     const failure = request.headers.get("x-mock-failure");
 
+    // E2E 관측 채널: 인가코드는 1회용 — 같은 code로 중복 호출되는지 카운트(#reissueCount와 동일 패턴).
+    if (typeof localStorage !== "undefined" && code) {
+      const key = `mock:oauthCallbackCallCount:${provider}:${code}`;
+      const prevCount = Number(localStorage.getItem(key) ?? "0");
+      localStorage.setItem(key, String(prevCount + 1));
+    }
+
     if (provider !== "kakao" && provider !== "naver" && provider !== "apple") {
       return HttpResponse.json(
         { status: "400", code: "UNSUPPORTED_PROVIDER", message: "지원하지 않는 소셜 로그인입니다." },


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #306

## ✅ 작업 내용

### 소셜 로그인 콜백이 같은 인가코드로 두 번 호출되던 문제를 막았습니다

카카오/네이버는 인가코드를 1회용으로 취급해서, 이미 쓴 code로 콜백 API가 다시 호출되면 provider가 거부합니다(카카오 400 INVALID_REQUEST, 네이버는 200+에러바디를 백엔드가 500 EXTERNAL_API_ERROR로 변환). 실제 로그인은 첫 호출에서 이미 성공(쿠키 발급 200)한 뒤라 사용자 임팩트는 크지 않지만, 재호출 시 에러 화면이 노출될 수 있었습니다.

원인은 `useOauthCallback`의 `gcTime: 0`이었습니다. 콜백 페이지가 언마운트되는 즉시 캐시가 비워지고, 이후 어떤 이유로든 리마운트되면 URL의 같은 code를 새 요청으로 취급해 재호출했습니다.

<br/>

### 1. 처리한 code를 세션에 기록

캐시 수명에만 기대면 gcTime이 지난 뒤 같은 문제가 돌아옵니다. 교환에 성공한 code 자체를 sessionStorage에 남겨 판단 근거로 씁니다. 기록은 `provider`·`code` 조합을 키로 삼아 code마다 분리해 두므로, 한 세션에서 다른 code로 다시 로그인해도 앞선 기록이 덮이지 않습니다.

```ts
// _api/consumed-code.ts
function consumedCodeKey(provider: string, code: string): string {
  return `${CONSUMED_CODE_KEY_PREFIX}:${provider}:${code}`;
}
```

#### 세부 작업
* 소모 여부를 읽고 쓰는 `isCodeConsumed`·`markCodeConsumed` 유틸 추가
* 서버 렌더 구간과 저장소 접근 실패는 "소모되지 않음"으로 처리

<br/>

### 2. 소모된 code면 콜백 query를 실행하지 않음

```ts
// _api/use-oauth-callback.ts
const enabled =
  validProvider !== null && code !== null && code !== "" && !isCodeConsumed(validProvider, code);
```

#### 세부 작업
* 교환에 성공한 시점에 code를 소모 처리
* 리마운트 직후의 불필요한 재요청을 줄이도록 `gcTime`을 0에서 5분으로 조정

## 🧪 테스트

Playwright + MSW **E2E 2개**(`apps/web/e2e/app-oauth-callback.spec.ts`). 같은 파일의 기존 3개를 포함해 전부 통과했습니다. 콜백 핸들러가 `mock:oauthCallbackCallCount:{provider}:{code}`로 호출 횟수를 남기는 관측 채널을 추가해 검증합니다.

| # | 테스트 | 검증 내용 |
|---|--------|-----------|
| 1 | 성공 후 콜백 페이지가 같은 code로 리마운트돼도 API가 한 번만 호출된다 | 같은 code로 콜백 URL 재방문 시 호출 횟수 1 |
| 2 | 다른 code로 로그인한 뒤에도 앞선 code의 소모 기록이 유지된다 | 두 번째 로그인 후 첫 code를 재방문해도 호출 횟수 1 |

## 💬 특이사항

수정 전 코드로 되돌려 두 테스트가 실제로 실패(호출 2회)하는 것을 확인한 뒤 원복해 회귀가 아님을 검증했습니다.

소모 기록을 처음에는 단일 키에 마지막 code만 담았는데, 이러면 한 세션에서 두 번째 로그인이 일어날 때 첫 code의 기록이 사라집니다. CodeRabbit 리뷰에서 짚어준 부분이라 code별 키로 나누고 위 2번 테스트를 함께 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 동일한 OAuth 인증 코드의 콜백이 중복 처리되지 않도록 개선했습니다.
  * 인증 코드 소비 상태를 제공자와 코드별로 기록해, 서로 다른 코드의 로그인이 올바르게 처리되도록 했습니다.
  * 인증 교환에 성공한 코드는 세션 동안 재사용되지 않습니다.

* **테스트**
  * 동일한 코드로 콜백 페이지를 재방문해도 API 호출이 한 번만 발생하는 시나리오를 검증했습니다.
  * 같은 세션에서 다른 코드로 로그인할 때 기존 소비 기록이 유지되는지 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
