### PR TITLE
[Settings] 앱 버전 1.0.2 반영(app)

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "바른보상",
     "slug": "mobile",
-    "version": "1.0.0",
+    "version": "1.0.2",
     "scheme": "brbosang",
     "plugins": [
       "expo-notifications",


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #309

## ✅ 작업 내용

### Play 스토어 업데이트 빌드용으로 앱 버전을 1.0.2로 올렸습니다.

현재 배포된 앱 버전은 1.0.0이고, 그 이후 dev에 쌓인 변경을 스토어에 올리려면 버전이 더 높아야 합니다.

#### 세부 작업
* `apps/mobile/app.json` → `expo.version` 1.0.0 → 1.0.2

## 💬 특이사항

### 빌드 번호는 레포에서 관리하지 않습니다

안드로이드 `versionCode`와 iOS `buildNumber`는 EAS 원격 자동 증가를 쓰고 있어 `app.json`에 두지 않습니다. 레포에서 손대는 값은 사용자에게 보이는 `expo.version` 하나입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 모바일 앱 버전이 1.0.0에서 1.0.2로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->